### PR TITLE
add-cloud-platform-mvp: Phase 4 — AI Agent Runtime

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/markolonius/housecall/backend/internal/agent"
 	"github.com/markolonius/housecall/backend/internal/api"
 	"github.com/markolonius/housecall/backend/internal/migrate"
 	"github.com/markolonius/housecall/backend/internal/store"
@@ -91,7 +92,22 @@ func runServe(dsn, addr string) error {
 	}
 
 	s := store.New(pool)
+
+	// Two-phase construction breaks the circular dependency:
+	//   Router → Drafter → Router (as PhysicianNotifier).
+	//
+	// 1. Build Router with no drafter yet.
 	rt := api.New(s, secret)
+
+	// 2. Build Drafter pointing at the Router (which satisfies
+	//    agent.PhysicianNotifier via rt.SendToPhysicians).
+	agentCfg := agent.ClientConfigFromEnv()
+	log.Printf("agent: model config %s", agentCfg)
+	drafter := agent.NewDrafter(agent.NewClient(agentCfg, nil), s, rt)
+
+	// 3. Wire the drafter into the Router before the server starts accepting
+	//    requests.
+	rt.SetDrafter(drafter)
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)

--- a/backend/internal/agent/client.go
+++ b/backend/internal/agent/client.go
@@ -1,0 +1,233 @@
+// Package agent implements the AI Agent Runtime. The model client in this file
+// is a pure HTTP concern: given a slice of messages it calls an
+// OpenAI-compatible Chat Completions endpoint and returns the assistant's text.
+//
+// # Failure contract
+//
+// Any non-success outcome is returned as a typed error — never as an empty
+// string or as valid text. Callers MUST treat a non-nil error as "no model
+// output available" and must NOT surface the error message to the patient as
+// clinical content. The concrete error types are:
+//
+//   - *ModelError  — the endpoint returned a non-2xx HTTP status.
+//   - *ParseError  — the response body was not valid / had unexpected shape.
+//   - Other errors — network / timeout failures (context.DeadlineExceeded, etc.)
+//
+// Example usage:
+//
+//	cfg := agent.ClientConfigFromEnv()
+//	c := agent.NewClient(cfg, nil) // nil → default http.Client with timeout
+//	text, err := c.Complete(ctx, []agent.Message{
+//	    {Role: "system", Content: "You are a medical assistant."},
+//	    {Role: "user",   Content: "What are common flu symptoms?"},
+//	})
+//	if err != nil {
+//	    // model unavailable — do NOT present err.Error() to the patient
+//	}
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// DefaultBaseURL is the OpenAI-compatible endpoint used when
+// AGENT_MODEL_BASE_URL is not set (Ollama's default listen address).
+const DefaultBaseURL = "http://localhost:11434/v1"
+
+// DefaultModel is the model name sent when AGENT_MODEL_NAME is not set.
+const DefaultModel = "medgemma"
+
+// DefaultTimeout is applied to each model call when the caller does not
+// supply a context deadline.
+const DefaultTimeout = 60 * time.Second
+
+// ClientConfig holds everything the Client needs to reach the model endpoint.
+// Values that come from environment variables are populated by ClientConfigFromEnv.
+//
+// API keys must not be logged. The config's String() method intentionally
+// omits the APIKey field to avoid accidental exposure in log lines.
+type ClientConfig struct {
+	// BaseURL is the base URL of an OpenAI-compatible endpoint, e.g.
+	// "http://localhost:11434/v1".  AGENT_MODEL_BASE_URL sets this at runtime.
+	BaseURL string
+
+	// Model is the model name forwarded in the Chat Completions request body.
+	// AGENT_MODEL_NAME sets this at runtime.
+	Model string
+
+	// APIKey is an optional bearer token.  AGENT_MODEL_API_KEY sets this at
+	// runtime.  Never log this value.
+	APIKey string
+}
+
+// String returns a safe representation suitable for log lines. The API key is
+// replaced with a redaction marker.
+func (c ClientConfig) String() string {
+	key := "<none>"
+	if c.APIKey != "" {
+		key = "<redacted>"
+	}
+	return fmt.Sprintf("ClientConfig{BaseURL:%q Model:%q APIKey:%s}", c.BaseURL, c.Model, key)
+}
+
+// ClientConfigFromEnv builds a ClientConfig from environment variables:
+//
+//   - AGENT_MODEL_BASE_URL   (default: DefaultBaseURL)
+//   - AGENT_MODEL_NAME       (default: DefaultModel)
+//   - AGENT_MODEL_API_KEY    (optional; never logged)
+func ClientConfigFromEnv() ClientConfig {
+	base := os.Getenv("AGENT_MODEL_BASE_URL")
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	model := os.Getenv("AGENT_MODEL_NAME")
+	if model == "" {
+		model = DefaultModel
+	}
+	return ClientConfig{
+		BaseURL: base,
+		Model:   model,
+		APIKey:  os.Getenv("AGENT_MODEL_API_KEY"),
+	}
+}
+
+// Message is one turn in the conversation sent to the model.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// Client calls an OpenAI-compatible Chat Completions endpoint.
+//
+// The zero value is not valid; construct via NewClient.
+type Client struct {
+	cfg  ClientConfig
+	http *http.Client
+}
+
+// NewClient creates a Client. If httpClient is nil a default client with
+// DefaultTimeout is used.
+func NewClient(cfg ClientConfig, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: DefaultTimeout}
+	}
+	return &Client{cfg: cfg, http: httpClient}
+}
+
+// chatRequest is the subset of the OpenAI Chat Completions request body used
+// by the agent. It is unexported; callers use Complete.
+type chatRequest struct {
+	Model    string    `json:"model"`
+	Messages []Message `json:"messages"`
+}
+
+// chatResponse captures only the fields the agent cares about. Extra fields
+// returned by various backends are silently ignored via json.Decoder.
+type chatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+}
+
+// ModelError is returned when the model endpoint replies with a non-2xx
+// HTTP status code.
+//
+// The Body field contains the raw response body trimmed to 256 bytes for
+// debugging; it MUST NOT be forwarded to a patient as clinical content.
+type ModelError struct {
+	StatusCode int
+	Body       string // truncated; for debugging only — never present to patients
+}
+
+func (e *ModelError) Error() string {
+	return fmt.Sprintf("agent: model endpoint returned HTTP %d", e.StatusCode)
+}
+
+// ParseError is returned when the response body cannot be decoded or does not
+// contain a usable assistant message.
+//
+// The Detail field is for debugging; it MUST NOT be forwarded to a patient.
+type ParseError struct {
+	Detail string
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("agent: could not parse model response: %s", e.Detail)
+}
+
+// Complete sends messages to the configured Chat Completions endpoint and
+// returns the assistant's text on success.
+//
+// On any non-success outcome the error is non-nil and the returned string is
+// empty. The concrete error type is one of *ModelError, *ParseError, or a
+// transport / context error. The caller MUST NOT treat a non-nil error as
+// clinical content — see the package-level failure contract.
+func (c *Client) Complete(ctx context.Context, messages []Message) (string, error) {
+	body, err := json.Marshal(chatRequest{Model: c.cfg.Model, Messages: messages})
+	if err != nil {
+		// json.Marshal failure is a programming error; wrap for context.
+		return "", fmt.Errorf("agent: marshal request: %w", err)
+	}
+
+	url := strings.TrimRight(c.cfg.BaseURL, "/") + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("agent: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if c.cfg.APIKey != "" {
+		// Set the bearer token without logging it.
+		req.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		// Transport / timeout errors pass through unmodified so the caller can
+		// inspect context.DeadlineExceeded, context.Canceled, etc.
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Read at most 64 KiB to avoid unbounded memory growth on runaway responses.
+	const maxBody = 64 * 1024
+	rawBody, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+	if err != nil {
+		return "", fmt.Errorf("agent: read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// Truncate the body in the error to avoid leaking large / sensitive
+		// payloads into logs.
+		const maxErrBody = 256
+		excerpt := string(rawBody)
+		if len(excerpt) > maxErrBody {
+			excerpt = excerpt[:maxErrBody] + "…"
+		}
+		return "", &ModelError{StatusCode: resp.StatusCode, Body: excerpt}
+	}
+
+	var cr chatResponse
+	if err := json.Unmarshal(rawBody, &cr); err != nil {
+		return "", &ParseError{Detail: "invalid JSON: " + err.Error()}
+	}
+	if len(cr.Choices) == 0 {
+		return "", &ParseError{Detail: "response contained no choices"}
+	}
+	text := cr.Choices[0].Message.Content
+	if text == "" {
+		return "", &ParseError{Detail: "first choice had empty content"}
+	}
+	return text, nil
+}

--- a/backend/internal/agent/client_test.go
+++ b/backend/internal/agent/client_test.go
@@ -1,0 +1,284 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/markolonius/housecall/backend/internal/agent"
+)
+
+// newTestClient builds a Client pointed at the given httptest.Server.
+func newTestClient(srv *httptest.Server) *agent.Client {
+	cfg := agent.ClientConfig{
+		BaseURL: srv.URL,
+		Model:   "test-model",
+	}
+	return agent.NewClient(cfg, srv.Client())
+}
+
+// chatResponseBody returns a minimal valid Chat Completions JSON body.
+func chatResponseBody(content string) string {
+	b, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{
+			{
+				"message":       map[string]any{"role": "assistant", "content": content},
+				"finish_reason": "stop",
+			},
+		},
+	})
+	return string(b)
+}
+
+// --- success path ---
+
+func TestComplete_Success(t *testing.T) {
+	const want = "Take two aspirin and rest."
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, chatResponseBody(want))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	got, err := c.Complete(context.Background(), []agent.Message{
+		{Role: "user", Content: "What should I do for a headache?"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestComplete_WithAPIKey_SetsAuthHeader(t *testing.T) {
+	const key = "sk-test-key"
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, chatResponseBody("ok"))
+	}))
+	defer srv.Close()
+
+	cfg := agent.ClientConfig{BaseURL: srv.URL, Model: "test-model", APIKey: key}
+	c := agent.NewClient(cfg, srv.Client())
+	_, err := c.Complete(context.Background(), []agent.Message{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAuth != "Bearer "+key {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer "+key)
+	}
+}
+
+// --- non-2xx → *ModelError ---
+
+func TestComplete_Non2xx_ReturnsModelError(t *testing.T) {
+	for _, code := range []int{400, 401, 429, 500, 503} {
+		code := code
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "error from model", code)
+			}))
+			defer srv.Close()
+
+			c := newTestClient(srv)
+			text, err := c.Complete(context.Background(), []agent.Message{{Role: "user", Content: "x"}})
+			if err == nil {
+				t.Fatalf("expected error for HTTP %d, got text=%q", code, text)
+			}
+			if text != "" {
+				t.Errorf("non-empty text returned alongside error: %q", text)
+			}
+			var me *agent.ModelError
+			if !errors.As(err, &me) {
+				t.Errorf("expected *ModelError, got %T: %v", err, err)
+			}
+			if me != nil && me.StatusCode != code {
+				t.Errorf("ModelError.StatusCode = %d, want %d", me.StatusCode, code)
+			}
+		})
+	}
+}
+
+// --- malformed body → *ParseError ---
+
+func TestComplete_MalformedJSON_ReturnsParseError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{not valid json`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	text, err := c.Complete(context.Background(), []agent.Message{{Role: "user", Content: "x"}})
+	if err == nil {
+		t.Fatalf("expected parse error, got text=%q", text)
+	}
+	if text != "" {
+		t.Errorf("non-empty text returned alongside error: %q", text)
+	}
+	var pe *agent.ParseError
+	if !errors.As(err, &pe) {
+		t.Errorf("expected *ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestComplete_EmptyChoices_ReturnsParseError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"choices":[]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	text, err := c.Complete(context.Background(), []agent.Message{{Role: "user", Content: "x"}})
+	if err == nil {
+		t.Fatalf("expected parse error, got text=%q", text)
+	}
+	if text != "" {
+		t.Errorf("non-empty text returned alongside error: %q", text)
+	}
+	var pe *agent.ParseError
+	if !errors.As(err, &pe) {
+		t.Errorf("expected *ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestComplete_EmptyContent_ReturnsParseError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, chatResponseBody("")) // empty string content
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	text, err := c.Complete(context.Background(), []agent.Message{{Role: "user", Content: "x"}})
+	if err == nil {
+		t.Fatalf("expected parse error for empty content, got text=%q", text)
+	}
+	if text != "" {
+		t.Errorf("non-empty text returned alongside error: %q", text)
+	}
+	var pe *agent.ParseError
+	if !errors.As(err, &pe) {
+		t.Errorf("expected *ParseError, got %T: %v", err, err)
+	}
+}
+
+// --- timeout / transport error ---
+
+func TestComplete_ContextCancelled_ReturnsError(t *testing.T) {
+	// Use an already-cancelled context so the http.Client bails out immediately
+	// before even establishing the connection — no server needed.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before the call
+
+	cfg := agent.ClientConfig{
+		BaseURL: "http://127.0.0.1:19999", // arbitrary; we never connect
+		Model:   "test-model",
+	}
+	c := agent.NewClient(cfg, &http.Client{Timeout: 2 * time.Second})
+	text, err := c.Complete(ctx, []agent.Message{{Role: "user", Content: "x"}})
+	if err == nil {
+		t.Fatalf("expected error for cancelled context, got text=%q", text)
+	}
+	if text != "" {
+		t.Errorf("non-empty text returned alongside error: %q", text)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Logf("error was: %v (type %T) — acceptable as long as it is non-nil and text is empty", err, err)
+	}
+}
+
+func TestComplete_TransportError_ReturnsError(t *testing.T) {
+	// Point the client at a port that (very likely) has nothing listening.
+	cfg := agent.ClientConfig{
+		BaseURL: "http://127.0.0.1:1", // port 1 is reserved; connection refused
+		Model:   "test-model",
+	}
+	c := agent.NewClient(cfg, &http.Client{Timeout: 2 * time.Second})
+	text, err := c.Complete(context.Background(), []agent.Message{{Role: "user", Content: "x"}})
+	if err == nil {
+		t.Fatalf("expected transport error, got text=%q", text)
+	}
+	if text != "" {
+		t.Errorf("non-empty text returned alongside transport error: %q", text)
+	}
+}
+
+// --- ClientConfig.String() does not leak the API key ---
+
+func TestClientConfig_String_RedactsAPIKey(t *testing.T) {
+	cfg := agent.ClientConfig{
+		BaseURL: "http://localhost:11434/v1",
+		Model:   "medgemma",
+		APIKey:  "sk-super-secret",
+	}
+	s := cfg.String()
+	if strings.Contains(s, "sk-super-secret") {
+		t.Errorf("ClientConfig.String() exposed API key: %s", s)
+	}
+	if !strings.Contains(s, "<redacted>") {
+		t.Errorf("ClientConfig.String() should contain '<redacted>', got: %s", s)
+	}
+}
+
+func TestClientConfig_String_NoKeyShowsNone(t *testing.T) {
+	cfg := agent.ClientConfig{BaseURL: "http://localhost:11434/v1", Model: "m"}
+	s := cfg.String()
+	if !strings.Contains(s, "<none>") {
+		t.Errorf("ClientConfig.String() should say '<none>' when APIKey is empty, got: %s", s)
+	}
+}
+
+// --- ClientConfigFromEnv ---
+
+func TestClientConfigFromEnv_Defaults(t *testing.T) {
+	// Unset the env vars to ensure defaults are used.
+	t.Setenv("AGENT_MODEL_BASE_URL", "")
+	t.Setenv("AGENT_MODEL_NAME", "")
+	t.Setenv("AGENT_MODEL_API_KEY", "")
+
+	cfg := agent.ClientConfigFromEnv()
+	if cfg.BaseURL != agent.DefaultBaseURL {
+		t.Errorf("BaseURL = %q, want %q", cfg.BaseURL, agent.DefaultBaseURL)
+	}
+	if cfg.Model != agent.DefaultModel {
+		t.Errorf("Model = %q, want %q", cfg.Model, agent.DefaultModel)
+	}
+	if cfg.APIKey != "" {
+		t.Errorf("APIKey should be empty, got non-empty")
+	}
+}
+
+func TestClientConfigFromEnv_Overrides(t *testing.T) {
+	t.Setenv("AGENT_MODEL_BASE_URL", "http://model.example.com/v1")
+	t.Setenv("AGENT_MODEL_NAME", "custom-model")
+	t.Setenv("AGENT_MODEL_API_KEY", "tok-xyz")
+
+	cfg := agent.ClientConfigFromEnv()
+	if cfg.BaseURL != "http://model.example.com/v1" {
+		t.Errorf("BaseURL = %q", cfg.BaseURL)
+	}
+	if cfg.Model != "custom-model" {
+		t.Errorf("Model = %q", cfg.Model)
+	}
+	if cfg.APIKey != "tok-xyz" {
+		t.Errorf("APIKey = %q", cfg.APIKey)
+	}
+}

--- a/backend/internal/agent/drafter.go
+++ b/backend/internal/agent/drafter.go
@@ -1,0 +1,170 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/google/uuid"
+	"github.com/markolonius/housecall/backend/internal/domain"
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// ModelClient is the narrow interface the Drafter needs from the model. Using
+// an interface rather than *Client directly lets tests inject a stub without
+// standing up a real model endpoint.
+type ModelClient interface {
+	Complete(ctx context.Context, messages []Message) (string, error)
+}
+
+// PhysicianNotifier is the narrow interface the Drafter needs to push
+// queue.updated events to connected physicians.
+type PhysicianNotifier interface {
+	SendToPhysicians(tenantID string, event []byte)
+}
+
+// Drafter listens for persisted patient messages and drives the
+// DRAFT → PENDING_REVIEW lifecycle for guidance recommendations.
+//
+// Threading: DraftAsync dispatches the work to a goroutine so the patient's
+// HTTP response is returned immediately; the model call (which may take up to
+// DefaultTimeout) runs concurrently. Context cancellation from the originating
+// request is NOT propagated — drafting must complete even if the patient
+// disconnects. The goroutine uses a background context derived from the store.
+type Drafter struct {
+	client   ModelClient
+	store    *store.Store
+	notifier PhysicianNotifier
+}
+
+// NewDrafter constructs a Drafter. All three arguments are required.
+func NewDrafter(client ModelClient, s *store.Store, notifier PhysicianNotifier) *Drafter {
+	return &Drafter{client: client, store: s, notifier: notifier}
+}
+
+// DraftAsync spawns a goroutine that assembles the conversation context,
+// calls the model, and persists a PENDING_REVIEW recommendation. It is
+// fire-and-forget: errors are logged but never returned to the caller.
+// The caller must not pass a request-scoped context — use context.Background()
+// or a long-lived server context so the goroutine is not cancelled when the
+// HTTP handler returns.
+func (d *Drafter) DraftAsync(tenantID store.TenantID, conv store.Conversation, patient store.Patient) {
+	go func() {
+		ctx := context.Background()
+		if err := d.draft(ctx, tenantID, conv, patient); err != nil {
+			// Task 4.3 will slot the failure path (ai_interaction_failed audit)
+			// here. For now we log without exposing error bodies that may echo
+			// request content (see ModelError.Body HIPAA note in client.go).
+			log.Printf("agent: draft failed conversation_id=%s: %T", conv.ID, err)
+		}
+	}()
+}
+
+// draft is the synchronous drafting logic, separated for testability.
+func (d *Drafter) draft(ctx context.Context, tenantID store.TenantID, conv store.Conversation, patient store.Patient) error {
+	// Assemble tenant-scoped conversation context. The query includes
+	// tenant_id in the WHERE clause so messages from other tenants are
+	// never mixed in, even if two tenants share a conversation UUID by
+	// some extreme coincidence.
+	msgs, err := d.store.ListMessagesByConversation(ctx, tenantID, conv.ID)
+	if err != nil {
+		return err
+	}
+
+	// Build the model message slice: a brief system prompt followed by the
+	// conversation history. Content goes into the model call only — it is
+	// never written to audit logs.
+	modelMsgs := make([]Message, 0, len(msgs)+1)
+	modelMsgs = append(modelMsgs, Message{
+		Role:    "system",
+		Content: "You are a medical assistant. Provide concise clinical guidance based on the conversation.",
+	})
+	for _, m := range msgs {
+		modelMsgs = append(modelMsgs, Message{
+			Role:    m.Role,
+			Content: m.Content,
+		})
+	}
+
+	text, err := d.client.Complete(ctx, modelMsgs)
+	if err != nil {
+		// Non-nil error means no valid model output — do NOT persist as
+		// clinical content (failure contract from client.go). Task 4.3
+		// handles this branch fully.
+		return err
+	}
+
+	// Build the guidance payload. Only the model text goes here — no
+	// audit metadata, no PHI from other sources.
+	payload, err := json.Marshal(map[string]string{"text": text})
+	if err != nil {
+		return err
+	}
+
+	agentActor := domain.Actor{Type: domain.ActorAgent, ID: uuid.Nil}
+
+	// Persist DRAFT → PENDING_REVIEW + audit event atomically. The
+	// two-step pattern (create DRAFT then transition to PENDING_REVIEW
+	// within the same Txn) mirrors the Phase 3 physician review pattern
+	// so there is never a DRAFT row visible outside the transaction.
+	var recID uuid.UUID
+	if err := d.store.Txn(ctx, func(tx *store.TxStore) error {
+		// Step 1: insert at DRAFT.
+		rec, err := tx.CreateRecommendation(ctx, tenantID, store.Recommendation{
+			ConversationID: conv.ID,
+			PatientID:      patient.ID,
+			State:          domain.StateDraft,
+			PayloadType:    "guidance",
+			Payload:        payload,
+			DraftContent:   text,
+		})
+		if err != nil {
+			return err
+		}
+		recID = rec.ID
+
+		// Step 2: pure state-machine transition DRAFT → PENDING_REVIEW.
+		// The agent actor has no path beyond this single transition.
+		nextState, err := domain.Transition(rec.State, domain.ActionSubmitForReview, agentActor, patient.State)
+		if err != nil {
+			return err
+		}
+
+		// Step 3: persist the new state within the same transaction.
+		if err := tx.UpdateRecommendationState(ctx, tenantID, rec.ID, nextState, nil, nil); err != nil {
+			return err
+		}
+
+		// Step 4: write the audit event. Metadata contains identifiers only
+		// — no PHI, no model output.
+		return tx.CreateAuditEvent(ctx, tenantID, store.AuditEvent{
+			ActorType: string(domain.ActorAgent),
+			ActorID:   nil, // agent has no user UUID
+			EventType: "recommendation.submitted_for_review",
+			Metadata: mustMarshalJSON(map[string]any{
+				"recommendation_id": recID.String(),
+				"conversation_id":   conv.ID.String(),
+				"new_state":         nextState,
+			}),
+		})
+	}); err != nil {
+		return err
+	}
+
+	// Emit queue.updated AFTER the successful commit so physicians only
+	// receive the event when the row is durably visible.
+	d.notifier.SendToPhysicians(tenantID.String(), mustMarshalJSON(map[string]any{
+		"type": "queue.updated",
+		"data": map[string]any{
+			"recommendation_id": recID.String(),
+			"conversation_id":   conv.ID.String(),
+		},
+	}))
+
+	return nil
+}
+
+func mustMarshalJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}

--- a/backend/internal/agent/drafter.go
+++ b/backend/internal/agent/drafter.go
@@ -50,6 +50,18 @@ func NewDrafter(client ModelClient, s *store.Store, notifier PhysicianNotifier) 
 // HTTP handler returns.
 func (d *Drafter) DraftAsync(tenantID store.TenantID, conv store.Conversation, patient store.Patient) {
 	go func() {
+		// Recover from any panic inside draft() (nil-deref, driver bug, etc.)
+		// so a single drafting failure cannot crash the server process.
+		// middleware.Recoverer only protects HTTP handler goroutines; fire-and-
+		// forget goroutines must manage their own recovery.
+		// Log type only — never the recovered value itself, which may echo
+		// request content or PHI.
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("agent: draft panicked conversation_id=%s: %T", conv.ID, r)
+			}
+		}()
+
 		ctx := context.Background()
 		if err := d.draft(ctx, tenantID, conv, patient); err != nil {
 			// Task 4.3 will slot the failure path (ai_interaction_failed audit)

--- a/backend/internal/agent/drafter.go
+++ b/backend/internal/agent/drafter.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
+	"net"
 
 	"github.com/google/uuid"
 	"github.com/markolonius/housecall/backend/internal/domain"
@@ -64,10 +66,30 @@ func (d *Drafter) DraftAsync(tenantID store.TenantID, conv store.Conversation, p
 
 		ctx := context.Background()
 		if err := d.draft(ctx, tenantID, conv, patient); err != nil {
-			// Task 4.3 will slot the failure path (ai_interaction_failed audit)
-			// here. For now we log without exposing error bodies that may echo
-			// request content (see ModelError.Body HIPAA note in client.go).
+			// Log type only — never the error message or body, which may echo
+			// request content or PHI (see ModelError.Body HIPAA note in
+			// client.go).
 			log.Printf("agent: draft failed conversation_id=%s: %T", conv.ID, err)
+
+			// Write the ai_interaction_failed audit event. The metadata contains
+			// only identifiers and a coarse reason derived from the error type —
+			// no PHI, no model error body, no error message text.
+			reason := draftFailureReason(err)
+			_, auditErr := d.store.CreateAuditEvent(ctx, tenantID, store.AuditEvent{
+				ActorType: string(domain.ActorAgent),
+				ActorID:   nil, // agent has no user UUID
+				EventType: "ai_interaction_failed",
+				Metadata: mustMarshalJSON(map[string]any{
+					"conversation_id": conv.ID.String(),
+					"patient_id":      patient.ID.String(),
+					"reason":          reason,
+				}),
+			})
+			if auditErr != nil {
+				// A failed audit write must not crash the goroutine. Log the
+				// error type only — never the value, which could echo PHI.
+				log.Printf("agent: audit write failed conversation_id=%s: %T", conv.ID, auditErr)
+			}
 		}
 	}()
 }
@@ -174,6 +196,45 @@ func (d *Drafter) draft(ctx context.Context, tenantID store.TenantID, conv store
 	}))
 
 	return nil
+}
+
+// draftFailureReason maps a draft error to a coarse, safe string reason that
+// can appear in audit metadata. The mapping is entirely type-driven — the
+// error message, body, or any embedded content is never inspected, so no PHI
+// or model-response content can leak into audit rows.
+//
+//   - context.DeadlineExceeded                   → "timeout"
+//   - *ParseError                                → "parse_error"
+//   - *ModelError (connection refused / net err) → "model_unavailable"
+//   - *ModelError (non-2xx from the model)       → "model_error"
+//   - anything else                              → "internal_error"
+func draftFailureReason(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var pe *ParseError
+	if errors.As(err, &pe) {
+		return "parse_error"
+	}
+	var me *ModelError
+	if errors.As(err, &me) {
+		// Distinguish a transport/connection failure (wrapped inside ModelError
+		// only when the HTTP client itself fails before a status code is
+		// available) from a well-formed non-2xx response. A net.Error or
+		// context.Canceled unwrapped from the error signals "unreachable";
+		// a StatusCode > 0 signals the model replied with an error status.
+		if me.StatusCode == 0 {
+			return "model_unavailable"
+		}
+		return "model_error"
+	}
+	// Transport errors that are not wrapped in *ModelError (e.g. connection
+	// refused before any HTTP response is parsed).
+	var ne net.Error
+	if errors.As(err, &ne) {
+		return "model_unavailable"
+	}
+	return "internal_error"
 }
 
 func mustMarshalJSON(v any) []byte {

--- a/backend/internal/agent/drafter_test.go
+++ b/backend/internal/agent/drafter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -387,6 +388,186 @@ func TestDraft_TenantScoping(t *testing.T) {
 		t.Errorf("tenant A has %d PENDING_REVIEW recommendations, want 1", len(recsA))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Task 4.3: failure-path tests
+// ---------------------------------------------------------------------------
+
+// assertFailurePath is a shared helper for the four Task 4.3 failure-mode
+// tests. It:
+//
+//  1. Waits up to 2 s for the goroutine to finish (detected via audit row).
+//  2. Asserts zero recommendations exist for the fixture's conversation.
+//  3. Asserts exactly one ai_interaction_failed audit row exists with the
+//     expected coarse reason and no PHI / model-body content.
+//  4. Asserts no queue.updated event was emitted.
+func assertFailurePath(t *testing.T, pool *pgxpool.Pool, s *store.Store, f drafterFixture, notifier *stubNotifier, wantReason string) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Poll until the audit row appears (goroutine completes near-instantly with
+	// stub clients, but give it up to 2 s to be safe in CI).
+	deadline := time.Now().Add(2 * time.Second)
+	var auditRows int
+	for time.Now().Before(deadline) {
+		row := pool.QueryRow(ctx,
+			`SELECT COUNT(*) FROM audit_events
+			  WHERE tenant_id = $1 AND event_type = 'ai_interaction_failed'`,
+			f.TenantID.UUID(),
+		)
+		if err := row.Scan(&auditRows); err == nil && auditRows > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// (a) Zero recommendations for this tenant's conversation.
+	recs, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
+	if err != nil {
+		t.Fatalf("list PENDING_REVIEW recs: %v", err)
+	}
+	// Filter to the fixture's conversation to be safe when tests run in parallel
+	// against the same DB.
+	for _, r := range recs {
+		if r.ConversationID == f.Conv.ID {
+			t.Errorf("found unexpected PENDING_REVIEW recommendation for conversation %s", f.Conv.ID)
+		}
+	}
+	drafts, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StateDraft)
+	if err != nil {
+		t.Fatalf("list DRAFT recs: %v", err)
+	}
+	for _, r := range drafts {
+		if r.ConversationID == f.Conv.ID {
+			t.Errorf("found unexpected DRAFT recommendation for conversation %s", f.Conv.ID)
+		}
+	}
+
+	// (b) Exactly one ai_interaction_failed audit row with correct reason and no PHI.
+	rows, err := pool.Query(ctx,
+		`SELECT metadata FROM audit_events
+		  WHERE tenant_id = $1 AND event_type = 'ai_interaction_failed'
+		    AND metadata->>'conversation_id' = $2`,
+		f.TenantID.UUID(),
+		f.Conv.ID.String(),
+	)
+	if err != nil {
+		t.Fatalf("query ai_interaction_failed audit rows: %v", err)
+	}
+	defer rows.Close()
+
+	var count int
+	for rows.Next() {
+		count++
+		var meta []byte
+		if err := rows.Scan(&meta); err != nil {
+			t.Fatalf("scan audit metadata: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(meta, &m); err != nil {
+			t.Fatalf("unmarshal audit metadata: %v", err)
+		}
+		// Reason must match expected coarse string.
+		if got, ok := m["reason"].(string); !ok || got != wantReason {
+			t.Errorf("audit reason = %q, want %q (metadata=%s)", got, wantReason, meta)
+		}
+		// conversation_id and patient_id must be present (identifiers only).
+		if _, ok := m["conversation_id"]; !ok {
+			t.Errorf("audit metadata missing conversation_id")
+		}
+		if _, ok := m["patient_id"]; !ok {
+			t.Errorf("audit metadata missing patient_id")
+		}
+		// Metadata must not contain any model-body / PHI fields.
+		for _, forbidden := range []string{"body", "content", "text", "error", "detail", "message"} {
+			if _, present := m[forbidden]; present {
+				t.Errorf("audit metadata must not contain field %q (PHI/body leak)", forbidden)
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 ai_interaction_failed audit row, got %d", count)
+	}
+
+	// (c) No queue.updated emitted.
+	if notifier.count() != 0 {
+		t.Errorf("expected 0 queue.updated events on failure, got %d", notifier.count())
+	}
+}
+
+// TestDraft_FailurePath_TransportError verifies that a transport-level error
+// (connection refused / net.Error) produces no recommendation and an
+// ai_interaction_failed audit event with reason "model_unavailable".
+func TestDraft_FailurePath_TransportError(t *testing.T) {
+	pool := testPool(t)
+	s := store.New(pool)
+	f := setupDrafterFixture(t, s)
+
+	// Simulate a transport error (net.Error). We use a real *net.OpError which
+	// implements net.Error, wrapped in the same way the http client would surface
+	// a connection-refused error.
+	transportErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	notifier := &stubNotifier{}
+	d := agent.NewDrafter(&stubClient{err: transportErr}, s, notifier)
+	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
+
+	assertFailurePath(t, pool, s, f, notifier, "model_unavailable")
+}
+
+// TestDraft_FailurePath_ModelError verifies that a non-2xx HTTP response from
+// the model endpoint produces no recommendation and an ai_interaction_failed
+// audit event with reason "model_error".
+func TestDraft_FailurePath_ModelError(t *testing.T) {
+	pool := testPool(t)
+	s := store.New(pool)
+	f := setupDrafterFixture(t, s)
+
+	modelErr := &agent.ModelError{StatusCode: 503}
+	notifier := &stubNotifier{}
+	d := agent.NewDrafter(&stubClient{err: modelErr}, s, notifier)
+	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
+
+	assertFailurePath(t, pool, s, f, notifier, "model_error")
+}
+
+// TestDraft_FailurePath_ParseError verifies that a well-formed HTTP response
+// whose body cannot be decoded (or has no usable choices) produces no
+// recommendation and an ai_interaction_failed audit event with reason
+// "parse_error".
+func TestDraft_FailurePath_ParseError(t *testing.T) {
+	pool := testPool(t)
+	s := store.New(pool)
+	f := setupDrafterFixture(t, s)
+
+	parseErr := &agent.ParseError{Detail: "response contained no choices"}
+	notifier := &stubNotifier{}
+	d := agent.NewDrafter(&stubClient{err: parseErr}, s, notifier)
+	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
+
+	assertFailurePath(t, pool, s, f, notifier, "parse_error")
+}
+
+// TestDraft_FailurePath_Timeout verifies that a context deadline exceeded error
+// produces no recommendation and an ai_interaction_failed audit event with
+// reason "timeout".
+func TestDraft_FailurePath_Timeout(t *testing.T) {
+	pool := testPool(t)
+	s := store.New(pool)
+	f := setupDrafterFixture(t, s)
+
+	notifier := &stubNotifier{}
+	d := agent.NewDrafter(&stubClient{err: context.DeadlineExceeded}, s, notifier)
+	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
+
+	assertFailurePath(t, pool, s, f, notifier, "timeout")
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time interface checks (moved after failure-path block)
+// ---------------------------------------------------------------------------
 
 // TestDraft_ModelClientInterface verifies that the ModelClient interface is
 // satisfied by a struct that does NOT embed *agent.Client — confirming the

--- a/backend/internal/agent/drafter_test.go
+++ b/backend/internal/agent/drafter_test.go
@@ -81,6 +81,14 @@ func (s *stubClient) Complete(_ context.Context, _ []agent.Message) (string, err
 	return s.text, s.err
 }
 
+// panicClient is a ModelClient whose Complete method always panics. Used to
+// verify that DraftAsync's recover() keeps the process alive.
+type panicClient struct{}
+
+func (p *panicClient) Complete(_ context.Context, _ []agent.Message) (string, error) {
+	panic("simulated model client panic")
+}
+
 // stubNotifier records the last event sent to physicians.
 type stubNotifier struct {
 	mu     sync.Mutex
@@ -429,5 +437,40 @@ func TestDraft_ErrorPath_StructuredForTask43(t *testing.T) {
 	var me *agent.ModelError
 	if !errors.As(modelErr, &me) {
 		t.Errorf("expected *agent.ModelError, got %T", modelErr)
+	}
+}
+
+// TestDraft_PanicRecovery verifies that a panic inside the model client does
+// NOT crash the server process: DraftAsync recovers, no recommendation is
+// persisted, and no queue.updated event is emitted.
+func TestDraft_PanicRecovery(t *testing.T) {
+	pool := testPool(t)
+	s := store.New(pool)
+	f := setupDrafterFixture(t, s)
+	ctx := context.Background()
+
+	notifier := &stubNotifier{}
+	d := agent.NewDrafter(&panicClient{}, s, notifier)
+
+	// DraftAsync must return without panicking — if the goroutine's panic
+	// propagates the test binary itself will crash here.
+	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
+
+	// Give the goroutine time to run and recover; the panic client returns
+	// immediately so 200 ms is very generous.
+	time.Sleep(200 * time.Millisecond)
+
+	// No recommendation must be created when the client panicked.
+	recs, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
+	if err != nil {
+		t.Fatalf("list recs: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Errorf("expected 0 recommendations after panicking client, got %d", len(recs))
+	}
+
+	// No queue.updated notification should be emitted on panic.
+	if notifier.count() != 0 {
+		t.Errorf("expected 0 queue.updated events after panicking client, got %d", notifier.count())
 	}
 }

--- a/backend/internal/agent/drafter_test.go
+++ b/backend/internal/agent/drafter_test.go
@@ -1,0 +1,433 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/markolonius/housecall/backend/internal/agent"
+	"github.com/markolonius/housecall/backend/internal/domain"
+	"github.com/markolonius/housecall/backend/internal/migrate"
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// testPool returns a pool connected to TEST_DATABASE_URL with migrations
+// applied. Skips when the env var is unset so the suite compiles without
+// Postgres.
+//
+// Unlike the store package's testPool, this helper does NOT TRUNCATE the
+// schema. Drafter tests create their own tenant rows using unique names and
+// scope all assertions to those tenants, so they are safe to run alongside
+// other packages without a clean-slate requirement. Avoiding a TRUNCATE
+// prevents a parallel-execution race with the store package's own TRUNCATE.
+func testPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping DB-bound test")
+	}
+
+	ctx := context.Background()
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer conn.Close(ctx)
+
+	if _, err := migrate.Apply(ctx, conn, os.DirFS(migrationsDir(t))); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func migrationsDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// agent/ → backend/migrations
+	return filepath.Join(filepath.Dir(file), "..", "..", "migrations")
+}
+
+// stubClient is a ModelClient that returns a canned response.
+type stubClient struct {
+	text string
+	err  error
+}
+
+func (s *stubClient) Complete(_ context.Context, _ []agent.Message) (string, error) {
+	return s.text, s.err
+}
+
+// stubNotifier records the last event sent to physicians.
+type stubNotifier struct {
+	mu     sync.Mutex
+	events [][]byte
+}
+
+func (n *stubNotifier) SendToPhysicians(_ string, event []byte) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.events = append(n.events, event)
+}
+
+func (n *stubNotifier) count() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.events)
+}
+
+func (n *stubNotifier) last() []byte {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.events) == 0 {
+		return nil
+	}
+	return n.events[len(n.events)-1]
+}
+
+// ---------------------------------------------------------------------------
+// setupDrafterFixture creates one tenant, patient, physician, care relationship,
+// conversation, and one user message, then returns everything needed to test the
+// drafter.
+// ---------------------------------------------------------------------------
+
+type drafterFixture struct {
+	TenantID store.TenantID
+	Patient  store.Patient
+	Conv     store.Conversation
+}
+
+func setupDrafterFixture(t *testing.T, s *store.Store) drafterFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	// Use a random suffix so parallel test runs against the same DB do not
+	// collide on unique constraint columns (email).
+	suffix := uuid.New().String()
+
+	tenant, err := s.CreateTenant(ctx, "dtc", "drafter-test-"+suffix)
+	if err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	tid := store.TenantID(tenant.ID)
+
+	patient, err := s.CreatePatient(ctx, tid, store.Patient{
+		Email:        "patient+" + suffix + "@drafter.test",
+		FullName:     "Test Patient",
+		State:        "CA",
+		PasswordHash: "hash",
+	})
+	if err != nil {
+		t.Fatalf("create patient: %v", err)
+	}
+
+	physician, err := s.CreatePhysician(ctx, tid, store.Physician{
+		Email:          "doc+" + suffix + "@drafter.test",
+		FullName:       "Test Doc",
+		StatesLicensed: []string{"CA"},
+		PasswordHash:   "hash",
+	})
+	if err != nil {
+		t.Fatalf("create physician: %v", err)
+	}
+
+	if _, err := s.CreateCareRelationship(ctx, tid, patient.ID, physician.ID); err != nil {
+		t.Fatalf("create care relationship: %v", err)
+	}
+
+	conv, err := s.CreateConversation(ctx, tid, patient.ID, "test conversation")
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	// Seed one patient message — this is what the drafter assembles as context.
+	if _, err := s.CreateMessage(ctx, tid, conv.ID, "user", "I have a headache"); err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+
+	return drafterFixture{TenantID: tid, Patient: patient, Conv: conv}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestDraft_HappyPath verifies that a patient message produces exactly one
+// PENDING_REVIEW recommendation with payload_type='guidance', an audit event,
+// and a queue.updated notification to physicians.
+func TestDraft_HappyPath(t *testing.T) {
+	pool := testPool(t)
+	s := store.New(pool)
+	f := setupDrafterFixture(t, s)
+	ctx := context.Background()
+
+	const wantText = "Take ibuprofen and rest. Consult a physician if symptoms worsen."
+
+	notifier := &stubNotifier{}
+	d := agent.NewDrafter(&stubClient{text: wantText}, s, notifier)
+
+	// Call draft synchronously (via the exported DraftAsync → goroutine path
+	// we test via a small wait, or we test the internal logic via the public
+	// interface). Since DraftAsync is fire-and-forget, we wait for the
+	// notification to confirm the goroutine completed.
+	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
+
+	// Poll until the notifier receives the event (max 5 s — the stub client
+	// returns instantly so this should be near-zero in practice).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && notifier.count() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if notifier.count() == 0 {
+		t.Fatal("queue.updated event never received — drafting may have failed")
+	}
+
+	// --- Assert exactly one PENDING_REVIEW recommendation ---
+	recs, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
+	if err != nil {
+		t.Fatalf("list recommendations: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 PENDING_REVIEW recommendation, got %d", len(recs))
+	}
+	rec := recs[0]
+
+	if rec.PayloadType != "guidance" {
+		t.Errorf("payload_type = %q, want %q", rec.PayloadType, "guidance")
+	}
+	if rec.ConversationID != f.Conv.ID {
+		t.Errorf("conversation_id mismatch")
+	}
+	if rec.PatientID != f.Patient.ID {
+		t.Errorf("patient_id mismatch")
+	}
+
+	// Verify payload contains the model output text.
+	var payload map[string]string
+	if err := json.Unmarshal(rec.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["text"] != wantText {
+		t.Errorf("payload[text] = %q, want %q", payload["text"], wantText)
+	}
+
+	// draft_content should also carry the model text.
+	if rec.DraftContent != wantText {
+		t.Errorf("draft_content = %q, want %q", rec.DraftContent, wantText)
+	}
+
+	// --- Assert no DRAFT rows remain (the DRAFT → PENDING_REVIEW transition
+	// was atomic: the DRAFT state should never be observable outside the Txn) ---
+	drafts, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StateDraft)
+	if err != nil {
+		t.Fatalf("list draft recommendations: %v", err)
+	}
+	if len(drafts) != 0 {
+		t.Errorf("expected 0 DRAFT recommendations, got %d", len(drafts))
+	}
+
+	// --- Assert audit event exists ---
+	// We query audit_events directly because the store's read path is
+	// tenant-scoped; the event_type must not contain PHI.
+	pool2 := pool // same pool, we re-use it
+	rows, err := pool2.Query(ctx,
+		`SELECT event_type, metadata
+		   FROM audit_events
+		  WHERE tenant_id = $1 AND event_type = 'recommendation.submitted_for_review'`,
+		f.TenantID.UUID(),
+	)
+	if err != nil {
+		t.Fatalf("query audit events: %v", err)
+	}
+	defer rows.Close()
+
+	var auditCount int
+	for rows.Next() {
+		var eventType string
+		var meta []byte
+		if err := rows.Scan(&eventType, &meta); err != nil {
+			t.Fatalf("scan audit row: %v", err)
+		}
+		// Metadata must contain recommendation_id and conversation_id but NOT
+		// the model text or any PHI.
+		var m map[string]any
+		if err := json.Unmarshal(meta, &m); err != nil {
+			t.Fatalf("unmarshal audit metadata: %v", err)
+		}
+		if _, ok := m["recommendation_id"]; !ok {
+			t.Errorf("audit metadata missing recommendation_id")
+		}
+		if _, ok := m["conversation_id"]; !ok {
+			t.Errorf("audit metadata missing conversation_id")
+		}
+		// Model output must NOT appear in audit metadata.
+		raw := string(meta)
+		if raw == wantText || (len(wantText) > 10 && len(raw) > 10) {
+			// Check by looking for the model text literally.
+			if json.Valid([]byte(wantText)) {
+				// model text happens to be JSON — unlikely in practice but skip
+				// this assertion to avoid false positives.
+			}
+		}
+		auditCount++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows error: %v", err)
+	}
+	if auditCount != 1 {
+		t.Errorf("expected 1 audit event for recommendation.submitted_for_review, got %d", auditCount)
+	}
+
+	// --- Assert queue.updated event was emitted ---
+	lastEvent := notifier.last()
+	if lastEvent == nil {
+		t.Fatal("no queue.updated event emitted")
+	}
+	var evt map[string]any
+	if err := json.Unmarshal(lastEvent, &evt); err != nil {
+		t.Fatalf("unmarshal queue.updated event: %v", err)
+	}
+	if evt["type"] != "queue.updated" {
+		t.Errorf("event type = %q, want %q", evt["type"], "queue.updated")
+	}
+}
+
+// TestDraft_TenantScoping verifies that the drafter only reads messages that
+// belong to the target conversation/tenant and never bleeds into another
+// tenant's data.
+func TestDraft_TenantScoping(t *testing.T) {
+	pool := testPool(t)
+	s := store.New(pool)
+	ctx := context.Background()
+
+	// Set up two completely independent tenants.
+	fA := setupDrafterFixture(t, s)
+
+	// Create tenant B with its own patient and conversation.
+	suffixB := uuid.New().String()
+	tenantB, err := s.CreateTenant(ctx, "dtc", "tenant-b-"+suffixB)
+	if err != nil {
+		t.Fatalf("create tenant B: %v", err)
+	}
+	tidB := store.TenantID(tenantB.ID)
+	patientB, err := s.CreatePatient(ctx, tidB, store.Patient{
+		Email:        "patient+" + suffixB + "@b.test",
+		FullName:     "B Patient",
+		State:        "NY",
+		PasswordHash: "hash",
+	})
+	if err != nil {
+		t.Fatalf("create patient B: %v", err)
+	}
+	convB, err := s.CreateConversation(ctx, tidB, patientB.ID, "conv B")
+	if err != nil {
+		t.Fatalf("create conv B: %v", err)
+	}
+	if _, err := s.CreateMessage(ctx, tidB, convB.ID, "user", "B's private message"); err != nil {
+		t.Fatalf("create message B: %v", err)
+	}
+
+	// Run drafter for tenant A only.
+	const wantText = "Guidance for A only."
+	notifier := &stubNotifier{}
+	d := agent.NewDrafter(&stubClient{text: wantText}, s, notifier)
+	d.DraftAsync(fA.TenantID, fA.Conv, fA.Patient)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && notifier.count() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Tenant B must have zero recommendations.
+	recsB, err := s.ListRecommendationsByState(ctx, tidB, domain.StatePendingReview)
+	if err != nil {
+		t.Fatalf("list B recs: %v", err)
+	}
+	if len(recsB) != 0 {
+		t.Errorf("tenant B has %d recommendations after drafting for tenant A — tenant leak!", len(recsB))
+	}
+
+	// Tenant A must have exactly one.
+	recsA, err := s.ListRecommendationsByState(ctx, fA.TenantID, domain.StatePendingReview)
+	if err != nil {
+		t.Fatalf("list A recs: %v", err)
+	}
+	if len(recsA) != 1 {
+		t.Errorf("tenant A has %d PENDING_REVIEW recommendations, want 1", len(recsA))
+	}
+}
+
+// TestDraft_ModelClientInterface verifies that the ModelClient interface is
+// satisfied by a struct that does NOT embed *agent.Client — confirming the
+// interface is the only contract between the drafter and the model.
+func TestDraft_ModelClientInterface(t *testing.T) {
+	// This test is a compile-time guard: if agent.ModelClient changes its
+	// signature, this stub won't compile. The blank assignment forces the check.
+	var _ agent.ModelClient = (*stubClient)(nil)
+	// Also verify that *agent.Client satisfies the interface.
+	var _ agent.ModelClient = (*agent.Client)(nil)
+}
+
+// TestDraft_ErrorPath_StructuredForTask43 verifies that when the model client
+// returns an error the drafter returns an error and creates no recommendation.
+// This is the structural stub for Task 4.3 — the full failure path (audit
+// event) is implemented there; here we assert the happy-path invariant holds
+// (no recommendation persisted on failure).
+func TestDraft_ErrorPath_StructuredForTask43(t *testing.T) {
+	pool := testPool(t)
+	s := store.New(pool)
+	f := setupDrafterFixture(t, s)
+	ctx := context.Background()
+
+	modelErr := &agent.ModelError{StatusCode: 503}
+	notifier := &stubNotifier{}
+	d := agent.NewDrafter(&stubClient{err: modelErr}, s, notifier)
+	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
+
+	// Wait briefly — the goroutine returns quickly since the stub fails.
+	time.Sleep(100 * time.Millisecond)
+
+	// No recommendation must be created on error.
+	recs, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
+	if err != nil {
+		t.Fatalf("list recs: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Errorf("expected 0 recommendations on model error, got %d", len(recs))
+	}
+
+	// No queue.updated should be sent.
+	if notifier.count() != 0 {
+		t.Errorf("expected 0 queue.updated events on model error, got %d", notifier.count())
+	}
+
+	// Confirm the error is a *ModelError (not a ParseError or other type) so
+	// Task 4.3 can switch on it.
+	var me *agent.ModelError
+	if !errors.As(modelErr, &me) {
+		t.Errorf("expected *agent.ModelError, got %T", modelErr)
+	}
+}

--- a/backend/internal/api/messages.go
+++ b/backend/internal/api/messages.go
@@ -83,6 +83,21 @@ func (rt *Router) handleCreateMessage(w http.ResponseWriter, r *http.Request) {
 			"conversation_id": convID.String(),
 			"message_id":      msg.ID.String(),
 		})
-	// Phase 4 (Task 4.2): trigger AI Agent Runtime here after persisting the message.
+
+	// Task 4.2: trigger reactive drafting asynchronously after the message is
+	// persisted. DraftAsync spawns a goroutine — the patient's response is
+	// returned immediately; drafting proceeds in the background. We load the
+	// patient here (tenant-scoped) so the drafter has the patient.State needed
+	// for the domain.Transition call without a second DB round-trip inside the
+	// goroutine startup path.
+	if rt.drafter != nil {
+		patient, err := rt.store.GetPatient(r.Context(), claims.TenantID, claims.ActorID)
+		if err == nil {
+			rt.drafter.DraftAsync(claims.TenantID, conv, patient)
+		}
+		// If the patient lookup fails (unexpected), we skip drafting and log
+		// nothing that includes PHI — the message is already persisted.
+	}
+
 	writeJSON(w, http.StatusCreated, msg)
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -4,20 +4,24 @@ package api
 
 import (
 	"github.com/go-chi/chi/v5"
+	"github.com/markolonius/housecall/backend/internal/agent"
 	"github.com/markolonius/housecall/backend/internal/audit"
 	"github.com/markolonius/housecall/backend/internal/store"
 )
 
 // Router holds shared dependencies for all HTTP handlers.
 type Router struct {
-	store  *store.Store
-	hub    *Hub
-	secret []byte
-	audit  *audit.Writer
+	store   *store.Store
+	hub     *Hub
+	secret  []byte
+	audit   *audit.Writer
+	drafter *agent.Drafter
 }
 
 // New constructs a Router. secret is the HMAC-SHA256 key used to sign and
 // verify JWTs; it must be non-empty (validated at startup in cmd/server).
+// Wire the Drafter after construction via SetDrafter to break the circular
+// dependency (Router → Drafter → Router as PhysicianNotifier).
 func New(s *store.Store, secret []byte) *Router {
 	return &Router{
 		store:  s,
@@ -26,6 +30,20 @@ func New(s *store.Store, secret []byte) *Router {
 		audit:  audit.New(s),
 	}
 }
+
+// SendToPhysicians broadcasts event to all physicians connected via WebSocket
+// in the given tenant. It implements agent.PhysicianNotifier so the Router can
+// be passed directly to agent.NewDrafter in cmd/server.
+func (rt *Router) SendToPhysicians(tenantID string, event []byte) {
+	rt.hub.SendToPhysicians(tenantID, event)
+}
+
+// SetDrafter wires the AI Agent Runtime drafter after construction. This
+// breaks the circular dependency between Router (which needs the Drafter) and
+// the Drafter (which needs the Router as a PhysicianNotifier): construct the
+// Router first — with a nil drafter — then construct the Drafter pointing at
+// the Router, then call SetDrafter.
+func (rt *Router) SetDrafter(d *agent.Drafter) { rt.drafter = d }
 
 // Mount registers all API and WebSocket routes on r.
 func (rt *Router) Mount(r chi.Router) {

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -393,6 +393,22 @@ func (s *Store) Txn(ctx context.Context, fn func(*TxStore) error) error {
 	return tx.Commit(ctx)
 }
 
+// CreateRecommendation inserts a new recommendation within tx.
+// Use this when the create must be atomic with a subsequent state update
+// and audit event (e.g. the agent drafting flow: DRAFT → PENDING_REVIEW + audit).
+func (ts *TxStore) CreateRecommendation(ctx context.Context, tenant TenantID, r Recommendation) (Recommendation, error) {
+	err := ts.tx.QueryRow(ctx,
+		`INSERT INTO recommendations
+		   (tenant_id, conversation_id, patient_id, state, payload_type, payload, draft_content)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
+		 RETURNING id, tenant_id, conversation_id, patient_id, state, payload_type, payload,
+		           draft_content, final_content, reviewed_by, reviewed_at, created_at`,
+		tenant.UUID(), r.ConversationID, r.PatientID, r.State, r.PayloadType, r.Payload, r.DraftContent,
+	).Scan(&r.ID, &r.TenantID, &r.ConversationID, &r.PatientID, &r.State, &r.PayloadType, &r.Payload,
+		&r.DraftContent, &r.FinalContent, &r.ReviewedBy, &r.ReviewedAt, &r.CreatedAt)
+	return r, err
+}
+
 // UpdateRecommendationState sets the state (and optionally reviewed_by,
 // reviewed_at, final_content) for a recommendation within tx.
 func (ts *TxStore) UpdateRecommendationState(ctx context.Context, tenant TenantID, id uuid.UUID, state string, reviewedBy *uuid.UUID, finalContent *string) error {

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -411,10 +411,19 @@ func (ts *TxStore) CreateRecommendation(ctx context.Context, tenant TenantID, r 
 
 // UpdateRecommendationState sets the state (and optionally reviewed_by,
 // reviewed_at, final_content) for a recommendation within tx.
+//
+// reviewed_at is only stamped when reviewedBy is non-nil — i.e. when a human
+// physician performs the review. Agent-driven transitions (reviewedBy == nil,
+// e.g. DRAFT→PENDING_REVIEW) must leave reviewed_at NULL so the Phase 5
+// physician queue can use "reviewed_at IS NOT NULL" as a reliable human-review
+// proxy.
 func (ts *TxStore) UpdateRecommendationState(ctx context.Context, tenant TenantID, id uuid.UUID, state string, reviewedBy *uuid.UUID, finalContent *string) error {
 	_, err := ts.tx.Exec(ctx,
 		`UPDATE recommendations
-		    SET state = $3, reviewed_by = $4, reviewed_at = NOW(), final_content = $5
+		    SET state         = $3,
+		        reviewed_by   = $4,
+		        reviewed_at   = CASE WHEN $4::uuid IS NOT NULL THEN NOW() ELSE reviewed_at END,
+		        final_content = $5
 		  WHERE tenant_id = $1 AND id = $2`,
 		tenant.UUID(), id, state, reviewedBy, finalContent,
 	)

--- a/backend/internal/store/store_test.go
+++ b/backend/internal/store/store_test.go
@@ -308,6 +308,73 @@ func TestTenantIsolation_AuditEvents(t *testing.T) {
 	}
 }
 
+// TestUpdateRecommendationState_ReviewedAt verifies the reviewed_at stamping
+// contract that Phase 5's physician queue depends on:
+//
+//   - Agent DRAFT→PENDING_REVIEW (reviewedBy == nil): reviewed_at stays NULL.
+//   - Physician review (reviewedBy != nil):          reviewed_at is set.
+func TestUpdateRecommendationState_ReviewedAt(t *testing.T) {
+	pool := testPool(t)
+	s := New(pool)
+	f := setupFixture(t, s)
+	ctx := context.Background()
+
+	tid := TenantID(f.A.Tenant.ID)
+
+	// --- Step 1: agent transition (nil reviewedBy) ---
+	// Create a fresh DRAFT recommendation, then transition to PENDING_REVIEW
+	// with a nil reviewedBy (simulating the agent path in drafter.go).
+	rec, err := s.CreateRecommendation(ctx, tid, Recommendation{
+		ConversationID: f.A.Conversation.ID,
+		PatientID:      f.A.Patient.ID,
+		State:          "DRAFT",
+		PayloadType:    "guidance",
+		Payload:        []byte(`{"text":"agent draft"}`),
+		DraftContent:   "agent draft",
+	})
+	if err != nil {
+		t.Fatalf("create recommendation: %v", err)
+	}
+
+	if err := s.Txn(ctx, func(tx *TxStore) error {
+		return tx.UpdateRecommendationState(ctx, tid, rec.ID, "PENDING_REVIEW", nil, nil)
+	}); err != nil {
+		t.Fatalf("agent transition: %v", err)
+	}
+
+	after, err := s.GetRecommendation(ctx, tid, rec.ID)
+	if err != nil {
+		t.Fatalf("get after agent transition: %v", err)
+	}
+	if after.ReviewedAt != nil {
+		t.Errorf("agent DRAFT→PENDING_REVIEW: reviewed_at = %v, want nil", after.ReviewedAt)
+	}
+	if after.ReviewedBy != nil {
+		t.Errorf("agent DRAFT→PENDING_REVIEW: reviewed_by = %v, want nil", after.ReviewedBy)
+	}
+
+	// --- Step 2: physician review (non-nil reviewedBy) ---
+	// Simulate a physician approving — reviewed_at must now be stamped.
+	physicianID := f.A.Physician.ID
+	finalText := "Approved."
+	if err := s.Txn(ctx, func(tx *TxStore) error {
+		return tx.UpdateRecommendationState(ctx, tid, rec.ID, "APPROVED", &physicianID, &finalText)
+	}); err != nil {
+		t.Fatalf("physician review transition: %v", err)
+	}
+
+	reviewed, err := s.GetRecommendation(ctx, tid, rec.ID)
+	if err != nil {
+		t.Fatalf("get after physician review: %v", err)
+	}
+	if reviewed.ReviewedAt == nil {
+		t.Errorf("physician APPROVED: reviewed_at is nil, want non-nil timestamp")
+	}
+	if reviewed.ReviewedBy == nil || *reviewed.ReviewedBy != physicianID {
+		t.Errorf("physician APPROVED: reviewed_by = %v, want %v", reviewed.ReviewedBy, physicianID)
+	}
+}
+
 func TestSchemaRejectsCrossTenantParent(t *testing.T) {
 	// The composite (tenant_id, parent_id) FKs added in 0001_init mean a
 	// conversation cannot be written under tenant A pointing at a patient

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -113,10 +113,10 @@ state-licensing tests pass.
 - [x] Timeout + error handling; failures do not surface as clinical content
 
 ### Task 4.2: Reactive drafting
-- [ ] On a persisted patient message: assemble tenant-scoped conversation
+- [x] On a persisted patient message: assemble tenant-scoped conversation
       context, call the model, create a `recommendation` in `DRAFT` with
       `payload_type = 'guidance'` and `payload = {"text": <model output>}`
-- [ ] Immediately transition `DRAFT` → `PENDING_REVIEW`, write the audit event,
+- [x] Immediately transition `DRAFT` → `PENDING_REVIEW`, write the audit event,
       emit `queue.updated`
 
 ### Task 4.3: Failure path

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -108,9 +108,9 @@ state-licensing tests pass.
 ## Phase 4: AI Agent Runtime
 
 ### Task 4.1: Model client
-- [ ] `internal/agent` — OpenAI-compatible HTTP client, configurable via
+- [x] `internal/agent` — OpenAI-compatible HTTP client, configurable via
       `AGENT_MODEL_BASE_URL`
-- [ ] Timeout + error handling; failures do not surface as clinical content
+- [x] Timeout + error handling; failures do not surface as clinical content
 
 ### Task 4.2: Reactive drafting
 - [ ] On a persisted patient message: assemble tenant-scoped conversation

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -120,7 +120,7 @@ state-licensing tests pass.
       emit `queue.updated`
 
 ### Task 4.3: Failure path
-- [ ] Model endpoint unavailable → no recommendation created,
+- [x] Model endpoint unavailable → no recommendation created,
       `ai_interaction_failed` audit event written
 
 **Validation**: a patient message produces a `PENDING_REVIEW` recommendation;


### PR DESCRIPTION
## Phase 4 — AI Agent Runtime

Adds the reactive AI drafting loop on top of the Phase 1–3 backend: a patient message triggers a model-drafted recommendation that lands in the physician review queue.

### Tasks
- [x] **4.1 Model client** — `internal/agent` OpenAI-compatible chat-completions client; base URL via `AGENT_MODEL_BASE_URL` (+ `AGENT_MODEL_NAME`/`AGENT_MODEL_API_KEY`); context+timeout; typed `*ModelError`/`*ParseError`; failures never returned as content; API key redacted in logs
- [x] **4.2 Reactive drafting** — on a persisted patient message, assemble tenant-scoped conversation context, call the model, create a `recommendation` (`payload_type='guidance'`, `payload={"text":…}`) and transition `DRAFT → PENDING_REVIEW` + audit atomically in one `store.Txn`, then emit `queue.updated` after commit. Drafting runs in a panic-safe background goroutine; agent is hard-capped at `DRAFT → PENDING_REVIEW`; `reviewed_at` is left NULL for agent transitions (only physician review stamps it)
- [x] **4.3 Failure path** — model failure (non-2xx / parse / timeout / transport / empty) creates NO recommendation and writes an `ai_interaction_failed` audit event with a coarse, type-derived reason; never logs/audits PHI or the raw model body; no `queue.updated` on failure

### Validation
- `go build ./...`, `go vet ./...` clean
- **189 tests pass**; `go test -race -count=3 ./internal/agent/...` clean (no data races in the drafting goroutines)
- Model client tested with stubbed transport; drafting/failure tested with DB + stubbed model client (no real model required)
- HIPAA review: tenant scoping on every drafting read/write, atomic state+audit, agent boundary enforced, no PHI/model-body in audit or logs

### Beads closed
- `HouseCall-akn` (#32) — 4.1
- `HouseCall-9ds` (#31) — 4.2
- `HouseCall-14s` (#30) — 4.3

### Deferred (non-blocking reviewer notes)
- `agent.ModelError.Body` holds up to 256B of the endpoint response (could echo request content); not currently logged/exposed — consider replacing with a fixed sentinel for future-caller safety.
- `draftFailureReason` has no distinct `context.Canceled` arm (unreachable today — drafting uses `context.Background()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)