### PR TITLE
add-cloud-platform-mvp: Phase 5 — Physician Web App

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -19,8 +19,10 @@ import (
 
 	"github.com/markolonius/housecall/backend/internal/agent"
 	"github.com/markolonius/housecall/backend/internal/api"
+	"github.com/markolonius/housecall/backend/internal/audit"
 	"github.com/markolonius/housecall/backend/internal/migrate"
 	"github.com/markolonius/housecall/backend/internal/store"
+	"github.com/markolonius/housecall/backend/internal/web"
 )
 
 func main() {
@@ -122,6 +124,13 @@ func runServe(dsn, addr string) error {
 	})
 
 	rt.Mount(r)
+
+	// Physician web app — server-rendered, mounted under /web.
+	webHandler, err := web.New(s, secret, audit.New(s))
+	if err != nil {
+		return fmt.Errorf("web handler: %w", err)
+	}
+	webHandler.Mount(r)
 
 	srv := &http.Server{
 		Addr:              addr,

--- a/backend/internal/api/recommendations.go
+++ b/backend/internal/api/recommendations.go
@@ -91,6 +91,13 @@ func (rt *Router) handleReviewRecommendation(w http.ResponseWriter, r *http.Requ
 	// Delegate to the shared, transport-agnostic review logic. This ensures the
 	// web app and the JSON API drive identical state-machine semantics.
 	result, err := review.Execute(ctx, rt.store, claims.TenantID, claims.ActorID, recID, req.Action, req.FinalContent)
+	if errors.Is(err, review.ErrActorNotFound) {
+		// Physician record not found for the session actor — treat as 403 (session
+		// anomaly) rather than leaking internal state, preserving the original
+		// pre-refactor contract.
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
 	if errors.Is(err, store.ErrNotFound) {
 		http.Error(w, "not found", http.StatusNotFound)
 		return

--- a/backend/internal/api/recommendations.go
+++ b/backend/internal/api/recommendations.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/markolonius/housecall/backend/internal/domain"
+	"github.com/markolonius/housecall/backend/internal/review"
 	"github.com/markolonius/housecall/backend/internal/store"
 )
 
@@ -86,143 +87,38 @@ func (rt *Router) handleReviewRecommendation(w http.ResponseWriter, r *http.Requ
 	}
 
 	ctx := r.Context()
-	// Use GetRecommendationForPhysician so the physician's care relationship
-	// with the patient is verified in the same query. A physician who is not in
-	// an active care relationship with the patient receives 404 — identical to
-	// the "does not exist" response — to avoid disclosing the recommendation's
-	// existence. Tenant scoping is enforced inside the method.
-	rec, err := rt.store.GetRecommendationForPhysician(ctx, claims.TenantID, claims.ActorID, recID)
+
+	// Delegate to the shared, transport-agnostic review logic. This ensures the
+	// web app and the JSON API drive identical state-machine semantics.
+	result, err := review.Execute(ctx, rt.store, claims.TenantID, claims.ActorID, recID, req.Action, req.FinalContent)
 	if errors.Is(err, store.ErrNotFound) {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
-	} else if err != nil {
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
 	}
-
-	// Load the physician's licence list and the patient's state so the pure
-	// domain function can enforce the state-licensing invariant. Both queries
-	// are tenant-scoped; neither result is logged (no PHI in audit metadata).
-	phys, err := rt.store.GetPhysician(ctx, claims.TenantID, claims.ActorID)
-	if errors.Is(err, store.ErrNotFound) {
-		// Should never happen because requireAuth validates the JWT actor, but
-		// treat it as a 403 rather than leaking internal state.
-		http.Error(w, "forbidden", http.StatusForbidden)
-		return
-	} else if err != nil {
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
-	}
-
-	patient, err := rt.store.GetPatient(ctx, claims.TenantID, rec.PatientID)
-	if errors.Is(err, store.ErrNotFound) {
-		http.Error(w, "not found", http.StatusNotFound)
-		return
-	} else if err != nil {
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
-	}
-
-	actor := domain.Actor{
-		Type:           domain.ActorPhysician,
-		ID:             claims.ActorID,
-		StatesLicensed: phys.StatesLicensed,
-	}
-
-	// Step 1: validate the physician's action using the canonical pure state
-	// machine — this moves PENDING_REVIEW → APPROVED / MODIFIED / REJECTED.
-	// Transition also enforces the state-licensing invariant here.
-	midState, err := domain.Transition(rec.State, req.Action, actor, patient.State)
 	if errors.Is(err, domain.ErrUnlicensedState) {
-		// Write a rejection audit event without touching the recommendation
-		// state. This is a standalone (non-Txn) audit write: there is no state
-		// mutation to pair it with, so it does not need to be atomic with a
-		// state update. Errors from the audit write are intentionally not
-		// propagated so the HTTP response is always returned to the caller.
-		reviewedBy := claims.ActorID
-		_, _ = rt.store.CreateAuditEvent(ctx, claims.TenantID, store.AuditEvent{
-			ActorType: "physician",
-			ActorID:   &reviewedBy,
-			EventType: "recommendation.review_rejected",
-			Metadata: marshalJSON(map[string]any{
-				"recommendation_id": recID.String(),
-				"action":            req.Action,
-				"reason":            "unlicensed_state",
-			}),
-		})
 		http.Error(w, "forbidden: physician not licensed in patient's state", http.StatusForbidden)
 		return
 	}
 	if errors.Is(err, domain.ErrInvalidTransition) {
 		http.Error(w, "invalid transition", http.StatusUnprocessableEntity)
 		return
-	} else if err != nil {
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
 	}
-
-	// Step 2: for approve/modify the workflow continues to DELIVERED in the
-	// same atomic commit.  Determine final_content here — it is set ONLY on
-	// the DELIVERED write, never on intermediate states.
-	finalState := midState
-	var finalContent *string
-	if midState == domain.StateApproved || midState == domain.StateModified {
-		// Transition APPROVED/MODIFIED → DELIVERED (cannot fail: both are
-		// valid source states in the pure machine; licensing is not re-checked
-		// for ActionDeliver as it was already verified in Step 1).
-		delivered, err := domain.Transition(midState, domain.ActionDeliver, actor, patient.State)
-		if err != nil {
-			// Should never happen given valid midState values above.
-			http.Error(w, "internal server error", http.StatusInternalServerError)
-			return
-		}
-		finalState = delivered
-
-		// Compute the patient-visible content only for the DELIVERED write.
-		content := rec.DraftContent
-		if req.FinalContent != "" {
-			content = req.FinalContent
-		}
-		finalContent = &content
-	}
-	// For REJECTED: finalContent remains nil — patients never see it.
-
-	// State change AND audit_event are written in a single DB transaction so
-	// they either both commit or both roll back.
-	reviewedBy := claims.ActorID
-	if err := rt.store.Txn(ctx, func(tx *store.TxStore) error {
-		// Write the final state. final_content is only non-nil when
-		// finalState == DELIVERED, enforcing the content-visibility gate.
-		if err := tx.UpdateRecommendationState(ctx, claims.TenantID, recID,
-			finalState, &reviewedBy, finalContent); err != nil {
-			return err
-		}
-		return tx.CreateAuditEvent(ctx, claims.TenantID, store.AuditEvent{
-			ActorType: "physician",
-			ActorID:   &reviewedBy,
-			EventType: "recommendation.reviewed",
-			Metadata: marshalJSON(map[string]any{
-				"recommendation_id": recID.String(),
-				"action":            req.Action,
-				"new_state":         finalState,
-			}),
-		})
-	}); err != nil {
+	if err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	// Push a WebSocket event to the patient only once DELIVERED.
-	if finalState == domain.StateDelivered {
-		rt.hub.SendToPatient(claims.TenantID.String(), rec.PatientID.String(),
+	if result.FinalState == domain.StateDelivered {
+		rt.hub.SendToPatient(claims.TenantID.String(), result.PatientID.String(),
 			marshalJSON(map[string]any{
 				"type": "recommendation.delivered",
 				"data": map[string]any{
-					"recommendation_id": recID.String(),
-					"conversation_id":   rec.ConversationID.String(),
+					"recommendation_id": result.RecommendationID.String(),
+					"conversation_id":   result.ConversationID.String(),
 				},
 			}))
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"state": finalState})
+	writeJSON(w, http.StatusOK, map[string]string{"state": result.FinalState})
 }

--- a/backend/internal/api/recommendations_test.go
+++ b/backend/internal/api/recommendations_test.go
@@ -317,10 +317,32 @@ func TestHandler_PhysicianNotFound_Returns403(t *testing.T) {
 	}
 
 	// Delete the physician so GetPhysician returns ErrNotFound during the request.
-	if _, err := pool.Exec(ctx,
-		`DELETE FROM physicians WHERE id = $1 AND tenant_id = $2`,
-		physician.ID, tid.UUID()); err != nil {
-		t.Fatalf("delete physician: %v", err)
+	//
+	// The care_relationships FK (ON DELETE RESTRICT) prevents a plain DELETE on
+	// physicians while care_relationships still references the physician — but we
+	// need the care_relationships row to survive so that GetRecommendationForPhysician
+	// can find the recommendation at request time (it JOINs on care_relationships).
+	// We use a dedicated connection with session_replication_role = replica to
+	// bypass FK enforcement for just this one DELETE, then restore the default.
+	// This is test-only infrastructure: the FK continues to protect production
+	// writes via every other connection.
+	{
+		conn, err := pool.Acquire(ctx)
+		if err != nil {
+			t.Fatalf("acquire conn for physician delete: %v", err)
+		}
+		defer conn.Release()
+		if _, err := conn.Exec(ctx, `SET session_replication_role = replica`); err != nil {
+			t.Fatalf("set session_replication_role: %v", err)
+		}
+		if _, err := conn.Exec(ctx,
+			`DELETE FROM physicians WHERE id = $1 AND tenant_id = $2`,
+			physician.ID, tid.UUID()); err != nil {
+			t.Fatalf("delete physician: %v", err)
+		}
+		if _, err := conn.Exec(ctx, `SET session_replication_role = DEFAULT`); err != nil {
+			t.Fatalf("reset session_replication_role: %v", err)
+		}
 	}
 
 	// --- build the real router ---

--- a/backend/internal/api/recommendations_test.go
+++ b/backend/internal/api/recommendations_test.go
@@ -250,3 +250,100 @@ func TestHandler_UnlicensedPhysicianReview_IsAudited(t *testing.T) {
 		}
 	}
 }
+
+// TestHandler_PhysicianNotFound_Returns403 verifies that when the JWT names a
+// physician that no longer exists in the DB (an auth anomaly), the
+// handleReviewRecommendation endpoint returns HTTP 403 — not 404.
+//
+// Before the review.Execute refactor the handler called rt.store.GetPhysician
+// directly and mapped its ErrNotFound to 403 with an explicit comment
+// ("treat it as a 403 rather than leaking internal state"). After refactoring
+// to shared review.Execute, the sentinel review.ErrActorNotFound must be
+// propagated and mapped identically. This test guards that regression.
+func TestHandler_PhysicianNotFound_Returns403(t *testing.T) {
+	pool := apiTestPool(t)
+	s := store.New(pool)
+	ctx := context.Background()
+
+	// --- fixture ---
+
+	tenant, err := s.CreateTenant(ctx, "dtc", "api-handler-phys-notfound-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	tid := store.TenantID(tenant.ID)
+
+	patient, err := s.CreatePatient(ctx, tid, store.Patient{
+		Email:        "patient@physnotfound.test",
+		FullName:     "Pat",
+		State:        "CA",
+		PasswordHash: "hash",
+	})
+	if err != nil {
+		t.Fatalf("create patient: %v", err)
+	}
+
+	// Create a physician only to get a valid UUID for the JWT; then delete it
+	// so GetPhysician returns ErrNotFound when the handler runs.
+	physician, err := s.CreatePhysician(ctx, tid, store.Physician{
+		Email:          "ghost@physnotfound.test",
+		FullName:       "Ghost Doc",
+		StatesLicensed: []string{"CA"},
+		PasswordHash:   "hash",
+	})
+	if err != nil {
+		t.Fatalf("create physician: %v", err)
+	}
+
+	if _, err := s.CreateCareRelationship(ctx, tid, patient.ID, physician.ID); err != nil {
+		t.Fatalf("care relationship: %v", err)
+	}
+
+	conv, err := s.CreateConversation(ctx, tid, patient.ID, "phys-notfound test conv")
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	rec, err := s.CreateRecommendation(ctx, tid, store.Recommendation{
+		ConversationID: conv.ID,
+		PatientID:      patient.ID,
+		State:          domain.StatePendingReview,
+		PayloadType:    "guidance",
+		Payload:        []byte(`{"text":"draft"}`),
+		DraftContent:   "draft content",
+	})
+	if err != nil {
+		t.Fatalf("create recommendation: %v", err)
+	}
+
+	// Delete the physician so GetPhysician returns ErrNotFound during the request.
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM physicians WHERE id = $1 AND tenant_id = $2`,
+		physician.ID, tid.UUID()); err != nil {
+		t.Fatalf("delete physician: %v", err)
+	}
+
+	// --- build the real router ---
+
+	router := api.New(s, apiTestSecret)
+	r := chi.NewRouter()
+	router.Mount(r)
+
+	// JWT references the now-deleted physician.
+	token := signedJWT(apiTestSecret, tid.String(), physician.ID.String(), "physician")
+
+	body, _ := json.Marshal(map[string]string{"action": domain.ActionApprove})
+	url := fmt.Sprintf("/api/recommendations/%s/review", rec.ID.String())
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rw := httptest.NewRecorder()
+	r.ServeHTTP(rw, req)
+
+	// Physician-not-found must be a 403 (session/auth anomaly), NOT 404.
+	if rw.Code != http.StatusForbidden {
+		t.Fatalf("expected HTTP 403 for deleted physician, got %d (body: %s)",
+			rw.Code, rw.Body.String())
+	}
+}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -1,0 +1,199 @@
+// Package review contains the transport-agnostic physician review flow.
+// It is shared by the JSON API (internal/api) and the server-rendered web app
+// (internal/web) so both surfaces drive the same domain.Transition + store.TxnW
+// path and cannot diverge in state-machine semantics.
+//
+// HIPAA notes:
+//   - final_content is PHI: it is accepted as a parameter but never logged or
+//     placed in audit metadata. It is only written to the DB as part of the
+//     atomic state+audit transaction.
+//   - Audit metadata carries only identifiers and action/state strings — no PHI.
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/markolonius/housecall/backend/internal/domain"
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// Store is the minimum set of store operations that Execute requires.
+// *store.Store satisfies this interface in production; test fakes supply their
+// own implementation so tests can run without a real database connection.
+type Store interface {
+	// GetRecommendationForPhysician returns the recommendation only when the
+	// physician has an active care relationship with the patient in the tenant,
+	// enforcing access isolation identical to the list path.
+	GetRecommendationForPhysician(ctx context.Context, tenant store.TenantID, physicianID, recID uuid.UUID) (store.Recommendation, error)
+
+	// GetPhysician returns the physician record (needed for StatesLicensed).
+	GetPhysician(ctx context.Context, tenant store.TenantID, id uuid.UUID) (store.Physician, error)
+
+	// GetPatient returns the patient record (needed for State).
+	GetPatient(ctx context.Context, tenant store.TenantID, id uuid.UUID) (store.Patient, error)
+
+	// CreateAuditEvent writes an audit event outside a transaction (used for
+	// the unlicensed-state rejection, which has no associated state mutation).
+	CreateAuditEvent(ctx context.Context, tenant store.TenantID, e store.AuditEvent) (store.AuditEvent, error)
+
+	// TxnW executes fn atomically inside a transaction. fn receives a
+	// store.TxWriter so that *store.TxStore (production) and test fakes can
+	// both satisfy the interface without a real database connection.
+	TxnW(ctx context.Context, fn func(store.TxWriter) error) error
+}
+
+// Result holds the outcome of a successful Execute call.
+type Result struct {
+	FinalState       string
+	PatientID        uuid.UUID
+	ConversationID   uuid.UUID
+	RecommendationID uuid.UUID
+}
+
+// Execute performs the physician review of a recommendation.
+//
+// Parameters:
+//   - tenant, physicianID: from the verified session — never from user input.
+//   - recID: the recommendation being reviewed (access-controlled by the store).
+//   - action: domain.ActionApprove | domain.ActionModify | domain.ActionReject.
+//   - finalContent: the physician's edited text; required for modify, used as
+//     override for approve; ignored for reject. PHI — never logged.
+//
+// Transitions mirror the Core API exactly:
+//   - approve:  PENDING_REVIEW → APPROVED → DELIVERED  (final_content set on DELIVERED)
+//   - modify:   PENDING_REVIEW → MODIFIED → DELIVERED  (final_content = finalContent, set on DELIVERED)
+//   - reject:   PENDING_REVIEW → REJECTED               (final_content stays nil)
+//
+// Invariants preserved:
+//   - DELIVERED is only reachable from APPROVED or MODIFIED.
+//   - final_content is set ONLY on the DELIVERED write, never on intermediate states.
+//   - State change + audit are written in one DB transaction (atomic).
+//   - An unlicensed-state rejection emits an audit event without mutating state;
+//     the caller receives domain.ErrUnlicensedState.
+//   - A non-care-relationship access returns store.ErrNotFound (no information disclosure).
+func Execute(
+	ctx context.Context,
+	s Store,
+	tenant store.TenantID,
+	physicianID uuid.UUID,
+	recID uuid.UUID,
+	action string,
+	finalContent string,
+) (Result, error) {
+	// Resolve the recommendation through the care-relationship-scoped query.
+	// A physician who is not in an active care relationship with the patient —
+	// or whose recommendation belongs to another tenant — receives ErrNotFound
+	// (same as "does not exist" to avoid information disclosure).
+	rec, err := s.GetRecommendationForPhysician(ctx, tenant, physicianID, recID)
+	if err != nil {
+		return Result{}, err // ErrNotFound or internal
+	}
+
+	// Load the physician's licence list.
+	phys, err := s.GetPhysician(ctx, tenant, physicianID)
+	if errors.Is(err, store.ErrNotFound) {
+		// Should never happen if the JWT actor was validated, but guard anyway.
+		return Result{}, store.ErrNotFound
+	} else if err != nil {
+		return Result{}, err
+	}
+
+	// Load the patient's state for the licensing check.
+	patient, err := s.GetPatient(ctx, tenant, rec.PatientID)
+	if errors.Is(err, store.ErrNotFound) {
+		return Result{}, store.ErrNotFound
+	} else if err != nil {
+		return Result{}, err
+	}
+
+	actor := domain.Actor{
+		Type:           domain.ActorPhysician,
+		ID:             physicianID,
+		StatesLicensed: phys.StatesLicensed,
+	}
+
+	// Step 1: validate the physician's action using the canonical pure state
+	// machine — moves PENDING_REVIEW → APPROVED / MODIFIED / REJECTED.
+	// Transition also enforces the state-licensing invariant.
+	midState, err := domain.Transition(rec.State, action, actor, patient.State)
+	if errors.Is(err, domain.ErrUnlicensedState) {
+		// Write the rejection audit event without touching recommendation state.
+		// This is intentionally a standalone (non-TxnW) audit write — there is no
+		// state mutation to pair it with, so it does not need to be atomic.
+		// Errors from the audit write are suppressed (audit must never block the
+		// clinical flow, even when the outcome is a rejection).
+		_, _ = s.CreateAuditEvent(ctx, tenant, store.AuditEvent{
+			ActorType: "physician",
+			ActorID:   &physicianID,
+			EventType: "recommendation.review_rejected",
+			Metadata: marshalJSON(map[string]any{
+				"recommendation_id": recID.String(),
+				"action":            action,
+				"reason":            "unlicensed_state",
+			}),
+		})
+		return Result{}, domain.ErrUnlicensedState
+	}
+	if err != nil {
+		// ErrInvalidTransition or unexpected error.
+		return Result{}, err
+	}
+
+	// Step 2: for approve/modify, continue to DELIVERED in the same atomic commit.
+	// final_content is set ONLY on the DELIVERED write.
+	finalState := midState
+	var storedContent *string
+	if midState == domain.StateApproved || midState == domain.StateModified {
+		delivered, err := domain.Transition(midState, domain.ActionDeliver, actor, patient.State)
+		if err != nil {
+			// Cannot happen given valid midState values above.
+			return Result{}, err
+		}
+		finalState = delivered
+
+		// Determine the patient-visible content: physician override takes
+		// precedence over the agent's draft. PHI — not logged.
+		content := rec.DraftContent
+		if finalContent != "" {
+			content = finalContent
+		}
+		storedContent = &content
+	}
+	// For REJECTED: storedContent remains nil — patients never see it.
+
+	// State change AND audit_event written in a single DB transaction so they
+	// either both commit or both roll back.
+	if err := s.TxnW(ctx, func(tx store.TxWriter) error {
+		if err := tx.UpdateRecommendationState(ctx, tenant, recID,
+			finalState, &physicianID, storedContent); err != nil {
+			return err
+		}
+		return tx.CreateAuditEvent(ctx, tenant, store.AuditEvent{
+			ActorType: "physician",
+			ActorID:   &physicianID,
+			EventType: "recommendation.reviewed",
+			Metadata: marshalJSON(map[string]any{
+				"recommendation_id": recID.String(),
+				"action":            action,
+				"new_state":         finalState,
+			}),
+		})
+	}); err != nil {
+		return Result{}, err
+	}
+
+	return Result{
+		FinalState:       finalState,
+		PatientID:        rec.PatientID,
+		ConversationID:   rec.ConversationID,
+		RecommendationID: recID,
+	}, nil
+}
+
+func marshalJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -20,6 +20,13 @@ import (
 	"github.com/markolonius/housecall/backend/internal/store"
 )
 
+// ErrActorNotFound is returned by Execute when the physician record cannot be
+// resolved for the session actor. This is distinct from store.ErrNotFound
+// (recommendation not found / no care relationship) so transports can map each
+// case to the correct HTTP status: recommendation-not-found → 404,
+// physician-not-found → 403 (session/auth anomaly, not a lookup miss).
+var ErrActorNotFound = errors.New("review: actor (physician) not found")
+
 // Store is the minimum set of store operations that Execute requires.
 // *store.Store satisfies this interface in production; test fakes supply their
 // own implementation so tests can run without a real database connection.
@@ -96,7 +103,10 @@ func Execute(
 	phys, err := s.GetPhysician(ctx, tenant, physicianID)
 	if errors.Is(err, store.ErrNotFound) {
 		// Should never happen if the JWT actor was validated, but guard anyway.
-		return Result{}, store.ErrNotFound
+		// Return ErrActorNotFound (distinct from store.ErrNotFound) so transports
+		// can map physician-not-found to 403 rather than 404 — a missing actor
+		// is a session/auth anomaly, not a normal lookup miss.
+		return Result{}, ErrActorNotFound
 	} else if err != nil {
 		return Result{}, err
 	}

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -1,0 +1,153 @@
+package review_test
+
+// review_test.go — unit tests for Execute using a fake store (no DB required).
+//
+// Covered:
+//   - TestExecute_PhysicianNotFound: Execute returns ErrActorNotFound (not
+//     store.ErrNotFound) when GetPhysician returns ErrNotFound, so API and web
+//     transports can map it to 403 rather than 404.
+//   - TestExecute_RecommendationNotFound: Execute returns store.ErrNotFound
+//     when GetRecommendationForPhysician returns ErrNotFound (→ 404).
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/markolonius/housecall/backend/internal/domain"
+	"github.com/markolonius/housecall/backend/internal/review"
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// ---- fake store ----------------------------------------------------------------
+
+// reviewFakeStore is a minimal fake that satisfies review.Store.
+type reviewFakeStore struct {
+	rec     *store.Recommendation // nil → GetRecommendationForPhysician returns ErrNotFound
+	phys    *store.Physician      // nil → GetPhysician returns ErrNotFound
+	patient *store.Patient        // nil → GetPatient returns ErrNotFound
+}
+
+func (f *reviewFakeStore) GetRecommendationForPhysician(_ context.Context, _ store.TenantID, _, _ uuid.UUID) (store.Recommendation, error) {
+	if f.rec == nil {
+		return store.Recommendation{}, store.ErrNotFound
+	}
+	return *f.rec, nil
+}
+
+func (f *reviewFakeStore) GetPhysician(_ context.Context, _ store.TenantID, _ uuid.UUID) (store.Physician, error) {
+	if f.phys == nil {
+		return store.Physician{}, store.ErrNotFound
+	}
+	return *f.phys, nil
+}
+
+func (f *reviewFakeStore) GetPatient(_ context.Context, _ store.TenantID, _ uuid.UUID) (store.Patient, error) {
+	if f.patient == nil {
+		return store.Patient{}, store.ErrNotFound
+	}
+	return *f.patient, nil
+}
+
+func (f *reviewFakeStore) CreateAuditEvent(_ context.Context, _ store.TenantID, e store.AuditEvent) (store.AuditEvent, error) {
+	return e, nil
+}
+
+func (f *reviewFakeStore) TxnW(_ context.Context, fn func(store.TxWriter) error) error {
+	return fn(&noopTxWriter{})
+}
+
+// noopTxWriter satisfies store.TxWriter for tests that only need TxnW to succeed.
+type noopTxWriter struct{}
+
+func (n *noopTxWriter) UpdateRecommendationState(_ context.Context, _ store.TenantID, _ uuid.UUID, _ string, _ *uuid.UUID, _ *string) error {
+	return nil
+}
+func (n *noopTxWriter) CreateAuditEvent(_ context.Context, _ store.TenantID, _ store.AuditEvent) error {
+	return nil
+}
+
+// ---- tests ---------------------------------------------------------------------
+
+var (
+	testTenant    = store.TenantID(uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001"))
+	testPhysicianID = uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000002")
+	testPatientID   = uuid.MustParse("cccccccc-0000-0000-0000-000000000003")
+	testRecID       = uuid.MustParse("dddddddd-0000-0000-0000-000000000004")
+)
+
+// TestExecute_RecommendationNotFound verifies that when the care-relationship
+// scoped query returns ErrNotFound, Execute propagates store.ErrNotFound — the
+// transport should map this to 404.
+func TestExecute_RecommendationNotFound(t *testing.T) {
+	s := &reviewFakeStore{rec: nil} // rec not found
+
+	_, err := review.Execute(context.Background(), s, testTenant,
+		testPhysicianID, testRecID, domain.ActionApprove, "")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want store.ErrNotFound, got %v", err)
+	}
+	// Must NOT be ErrActorNotFound — that's reserved for physician-not-found.
+	if errors.Is(err, review.ErrActorNotFound) {
+		t.Fatal("rec-not-found must not return ErrActorNotFound")
+	}
+}
+
+// TestExecute_PhysicianNotFound verifies that when GetPhysician returns
+// ErrNotFound (session actor no longer in DB), Execute returns
+// review.ErrActorNotFound — NOT store.ErrNotFound — so transports can
+// distinguish the two cases and map physician-not-found to 403 (not 404).
+func TestExecute_PhysicianNotFound(t *testing.T) {
+	rec := &store.Recommendation{
+		ID:           testRecID,
+		TenantID:     testTenant,
+		PatientID:    testPatientID,
+		State:        domain.StatePendingReview,
+		DraftContent: "some draft",
+	}
+	// Physician is nil → GetPhysician returns ErrNotFound.
+	s := &reviewFakeStore{rec: rec, phys: nil}
+
+	_, err := review.Execute(context.Background(), s, testTenant,
+		testPhysicianID, testRecID, domain.ActionApprove, "")
+	if !errors.Is(err, review.ErrActorNotFound) {
+		t.Fatalf("want review.ErrActorNotFound, got %v", err)
+	}
+	// Must NOT be plain store.ErrNotFound — that would cause 404 mapping.
+	if errors.Is(err, store.ErrNotFound) {
+		t.Fatal("physician-not-found must not return bare store.ErrNotFound (would map to 404)")
+	}
+}
+
+// TestExecute_ApproveDelivers verifies the happy-path: approve transitions
+// PENDING_REVIEW → DELIVERED when the physician is licensed in the patient's state.
+func TestExecute_ApproveDelivers(t *testing.T) {
+	rec := &store.Recommendation{
+		ID:           testRecID,
+		TenantID:     testTenant,
+		PatientID:    testPatientID,
+		State:        domain.StatePendingReview,
+		DraftContent: "drink water",
+	}
+	phys := &store.Physician{
+		ID:             testPhysicianID,
+		TenantID:       testTenant,
+		StatesLicensed: []string{"CA"},
+	}
+	patient := &store.Patient{
+		ID:       testPatientID,
+		TenantID: testTenant,
+		State:    "CA",
+	}
+	s := &reviewFakeStore{rec: rec, phys: phys, patient: patient}
+
+	result, err := review.Execute(context.Background(), s, testTenant,
+		testPhysicianID, testRecID, domain.ActionApprove, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.FinalState != domain.StateDelivered {
+		t.Fatalf("want DELIVERED, got %q", result.FinalState)
+	}
+}

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -371,6 +371,14 @@ func (s *Store) GetRecommendationForPhysician(ctx context.Context, tenant Tenant
 	return r, err
 }
 
+// TxWriter is the minimum write interface needed inside a transaction. It is
+// satisfied by *TxStore in production and by test fakes that do not require a
+// real database connection.
+type TxWriter interface {
+	UpdateRecommendationState(ctx context.Context, tenant TenantID, id uuid.UUID, state string, reviewedBy *uuid.UUID, finalContent *string) error
+	CreateAuditEvent(ctx context.Context, tenant TenantID, e AuditEvent) error
+}
+
 // TxStore wraps a pgx.Tx and exposes the write methods needed for atomic
 // multi-operation sequences (e.g. state transition + audit event). Obtain
 // one via Store.Txn.
@@ -391,6 +399,17 @@ func (s *Store) Txn(ctx context.Context, fn func(*TxStore) error) error {
 		return err
 	}
 	return tx.Commit(ctx)
+}
+
+// TxnW executes fn inside a transaction, passing a TxWriter interface value
+// rather than the concrete *TxStore. This allows callers that accept a
+// store.TxWriter (e.g. internal/review) to share the same transaction without
+// an import cycle. The transaction is committed if fn returns nil; rolled back
+// otherwise.
+func (s *Store) TxnW(ctx context.Context, fn func(TxWriter) error) error {
+	return s.Txn(ctx, func(tx *TxStore) error {
+		return fn(tx)
+	})
 }
 
 // CreateRecommendation inserts a new recommendation within tx.

--- a/backend/internal/web/export_test.go
+++ b/backend/internal/web/export_test.go
@@ -21,6 +21,13 @@ type StoreQuerier interface {
 	GetPhysicianByEmail(ctx context.Context, tenant store.TenantID, email string) (store.Physician, error)
 	ListPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.Patient, error)
 	ListRecommendationsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID, state string) ([]store.Recommendation, error)
+
+	// Review action methods (task 5.3).
+	GetRecommendationForPhysician(ctx context.Context, tenant store.TenantID, physicianID, recID uuid.UUID) (store.Recommendation, error)
+	GetPhysician(ctx context.Context, tenant store.TenantID, id uuid.UUID) (store.Physician, error)
+	GetPatient(ctx context.Context, tenant store.TenantID, id uuid.UUID) (store.Patient, error)
+	CreateAuditEvent(ctx context.Context, tenant store.TenantID, e store.AuditEvent) (store.AuditEvent, error)
+	TxnW(ctx context.Context, fn func(store.TxWriter) error) error
 }
 
 // AuditQuerier is the audit-write interface used by the Handler.

--- a/backend/internal/web/export_test.go
+++ b/backend/internal/web/export_test.go
@@ -19,6 +19,8 @@ type WebClaims = webClaims
 // Exposed so web_test can supply a fake without importing store.Store.
 type StoreQuerier interface {
 	GetPhysicianByEmail(ctx context.Context, tenant store.TenantID, email string) (store.Physician, error)
+	ListPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.Patient, error)
+	ListRecommendationsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID, state string) ([]store.Recommendation, error)
 }
 
 // AuditQuerier is the audit-write interface used by the Handler.

--- a/backend/internal/web/export_test.go
+++ b/backend/internal/web/export_test.go
@@ -1,0 +1,76 @@
+// export_test.go exposes internal symbols needed by web_test (package web_test).
+// This file is only compiled during `go test`.
+package web
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// WebClaims is an exported alias so web_test can inspect context values
+// returned by WebClaimsFromCtx.
+type WebClaims = webClaims
+
+// StoreQuerier is the minimum store interface the Handler needs.
+// Exposed so web_test can supply a fake without importing store.Store.
+type StoreQuerier interface {
+	GetPhysicianByEmail(ctx context.Context, tenant store.TenantID, email string) (store.Physician, error)
+}
+
+// AuditQuerier is the audit-write interface used by the Handler.
+// Exposed so web_test can supply a no-op implementation.
+type AuditQuerier interface {
+	Write(ctx context.Context, tenant store.TenantID, actorType string, actorID *uuid.UUID, eventType string, metadata map[string]any)
+}
+
+// NewWithQuerier constructs a Handler for tests, accepting interface values
+// in place of the concrete *store.Store and *audit.Writer.
+func NewWithQuerier(sq StoreQuerier, secret []byte, aq AuditQuerier) (*Handler, error) {
+	tmpl, err := parseTemplates()
+	if err != nil {
+		return nil, err
+	}
+	return &Handler{
+		store:     nil,
+		secret:    secret,
+		audit:     nil,
+		templates: tmpl,
+		storeQ:    sq,
+		auditQ:    aq,
+	}, nil
+}
+
+// IssueTestToken issues a signed web token with the default TTL. Used by
+// web_test to construct session cookies for middleware tests.
+func IssueTestToken(secret []byte, tenantID store.TenantID, actorID uuid.UUID, actorType string) (string, error) {
+	return issueWebToken(secret, webClaims{
+		TenantID:  tenantID,
+		ActorID:   actorID,
+		ActorType: actorType,
+	})
+}
+
+// IssueTestTokenWithTTL issues a signed web token with a custom TTL offset.
+// Pass a negative duration to produce an already-expired token.
+func IssueTestTokenWithTTL(secret []byte, tenantID store.TenantID, actorID uuid.UUID, actorType string, ttl time.Duration) (string, error) {
+	return issueWebTokenWithTTL(secret, webClaims{
+		TenantID:  tenantID,
+		ActorID:   actorID,
+		ActorType: actorType,
+	}, ttl)
+}
+
+// ExportedRequireWebAuth returns the requireWebAuth middleware for use in
+// test routes that are registered outside Handler.Mount.
+func ExportedRequireWebAuth(h *Handler) func(http.Handler) http.Handler {
+	return h.requireWebAuth
+}
+
+// WebClaimsFromCtx re-exports the unexported helper for test assertions.
+func WebClaimsFromCtx(ctx context.Context) (webClaims, bool) {
+	return webClaimsFromCtx(ctx)
+}

--- a/backend/internal/web/templates/layout.html
+++ b/backend/internal/web/templates/layout.html
@@ -1,0 +1,32 @@
+{{define "layout"}}<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{block "title" .}}HouseCall{{end}}</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: system-ui, sans-serif; background: #f5f5f5; color: #1a1a1a; }
+  header { background: #1d3557; color: #fff; padding: 0.75rem 1.5rem; display: flex; align-items: center; gap: 1rem; }
+  header h1 { font-size: 1.1rem; font-weight: 600; letter-spacing: 0.02em; }
+  nav { display: flex; gap: 1rem; margin-left: auto; }
+  nav a { color: #a8dadc; text-decoration: none; font-size: 0.9rem; }
+  nav a:hover { color: #fff; }
+  main { max-width: 900px; margin: 2rem auto; padding: 0 1rem; }
+  .flash-error { background: #fde8e8; border: 1px solid #f5a0a0; color: #9b1c1c; padding: 0.75rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
+</style>
+{{block "head" .}}{{end}}
+</head>
+<body>
+<header>
+  <h1>HouseCall — Physician Portal</h1>
+  <nav>
+    {{block "nav" .}}{{end}}
+  </nav>
+</header>
+<main>
+  {{block "content" .}}{{end}}
+</main>
+</body>
+</html>
+{{end}}

--- a/backend/internal/web/templates/login.html
+++ b/backend/internal/web/templates/login.html
@@ -1,0 +1,36 @@
+{{template "layout" .}}
+
+{{define "title"}}Login — HouseCall{{end}}
+
+{{define "content"}}
+<div style="max-width:420px;margin:3rem auto;background:#fff;padding:2rem;border-radius:6px;box-shadow:0 1px 4px rgba(0,0,0,.12);">
+  <h2 style="margin-bottom:1.5rem;font-size:1.25rem;">Physician Sign In</h2>
+  {{if .Error}}
+  <div class="flash-error">{{.Error}}</div>
+  {{end}}
+  <form method="POST" action="/web/login" autocomplete="off">
+    <div style="margin-bottom:1rem;">
+      <label style="display:block;font-size:.875rem;margin-bottom:.25rem;">Tenant ID</label>
+      <input type="text" name="tenant_id" required
+             style="width:100%;padding:.5rem .75rem;border:1px solid #ccc;border-radius:4px;font-size:.95rem;"
+             placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx">
+    </div>
+    <div style="margin-bottom:1rem;">
+      <label style="display:block;font-size:.875rem;margin-bottom:.25rem;">Email</label>
+      <input type="email" name="email" required
+             style="width:100%;padding:.5rem .75rem;border:1px solid #ccc;border-radius:4px;font-size:.95rem;"
+             autocomplete="username">
+    </div>
+    <div style="margin-bottom:1.5rem;">
+      <label style="display:block;font-size:.875rem;margin-bottom:.25rem;">Password</label>
+      <input type="password" name="password" required
+             style="width:100%;padding:.5rem .75rem;border:1px solid #ccc;border-radius:4px;font-size:.95rem;"
+             autocomplete="current-password">
+    </div>
+    <button type="submit"
+            style="width:100%;padding:.6rem;background:#1d3557;color:#fff;border:none;border-radius:4px;font-size:1rem;cursor:pointer;">
+      Sign In
+    </button>
+  </form>
+</div>
+{{end}}

--- a/backend/internal/web/templates/panel.html
+++ b/backend/internal/web/templates/panel.html
@@ -1,0 +1,32 @@
+{{template "layout" .}}
+
+{{define "title"}}Patient Panel — HouseCall{{end}}
+
+{{define "nav"}}
+<a href="/web/panel">Panel</a>
+<a href="/web/queue">Queue</a>
+{{end}}
+
+{{define "content"}}
+<h2 style="margin-bottom:1.25rem;font-size:1.25rem;">Your Patient Panel</h2>
+{{if .Patients}}
+<table style="width:100%;border-collapse:collapse;background:#fff;border-radius:6px;box-shadow:0 1px 4px rgba(0,0,0,.08);">
+  <thead>
+    <tr style="background:#1d3557;color:#fff;text-align:left;">
+      <th style="padding:.65rem 1rem;">Name</th>
+      <th style="padding:.65rem 1rem;">State</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{range .Patients}}
+    <tr style="border-top:1px solid #e5e7eb;">
+      <td style="padding:.65rem 1rem;">{{.FullName}}</td>
+      <td style="padding:.65rem 1rem;">{{.State}}</td>
+    </tr>
+    {{end}}
+  </tbody>
+</table>
+{{else}}
+<p style="color:#6b7280;">No active patients in your panel.</p>
+{{end}}
+{{end}}

--- a/backend/internal/web/templates/queue.html
+++ b/backend/internal/web/templates/queue.html
@@ -1,0 +1,36 @@
+{{template "layout" .}}
+
+{{define "title"}}Review Queue — HouseCall{{end}}
+
+{{define "nav"}}
+<a href="/web/panel">Panel</a>
+<a href="/web/queue">Queue</a>
+{{end}}
+
+{{define "content"}}
+<h2 style="margin-bottom:1.25rem;font-size:1.25rem;">Pending Review Queue</h2>
+{{if .Recommendations}}
+<table style="width:100%;border-collapse:collapse;background:#fff;border-radius:6px;box-shadow:0 1px 4px rgba(0,0,0,.08);">
+  <thead>
+    <tr style="background:#1d3557;color:#fff;text-align:left;">
+      <th style="padding:.65rem 1rem;">ID</th>
+      <th style="padding:.65rem 1rem;">Type</th>
+      <th style="padding:.65rem 1rem;">Draft</th>
+      <th style="padding:.65rem 1rem;">Created</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{range .Recommendations}}
+    <tr style="border-top:1px solid #e5e7eb;">
+      <td style="padding:.65rem 1rem;font-family:monospace;font-size:.8rem;">{{.ID}}</td>
+      <td style="padding:.65rem 1rem;">{{.PayloadType}}</td>
+      <td style="padding:.65rem 1rem;">{{.DraftContent}}</td>
+      <td style="padding:.65rem 1rem;font-size:.85rem;color:#6b7280;">{{.CreatedAt.Format "2006-01-02 15:04"}}</td>
+    </tr>
+    {{end}}
+  </tbody>
+</table>
+{{else}}
+<p style="color:#6b7280;">No pending recommendations to review.</p>
+{{end}}
+{{end}}

--- a/backend/internal/web/templates/queue.html
+++ b/backend/internal/web/templates/queue.html
@@ -9,6 +9,11 @@
 
 {{define "content"}}
 <h2 style="margin-bottom:1.25rem;font-size:1.25rem;">Pending Review Queue</h2>
+
+{{if .Error}}
+<div class="flash-error">{{.Error}}</div>
+{{end}}
+
 {{if .Recommendations}}
 <table style="width:100%;border-collapse:collapse;background:#fff;border-radius:6px;box-shadow:0 1px 4px rgba(0,0,0,.08);">
   <thead>
@@ -17,6 +22,7 @@
       <th style="padding:.65rem 1rem;">Type</th>
       <th style="padding:.65rem 1rem;">Draft</th>
       <th style="padding:.65rem 1rem;">Created</th>
+      <th style="padding:.65rem 1rem;">Actions</th>
     </tr>
   </thead>
   <tbody>
@@ -26,6 +32,47 @@
       <td style="padding:.65rem 1rem;">{{.PayloadType}}</td>
       <td style="padding:.65rem 1rem;">{{.DraftContent}}</td>
       <td style="padding:.65rem 1rem;font-size:.85rem;color:#6b7280;">{{.CreatedAt.Format "2006-01-02 15:04"}}</td>
+      <td style="padding:.65rem 1rem;">
+        {{/* Approve: no edit needed — physician confirms draft content */}}
+        <form method="POST" action="/web/recommendations/{{.ID}}/review" style="display:inline;">
+          <input type="hidden" name="action" value="approve">
+          <button type="submit"
+            style="background:#1d6f42;color:#fff;border:none;padding:.35rem .75rem;border-radius:4px;cursor:pointer;font-size:.85rem;">
+            Approve
+          </button>
+        </form>
+
+        {{/* Reject */}}
+        <form method="POST" action="/web/recommendations/{{.ID}}/review" style="display:inline;margin-left:.4rem;">
+          <input type="hidden" name="action" value="reject">
+          <button type="submit"
+            style="background:#9b1c1c;color:#fff;border:none;padding:.35rem .75rem;border-radius:4px;cursor:pointer;font-size:.85rem;">
+            Reject
+          </button>
+        </form>
+
+        {{/* Modify: inline textarea + submit button */}}
+        <details style="display:inline-block;margin-left:.4rem;vertical-align:top;">
+          <summary style="cursor:pointer;background:#1d3557;color:#fff;border:none;padding:.35rem .75rem;border-radius:4px;font-size:.85rem;list-style:none;display:inline-block;">
+            Modify &amp; Deliver
+          </summary>
+          <div style="margin-top:.5rem;padding:.75rem;background:#f9fafb;border:1px solid #e5e7eb;border-radius:4px;">
+            <form method="POST" action="/web/recommendations/{{.ID}}/review">
+              <input type="hidden" name="action" value="modify">
+              <label style="display:block;font-size:.85rem;margin-bottom:.35rem;">
+                Edited content (required):
+              </label>
+              <textarea name="final_content" rows="3"
+                style="width:100%;padding:.4rem;border:1px solid #d1d5db;border-radius:4px;font-size:.85rem;resize:vertical;"
+                placeholder="Enter edited recommendation text…"></textarea>
+              <button type="submit"
+                style="margin-top:.5rem;background:#1d3557;color:#fff;border:none;padding:.35rem .75rem;border-radius:4px;cursor:pointer;font-size:.85rem;">
+                Deliver Modified
+              </button>
+            </form>
+          </div>
+        </details>
+      </td>
     </tr>
     {{end}}
   </tbody>

--- a/backend/internal/web/token.go
+++ b/backend/internal/web/token.go
@@ -1,0 +1,98 @@
+package web
+
+// token.go contains the JWT issue/verify helpers for the web package.
+// The JWT format is identical to the Core API's (api/jwt.go): HS256 with the
+// same rawClaims JSON shape, so a token issued here can be verified by the
+// Core API middleware if needed. The logic is not shared via import because
+// api.issueToken / api.verifyToken are unexported; the implementation is
+// small enough to duplicate without risk of divergence. Any future change to
+// the claim schema must be applied in both places.
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+var errInvalidWebToken = errors.New("web: invalid token")
+
+// sessionTTL mirrors the API token TTL so the cookie and the embedded JWT
+// expire together.
+const sessionTTL = 24 * time.Hour
+
+// webClaims is the decoded JWT payload used by the physician web app.
+type webClaims struct {
+	TenantID  store.TenantID
+	ActorID   uuid.UUID
+	ActorType string // always "physician" for web sessions
+}
+
+// rawWebClaims is the JSON representation stored in the JWT payload. Field
+// names match api/jwt.go rawClaims so tokens are interoperable.
+type rawWebClaims struct {
+	TenantID  string `json:"tid"`
+	ActorID   string `json:"sub"`
+	ActorType string `json:"act"`
+	Exp       int64  `json:"exp"`
+}
+
+// issueWebToken creates an HS256 JWT with the default session TTL.
+func issueWebToken(secret []byte, c webClaims) (string, error) {
+	return issueWebTokenWithTTL(secret, c, sessionTTL)
+}
+
+// issueWebTokenWithTTL creates an HS256 JWT that expires after ttl from now.
+// A negative ttl produces an already-expired token (useful for tests).
+func issueWebTokenWithTTL(secret []byte, c webClaims, ttl time.Duration) (string, error) {
+	rc := rawWebClaims{
+		TenantID:  c.TenantID.String(),
+		ActorID:   c.ActorID.String(),
+		ActorType: c.ActorType,
+		Exp:       time.Now().Add(ttl).Unix(),
+	}
+	hdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload, err := json.Marshal(rc)
+	if err != nil {
+		return "", err
+	}
+	enc := hdr + "." + base64.RawURLEncoding.EncodeToString(payload)
+	return enc + "." + webJWTSign(secret, enc), nil
+}
+
+// verifyWebToken validates an HS256 JWT and returns its decoded claims.
+// Returns errInvalidWebToken for any tamper, format, or expiry issue.
+func verifyWebToken(secret []byte, token string) (rawWebClaims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return rawWebClaims{}, errInvalidWebToken
+	}
+	msg := parts[0] + "." + parts[1]
+	if webJWTSign(secret, msg) != parts[2] {
+		return rawWebClaims{}, errInvalidWebToken
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return rawWebClaims{}, errInvalidWebToken
+	}
+	var rc rawWebClaims
+	if err := json.Unmarshal(raw, &rc); err != nil {
+		return rawWebClaims{}, errInvalidWebToken
+	}
+	if time.Now().Unix() > rc.Exp {
+		return rawWebClaims{}, errInvalidWebToken
+	}
+	return rc, nil
+}
+
+func webJWTSign(secret []byte, msg string) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(msg))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -446,6 +446,13 @@ func (h *Handler) handleReview(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	result, err := review.Execute(ctx, h.reviewStore(), claims.TenantID, claims.ActorID, recID, action, finalContent)
 
+	if errors.Is(err, review.ErrActorNotFound) {
+		// Physician record not found for the session actor — the session is no
+		// longer valid. Redirect to login (same policy as requireWebAuth for any
+		// auth anomaly).
+		http.Redirect(w, r, "/web/login", http.StatusSeeOther)
+		return
+	}
 	if errors.Is(err, store.ErrNotFound) {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
@@ -466,12 +473,12 @@ func (h *Handler) handleReview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.writeAudit(ctx, claims.TenantID, "physician", &claims.ActorID, "web.recommendation.reviewed", map[string]any{
-		"actor_id":          claims.ActorID.String(),
-		"recommendation_id": result.RecommendationID.String(),
-		"action":            action,
-		"new_state":         result.FinalState,
-	})
+	// The recommendation.reviewed audit event is written atomically inside
+	// review.Execute's TxnW — do NOT write a second event here. Writing it
+	// outside the transaction would (a) duplicate the event on the web path
+	// while the API path emits only one, and (b) break atomicity (the audit
+	// row would be written even if the state update rolled back).
+	_ = result // result used for redirect; audit already handled
 
 	// Redirect back to the queue (PRG pattern: prevents double-submit on reload).
 	http.Redirect(w, r, "/web/queue", http.StatusSeeOther)

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -44,11 +44,17 @@ type Handler struct {
 	store     *store.Store
 	secret    []byte
 	audit     *audit.Writer
-	templates *template.Template
+	// templates is a per-page template set keyed by page name (e.g. "login",
+	// "panel", "queue"). Each value is the layout cloned with only that page's
+	// block definitions, so {{define "content"}} in different page files do not
+	// collide inside a single shared *template.Template.
+	templates map[string]*template.Template
 
 	// test-injectable interfaces (nil in production).
 	storeQ interface {
 		GetPhysicianByEmail(ctx context.Context, tenant store.TenantID, email string) (store.Physician, error)
+		ListPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.Patient, error)
+		ListRecommendationsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID, state string) ([]store.Recommendation, error)
 	}
 	auditQ interface {
 		Write(ctx context.Context, tenant store.TenantID, actorType string, actorID *uuid.UUID, eventType string, metadata map[string]any)
@@ -70,9 +76,33 @@ func New(s *store.Store, secret []byte, aw *audit.Writer) (*Handler, error) {
 	}, nil
 }
 
-// parseTemplates parses all html/template files embedded in the templates/ dir.
-func parseTemplates() (*template.Template, error) {
-	return template.ParseFS(templateFS, "templates/*.html")
+// pageTemplates maps each page name to the set of template files it needs.
+// The layout is always included first so {{block}} definitions in the page
+// file can override the layout's default (empty) blocks. Each page gets its
+// own template set so {{define "content"}} in different page files do not
+// overwrite each other in a shared set.
+var pageTemplates = map[string][]string{
+	"login": {"templates/layout.html", "templates/login.html"},
+	"panel": {"templates/layout.html", "templates/panel.html"},
+	"queue": {"templates/layout.html", "templates/queue.html"},
+}
+
+// parseTemplates builds a per-page template set from the embedded FS.
+func parseTemplates() (map[string]*template.Template, error) {
+	sets := make(map[string]*template.Template, len(pageTemplates))
+	for name, files := range pageTemplates {
+		t, err := template.ParseFS(templateFS, files...)
+		if err != nil {
+			return nil, err
+		}
+		sets[name] = t
+	}
+	return sets, nil
+}
+
+// tmpl returns the template set for the named page, or nil if not found.
+func (h *Handler) tmpl(name string) *template.Template {
+	return h.templates[name]
 }
 
 // Mount registers all physician web app routes on r under a /web prefix.
@@ -87,10 +117,11 @@ func (h *Handler) Mount(r chi.Router) {
 		// Authenticated, physician-only routes.
 		r.Group(func(r chi.Router) {
 			r.Use(h.requireWebAuth)
-			// Root redirect; 5.2/5.3 will add real pages here.
 			r.Get("/", func(w http.ResponseWriter, req *http.Request) {
 				http.Redirect(w, req, "/web/queue", http.StatusSeeOther)
 			})
+			r.Get("/panel", h.handlePanel)
+			r.Get("/queue", h.handleQueue)
 		})
 	})
 }
@@ -270,12 +301,92 @@ func (h *Handler) writeAudit(ctx context.Context, tenant store.TenantID, actorTy
 	h.audit.Write(ctx, tenant, actorType, actorID, eventType, metadata)
 }
 
+// listPatientsByPhysician routes to the test-injectable interface if set,
+// otherwise to the concrete store.
+func (h *Handler) listPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.Patient, error) {
+	if h.storeQ != nil {
+		return h.storeQ.ListPatientsByPhysician(ctx, tenant, physicianID)
+	}
+	return h.store.ListPatientsByPhysician(ctx, tenant, physicianID)
+}
+
+// listRecommendationsByPhysician routes to the test-injectable interface if set,
+// otherwise to the concrete store.
+func (h *Handler) listRecommendationsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID, state string) ([]store.Recommendation, error) {
+	if h.storeQ != nil {
+		return h.storeQ.ListRecommendationsByPhysician(ctx, tenant, physicianID, state)
+	}
+	return h.store.ListRecommendationsByPhysician(ctx, tenant, physicianID, state)
+}
+
+// ---- panel handler ----
+
+type panelPageData struct {
+	Patients []store.Patient
+}
+
+func (h *Handler) handlePanel(w http.ResponseWriter, r *http.Request) {
+	claims, ok := webClaimsFromCtx(r.Context())
+	if !ok {
+		// requireWebAuth already guarantees this; defensive check.
+		http.Redirect(w, r, "/web/login", http.StatusSeeOther)
+		return
+	}
+
+	patients, err := h.listPatientsByPhysician(r.Context(), claims.TenantID, claims.ActorID)
+	if err != nil {
+		log.Printf("web: panel store error: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	h.writeAudit(r.Context(), claims.TenantID, "physician", &claims.ActorID, "web.panel.viewed", map[string]any{
+		"actor_id": claims.ActorID.String(),
+	})
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.tmpl("panel").ExecuteTemplate(w, "layout", panelPageData{Patients: patients}); err != nil {
+		log.Printf("web: render panel template: %v", err)
+	}
+}
+
+// ---- queue handler ----
+
+type queuePageData struct {
+	Recommendations []store.Recommendation
+}
+
+func (h *Handler) handleQueue(w http.ResponseWriter, r *http.Request) {
+	claims, ok := webClaimsFromCtx(r.Context())
+	if !ok {
+		// requireWebAuth already guarantees this; defensive check.
+		http.Redirect(w, r, "/web/login", http.StatusSeeOther)
+		return
+	}
+
+	recs, err := h.listRecommendationsByPhysician(r.Context(), claims.TenantID, claims.ActorID, "PENDING_REVIEW")
+	if err != nil {
+		log.Printf("web: queue store error: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	h.writeAudit(r.Context(), claims.TenantID, "physician", &claims.ActorID, "web.queue.viewed", map[string]any{
+		"actor_id": claims.ActorID.String(),
+	})
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.tmpl("queue").ExecuteTemplate(w, "layout", queuePageData{Recommendations: recs}); err != nil {
+		log.Printf("web: render queue template: %v", err)
+	}
+}
+
 // ---- template renderer ----
 
 func (h *Handler) renderLogin(w http.ResponseWriter, status int, errMsg string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(status)
-	if err := h.templates.ExecuteTemplate(w, "layout", loginPageData{Error: errMsg}); err != nil {
+	if err := h.tmpl("login").ExecuteTemplate(w, "layout", loginPageData{Error: errMsg}); err != nil {
 		log.Printf("web: render login template: %v", err)
 	}
 }

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -26,6 +26,8 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/markolonius/housecall/backend/internal/audit"
+	"github.com/markolonius/housecall/backend/internal/domain"
+	"github.com/markolonius/housecall/backend/internal/review"
 	"github.com/markolonius/housecall/backend/internal/store"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -55,6 +57,14 @@ type Handler struct {
 		GetPhysicianByEmail(ctx context.Context, tenant store.TenantID, email string) (store.Physician, error)
 		ListPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.Patient, error)
 		ListRecommendationsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID, state string) ([]store.Recommendation, error)
+
+		// Review action methods (task 5.3). These satisfy review.Store so the
+		// handler can pass storeQ directly to review.Execute in tests.
+		GetRecommendationForPhysician(ctx context.Context, tenant store.TenantID, physicianID, recID uuid.UUID) (store.Recommendation, error)
+		GetPhysician(ctx context.Context, tenant store.TenantID, id uuid.UUID) (store.Physician, error)
+		GetPatient(ctx context.Context, tenant store.TenantID, id uuid.UUID) (store.Patient, error)
+		CreateAuditEvent(ctx context.Context, tenant store.TenantID, e store.AuditEvent) (store.AuditEvent, error)
+		TxnW(ctx context.Context, fn func(store.TxWriter) error) error
 	}
 	auditQ interface {
 		Write(ctx context.Context, tenant store.TenantID, actorType string, actorID *uuid.UUID, eventType string, metadata map[string]any)
@@ -122,6 +132,7 @@ func (h *Handler) Mount(r chi.Router) {
 			})
 			r.Get("/panel", h.handlePanel)
 			r.Get("/queue", h.handleQueue)
+			r.Post("/recommendations/{id}/review", h.handleReview)
 		})
 	})
 }
@@ -319,6 +330,15 @@ func (h *Handler) listRecommendationsByPhysician(ctx context.Context, tenant sto
 	return h.store.ListRecommendationsByPhysician(ctx, tenant, physicianID, state)
 }
 
+// reviewStore returns the review.Store implementation to use. In tests storeQ
+// satisfies review.Store directly; in production the concrete *store.Store does.
+func (h *Handler) reviewStore() review.Store {
+	if h.storeQ != nil {
+		return h.storeQ
+	}
+	return h.store
+}
+
 // ---- panel handler ----
 
 type panelPageData struct {
@@ -354,6 +374,9 @@ func (h *Handler) handlePanel(w http.ResponseWriter, r *http.Request) {
 
 type queuePageData struct {
 	Recommendations []store.Recommendation
+	// Error is shown as a flash banner when a review action fails (e.g.
+	// unlicensed-state rejection). Empty string means no error.
+	Error string
 }
 
 func (h *Handler) handleQueue(w http.ResponseWriter, r *http.Request) {
@@ -378,6 +401,97 @@ func (h *Handler) handleQueue(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := h.tmpl("queue").ExecuteTemplate(w, "layout", queuePageData{Recommendations: recs}); err != nil {
 		log.Printf("web: render queue template: %v", err)
+	}
+}
+
+// ---- review handler (task 5.3) ----
+
+// handleReview processes POST /web/recommendations/{id}/review.
+// It accepts application/x-www-form-urlencoded with fields:
+//   - action: "approve" | "reject" | "modify"
+//   - final_content: required for "modify"; accepted (but not required) for "approve"
+//
+// On success it redirects to /web/queue (303).
+// On ErrUnlicensedState it renders the queue with an error banner (state is NOT
+// mutated; the rejection audit event was already written by review.Execute).
+// On a care-relationship / access failure it returns 403/404.
+func (h *Handler) handleReview(w http.ResponseWriter, r *http.Request) {
+	claims, ok := webClaimsFromCtx(r.Context())
+	if !ok {
+		http.Redirect(w, r, "/web/login", http.StatusSeeOther)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form submission", http.StatusBadRequest)
+		return
+	}
+
+	recIDStr := chi.URLParam(r, "id")
+	recID, err := uuid.Parse(recIDStr)
+	if err != nil {
+		http.Error(w, "invalid recommendation id", http.StatusBadRequest)
+		return
+	}
+
+	action := r.FormValue("action")
+	finalContent := r.FormValue("final_content")
+
+	// modify requires a non-empty final_content.
+	if action == domain.ActionModify && finalContent == "" {
+		http.Error(w, "final_content required for modify", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	result, err := review.Execute(ctx, h.reviewStore(), claims.TenantID, claims.ActorID, recID, action, finalContent)
+
+	if errors.Is(err, store.ErrNotFound) {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	if errors.Is(err, domain.ErrUnlicensedState) {
+		// Render the queue with an error banner. State was NOT mutated; the audit
+		// event was already written by review.Execute.
+		h.renderQueueWithError(w, r, claims, "Action rejected: you are not licensed in the patient's state.")
+		return
+	}
+	if errors.Is(err, domain.ErrInvalidTransition) {
+		http.Error(w, "invalid transition", http.StatusUnprocessableEntity)
+		return
+	}
+	if err != nil {
+		log.Printf("web: review recommendation %s: %v", recIDStr, err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	h.writeAudit(ctx, claims.TenantID, "physician", &claims.ActorID, "web.recommendation.reviewed", map[string]any{
+		"actor_id":          claims.ActorID.String(),
+		"recommendation_id": result.RecommendationID.String(),
+		"action":            action,
+		"new_state":         result.FinalState,
+	})
+
+	// Redirect back to the queue (PRG pattern: prevents double-submit on reload).
+	http.Redirect(w, r, "/web/queue", http.StatusSeeOther)
+}
+
+// renderQueueWithError re-fetches the queue and renders it with an error banner.
+func (h *Handler) renderQueueWithError(w http.ResponseWriter, r *http.Request, claims webClaims, errMsg string) {
+	recs, err := h.listRecommendationsByPhysician(r.Context(), claims.TenantID, claims.ActorID, "PENDING_REVIEW")
+	if err != nil {
+		log.Printf("web: queue store error on error render: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusForbidden)
+	if err := h.tmpl("queue").ExecuteTemplate(w, "layout", queuePageData{
+		Recommendations: recs,
+		Error:           errMsg,
+	}); err != nil {
+		log.Printf("web: render queue error template: %v", err)
 	}
 }
 

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -1,0 +1,281 @@
+// Package web implements the server-rendered physician web application.
+// Routes are mounted under a /web prefix by the caller (cmd/server) so they
+// remain cleanly separated from the JSON API handlers under /api.
+//
+// Authentication: a form-based login POST issues the same HMAC-HS256 JWT that
+// the Core API /auth/login endpoint issues, then wraps it in a session cookie
+// (HttpOnly, Secure, SameSite=Lax). The requireWebAuth middleware reads the
+// cookie, verifies the JWT via the shared verifyToken logic, and rejects
+// non-physician actors with a redirect to the login form.
+//
+// HIPAA notes:
+//   - The JWT value is never logged; only the actor_id is used in audit metadata.
+//   - Every data read is tenant-scoped: tenant_id comes from the verified JWT,
+//     never from request params.
+//   - Session cookie is HttpOnly + Secure + SameSite=Lax.
+package web
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"html/template"
+	"log"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/markolonius/housecall/backend/internal/audit"
+	"github.com/markolonius/housecall/backend/internal/store"
+	"golang.org/x/crypto/bcrypt"
+)
+
+//go:embed templates/*.html
+var templateFS embed.FS
+
+const sessionCookieName = "hc_session"
+
+// Handler holds the shared dependencies for the physician web app.
+//
+// The storeQ and auditQ fields allow tests (via NewWithQuerier in export_test.go)
+// to inject fakes without a real database. Production code (New) leaves those
+// nil and falls back to the concrete store/audit fields.
+type Handler struct {
+	store     *store.Store
+	secret    []byte
+	audit     *audit.Writer
+	templates *template.Template
+
+	// test-injectable interfaces (nil in production).
+	storeQ interface {
+		GetPhysicianByEmail(ctx context.Context, tenant store.TenantID, email string) (store.Physician, error)
+	}
+	auditQ interface {
+		Write(ctx context.Context, tenant store.TenantID, actorType string, actorID *uuid.UUID, eventType string, metadata map[string]any)
+	}
+}
+
+// New constructs a Handler for production use. secret is the HMAC-SHA256
+// signing key shared with the Core API. aw is the shared audit.Writer.
+func New(s *store.Store, secret []byte, aw *audit.Writer) (*Handler, error) {
+	tmpl, err := parseTemplates()
+	if err != nil {
+		return nil, err
+	}
+	return &Handler{
+		store:     s,
+		secret:    secret,
+		audit:     aw,
+		templates: tmpl,
+	}, nil
+}
+
+// parseTemplates parses all html/template files embedded in the templates/ dir.
+func parseTemplates() (*template.Template, error) {
+	return template.ParseFS(templateFS, "templates/*.html")
+}
+
+// Mount registers all physician web app routes on r under a /web prefix.
+// The routes are separate from the JSON API handlers (/api) on the same chi
+// router.
+func (h *Handler) Mount(r chi.Router) {
+	r.Route("/web", func(r chi.Router) {
+		// Unauthenticated routes.
+		r.Get("/login", h.handleLoginForm)
+		r.Post("/login", h.handleLoginSubmit)
+
+		// Authenticated, physician-only routes.
+		r.Group(func(r chi.Router) {
+			r.Use(h.requireWebAuth)
+			// Root redirect; 5.2/5.3 will add real pages here.
+			r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+				http.Redirect(w, req, "/web/queue", http.StatusSeeOther)
+			})
+		})
+	})
+}
+
+// ---- login form ----
+
+type loginPageData struct {
+	Error string
+}
+
+func (h *Handler) handleLoginForm(w http.ResponseWriter, r *http.Request) {
+	h.renderLogin(w, http.StatusOK, "")
+}
+
+func (h *Handler) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		h.renderLogin(w, http.StatusBadRequest, "invalid form submission")
+		return
+	}
+
+	tenantRaw := r.FormValue("tenant_id")
+	email := r.FormValue("email")
+	password := r.FormValue("password")
+
+	if tenantRaw == "" || email == "" || password == "" {
+		h.renderLogin(w, http.StatusBadRequest, "all fields are required")
+		return
+	}
+
+	tid, err := uuid.Parse(tenantRaw)
+	if err != nil {
+		h.renderLogin(w, http.StatusBadRequest, "invalid tenant")
+		return
+	}
+	tenant := store.TenantID(tid)
+	ctx := r.Context()
+
+	// Look up the physician. Only physicians may log in to the web app.
+	physician, err := h.getPhysicianByEmail(ctx, tenant, email)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// Return the same opaque message as the Core API to prevent
+			// account enumeration (consistent with api/auth.go).
+			h.renderLogin(w, http.StatusUnauthorized, "invalid credentials")
+			return
+		}
+		log.Printf("web: login store error: %v", err)
+		h.renderLogin(w, http.StatusInternalServerError, "internal error, please try again")
+		return
+	}
+
+	if bcrypt.CompareHashAndPassword([]byte(physician.PasswordHash), []byte(password)) != nil {
+		h.renderLogin(w, http.StatusUnauthorized, "invalid credentials")
+		return
+	}
+
+	// Issue a JWT with the same claims shape the Core API uses.
+	claims := webClaims{
+		TenantID:  tenant,
+		ActorID:   physician.ID,
+		ActorType: "physician",
+	}
+	token, err := issueWebToken(h.secret, claims)
+	if err != nil {
+		log.Printf("web: token issue error: %v", err)
+		h.renderLogin(w, http.StatusInternalServerError, "internal error, please try again")
+		return
+	}
+
+	// Wrap the JWT in an HttpOnly session cookie. The JWT value itself is
+	// never written to logs; the audit record carries only the actor_id.
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    token,
+		Path:     "/web",
+		MaxAge:   int(sessionTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	h.writeAudit(ctx, tenant, "physician", &physician.ID, "web.auth.login", map[string]any{
+		"actor_id": physician.ID.String(),
+	})
+
+	http.Redirect(w, r, "/web/queue", http.StatusSeeOther)
+}
+
+// ---- middleware ----
+
+// webClaimsContextKey is the context key for the physician's verified claims.
+type webClaimsContextKey struct{}
+
+// requireWebAuth validates the session cookie, verifies the embedded JWT, and
+// rejects non-physician actors. On failure it redirects to the login form
+// (never returning a JSON error — this is a browser-facing app).
+func (h *Handler) requireWebAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie, err := r.Cookie(sessionCookieName)
+		if err != nil {
+			http.Redirect(w, r, "/web/login", http.StatusSeeOther)
+			return
+		}
+
+		rc, err := verifyWebToken(h.secret, cookie.Value)
+		if err != nil {
+			// Clear the stale cookie before redirecting.
+			http.SetCookie(w, &http.Cookie{
+				Name:     sessionCookieName,
+				Value:    "",
+				Path:     "/web",
+				MaxAge:   -1,
+				HttpOnly: true,
+				Secure:   true,
+				SameSite: http.SameSiteLaxMode,
+			})
+			http.Redirect(w, r, "/web/login", http.StatusSeeOther)
+			return
+		}
+
+		// Physician-only gate. Patients authenticated against the Core API
+		// cannot access the web app.
+		if rc.ActorType != "physician" {
+			http.Redirect(w, r, "/web/login", http.StatusSeeOther)
+			return
+		}
+
+		tid, err := uuid.Parse(rc.TenantID)
+		if err != nil {
+			http.Redirect(w, r, "/web/login", http.StatusSeeOther)
+			return
+		}
+		actorID, err := uuid.Parse(rc.ActorID)
+		if err != nil {
+			http.Redirect(w, r, "/web/login", http.StatusSeeOther)
+			return
+		}
+
+		c := webClaims{
+			TenantID:  store.TenantID(tid),
+			ActorID:   actorID,
+			ActorType: rc.ActorType,
+		}
+		next.ServeHTTP(w, r.WithContext(withWebClaims(r.Context(), c)))
+	})
+}
+
+// webClaimsFromCtx retrieves the verified physician claims from a request
+// context populated by requireWebAuth.
+func webClaimsFromCtx(ctx context.Context) (webClaims, bool) {
+	c, ok := ctx.Value(webClaimsContextKey{}).(webClaims)
+	return c, ok
+}
+
+func withWebClaims(ctx context.Context, c webClaims) context.Context {
+	return context.WithValue(ctx, webClaimsContextKey{}, c)
+}
+
+// ---- store / audit dispatch (production vs test) ----
+
+// getPhysicianByEmail routes to the test-injectable interface if set,
+// otherwise to the concrete store.
+func (h *Handler) getPhysicianByEmail(ctx context.Context, tenant store.TenantID, email string) (store.Physician, error) {
+	if h.storeQ != nil {
+		return h.storeQ.GetPhysicianByEmail(ctx, tenant, email)
+	}
+	return h.store.GetPhysicianByEmail(ctx, tenant, email)
+}
+
+// writeAudit routes to the test-injectable audit interface if set,
+// otherwise to the concrete audit.Writer.
+func (h *Handler) writeAudit(ctx context.Context, tenant store.TenantID, actorType string, actorID *uuid.UUID, eventType string, metadata map[string]any) {
+	if h.auditQ != nil {
+		h.auditQ.Write(ctx, tenant, actorType, actorID, eventType, metadata)
+		return
+	}
+	h.audit.Write(ctx, tenant, actorType, actorID, eventType, metadata)
+}
+
+// ---- template renderer ----
+
+func (h *Handler) renderLogin(w http.ResponseWriter, status int, errMsg string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	if err := h.templates.ExecuteTemplate(w, "layout", loginPageData{Error: errMsg}); err != nil {
+		log.Printf("web: render login template: %v", err)
+	}
+}

--- a/backend/internal/web/web_test.go
+++ b/backend/internal/web/web_test.go
@@ -21,6 +21,7 @@ package web_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -32,6 +33,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/markolonius/housecall/backend/internal/domain"
 	"github.com/markolonius/housecall/backend/internal/store"
 	"github.com/markolonius/housecall/backend/internal/web"
 	"golang.org/x/crypto/bcrypt"
@@ -45,13 +47,21 @@ var testSecret = []byte("web-test-secret-32-bytes!!!!!!!")
 // fakeStore implements the store methods the web package calls so tests can
 // run without a database.
 type fakeStore struct {
-	physicians      map[string]store.Physician      // keyed by email
-	patients        map[string]store.Patient        // keyed by email
-	panelPatients   []store.Patient                 // returned by ListPatientsByPhysician
-	queueRecs       []store.Recommendation          // returned by ListRecommendationsByPhysician
+	physicians    map[string]store.Physician    // keyed by email
+	patients      map[string]store.Patient      // keyed by email
+	panelPatients []store.Patient               // returned by ListPatientsByPhysician
+	queueRecs     []store.Recommendation        // returned by ListRecommendationsByPhysician
 	// physicianForPanel / Rec scoping: keyed by physician id string
-	panelByPhys     map[string][]store.Patient
-	recsByPhys      map[string][]store.Recommendation
+	panelByPhys map[string][]store.Patient
+	recsByPhys  map[string][]store.Recommendation
+
+	// review action support (task 5.3)
+	recsByID      map[uuid.UUID]store.Recommendation // all recs by ID (for GetRecommendationForPhysician)
+	physByID      map[uuid.UUID]store.Physician      // physicians by ID (for GetPhysician)
+	patientsByID  map[uuid.UUID]store.Patient        // patients by ID (for GetPatient)
+	auditEvents   []store.AuditEvent                 // captured audit events
+	updatedStates map[uuid.UUID]string               // final state per recommendation (set by Txn)
+	txnErr        error                              // if set, Txn returns this error
 }
 
 func (f *fakeStore) GetPhysicianByEmail(_ context.Context, tenant store.TenantID, email string) (store.Physician, error) {
@@ -120,6 +130,86 @@ func (f *fakeStore) ListRecommendationsByPhysician(_ context.Context, tenant sto
 	return out, nil
 }
 
+// ---- review action methods (task 5.3) ----
+
+func (f *fakeStore) GetRecommendationForPhysician(_ context.Context, tenant store.TenantID, physicianID, recID uuid.UUID) (store.Recommendation, error) {
+	r, ok := f.recsByID[recID]
+	if !ok || r.TenantID != tenant {
+		return store.Recommendation{}, store.ErrNotFound
+	}
+	// Check that the physician has an active care relationship (simulated by
+	// verifying the physician is listed in recsByPhys for the patient).
+	if f.recsByPhys != nil {
+		found := false
+		for _, rec := range f.recsByPhys[physicianID.String()] {
+			if rec.ID == recID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return store.Recommendation{}, store.ErrNotFound
+		}
+	}
+	return r, nil
+}
+
+func (f *fakeStore) GetPhysician(_ context.Context, tenant store.TenantID, id uuid.UUID) (store.Physician, error) {
+	p, ok := f.physByID[id]
+	if !ok || p.TenantID != tenant {
+		return store.Physician{}, store.ErrNotFound
+	}
+	return p, nil
+}
+
+func (f *fakeStore) GetPatient(_ context.Context, tenant store.TenantID, id uuid.UUID) (store.Patient, error) {
+	p, ok := f.patientsByID[id]
+	if !ok || p.TenantID != tenant {
+		return store.Patient{}, store.ErrNotFound
+	}
+	return p, nil
+}
+
+func (f *fakeStore) CreateAuditEvent(_ context.Context, _ store.TenantID, e store.AuditEvent) (store.AuditEvent, error) {
+	f.auditEvents = append(f.auditEvents, e)
+	return e, nil
+}
+
+// TxnW simulates a transaction by calling fn with a fakeTxWriter that
+// captures UpdateRecommendationState calls into f.updatedStates and
+// CreateAuditEvent calls into f.auditEvents.
+func (f *fakeStore) TxnW(_ context.Context, fn func(store.TxWriter) error) error {
+	if f.txnErr != nil {
+		return f.txnErr
+	}
+	if f.updatedStates == nil {
+		f.updatedStates = make(map[uuid.UUID]string)
+	}
+	return fn(&fakeTxWriter{f: f})
+}
+
+// fakeTxWriter implements store.TxWriter for DB-free tests.
+type fakeTxWriter struct{ f *fakeStore }
+
+func (t *fakeTxWriter) UpdateRecommendationState(_ context.Context, _ store.TenantID, id uuid.UUID, state string, _ *uuid.UUID, content *string) error {
+	if t.f.updatedStates == nil {
+		t.f.updatedStates = make(map[uuid.UUID]string)
+	}
+	t.f.updatedStates[id] = state
+	// Update the recommendation in recsByID so subsequent reads reflect the new state.
+	if rec, ok := t.f.recsByID[id]; ok {
+		rec.State = state
+		rec.FinalContent = content
+		t.f.recsByID[id] = rec
+	}
+	return nil
+}
+
+func (t *fakeTxWriter) CreateAuditEvent(_ context.Context, _ store.TenantID, e store.AuditEvent) error {
+	t.f.auditEvents = append(t.f.auditEvents, e)
+	return nil
+}
+
 // storeAdapter wraps fakeStore to satisfy the web.StoreQuerier interface.
 type storeAdapter struct{ f *fakeStore }
 
@@ -133,6 +223,26 @@ func (a *storeAdapter) ListPatientsByPhysician(ctx context.Context, t store.Tena
 
 func (a *storeAdapter) ListRecommendationsByPhysician(ctx context.Context, t store.TenantID, physicianID uuid.UUID, state string) ([]store.Recommendation, error) {
 	return a.f.ListRecommendationsByPhysician(ctx, t, physicianID, state)
+}
+
+func (a *storeAdapter) GetRecommendationForPhysician(ctx context.Context, t store.TenantID, physicianID, recID uuid.UUID) (store.Recommendation, error) {
+	return a.f.GetRecommendationForPhysician(ctx, t, physicianID, recID)
+}
+
+func (a *storeAdapter) GetPhysician(ctx context.Context, t store.TenantID, id uuid.UUID) (store.Physician, error) {
+	return a.f.GetPhysician(ctx, t, id)
+}
+
+func (a *storeAdapter) GetPatient(ctx context.Context, t store.TenantID, id uuid.UUID) (store.Patient, error) {
+	return a.f.GetPatient(ctx, t, id)
+}
+
+func (a *storeAdapter) CreateAuditEvent(ctx context.Context, t store.TenantID, e store.AuditEvent) (store.AuditEvent, error) {
+	return a.f.CreateAuditEvent(ctx, t, e)
+}
+
+func (a *storeAdapter) TxnW(ctx context.Context, fn func(store.TxWriter) error) error {
+	return a.f.TxnW(ctx, fn)
 }
 
 // noopAuditWriter discards all audit events for tests that don't need a DB.
@@ -731,6 +841,364 @@ func TestNavLinks_PanelAndQueue(t *testing.T) {
 			t.Errorf("%s: page must contain nav link to /web/queue", path)
 		}
 	}
+}
+
+// ---- review action tests (task 5.3) ---------------------------------------------
+
+// testRecID is a stable recommendation UUID used across review action tests.
+var testRecID = uuid.MustParse("55555555-0000-0000-0000-000000000005")
+
+// newFakeStoreForReview returns a fakeStore pre-populated with a PENDING_REVIEW
+// recommendation, a physician (with given states_licensed), and their patient (in state patientState).
+func newFakeStoreForReview(physStates []string, patientState string) *fakeStore {
+	phys := store.Physician{
+		ID:             testPhysID,
+		TenantID:       testTenantID,
+		Email:          "doc@clinic.example",
+		StatesLicensed: physStates,
+	}
+	patient := store.Patient{
+		ID:       testPatientID,
+		TenantID: testTenantID,
+		State:    patientState,
+	}
+	rec := store.Recommendation{
+		ID:           testRecID,
+		TenantID:     testTenantID,
+		PatientID:    testPatientID,
+		State:        domain.StatePendingReview,
+		PayloadType:  "guidance",
+		DraftContent: "Drink plenty of water and rest",
+	}
+	return &fakeStore{
+		physicians:   map[string]store.Physician{"doc@clinic.example": phys},
+		physByID:     map[uuid.UUID]store.Physician{testPhysID: phys},
+		patientsByID: map[uuid.UUID]store.Patient{testPatientID: patient},
+		recsByID:     map[uuid.UUID]store.Recommendation{testRecID: rec},
+		// recsByPhys wires the care-relationship check in GetRecommendationForPhysician.
+		recsByPhys: map[string][]store.Recommendation{
+			testPhysID.String(): {rec},
+		},
+		updatedStates: make(map[uuid.UUID]string),
+	}
+}
+
+// postReview sends a POST to /web/recommendations/{id}/review with the given
+// action and optional final_content, using the session cookie for testPhysID.
+func postReview(t *testing.T, h http.Handler, recID uuid.UUID, action, finalContent string) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{"action": {action}}
+	if finalContent != "" {
+		form.Set("final_content", finalContent)
+	}
+	req := httptest.NewRequest(http.MethodPost,
+		"/web/recommendations/"+recID.String()+"/review",
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestReview_Unauthenticated verifies that an unauthenticated POST to the
+// review endpoint redirects to login.
+func TestReview_Unauthenticated(t *testing.T) {
+	fs := newFakeStoreForReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+
+	form := url.Values{"action": {"approve"}}
+	req := httptest.NewRequest(http.MethodPost,
+		"/web/recommendations/"+testRecID.String()+"/review",
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	assertRedirectToLogin(t, rec)
+}
+
+// TestReview_NonPhysician verifies that a patient JWT is rejected.
+func TestReview_NonPhysician(t *testing.T) {
+	fs := newFakeStoreForReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+
+	form := url.Values{"action": {"approve"}}
+	req := httptest.NewRequest(http.MethodPost,
+		"/web/recommendations/"+testRecID.String()+"/review",
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(makeCookie(t, testTenantID, testPatientID, "patient"))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	assertRedirectToLogin(t, rec)
+}
+
+// TestReview_Approve verifies that POSTing action=approve:
+//   - Redirects back to /web/queue (303)
+//   - Drives the recommendation to DELIVERED
+//   - Sets final_content to the draft (no override provided)
+//   - Writes a recommendation.reviewed audit event
+func TestReview_Approve(t *testing.T) {
+	fs := newFakeStoreForReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+
+	rec := postReview(t, h, testRecID, domain.ActionApprove, "")
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("approve: want 303, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/web/queue" {
+		t.Fatalf("approve: want redirect to /web/queue, got %q", loc)
+	}
+
+	// The recommendation must have reached DELIVERED.
+	if got := fs.updatedStates[testRecID]; got != domain.StateDelivered {
+		t.Fatalf("approve: want state DELIVERED, got %q", got)
+	}
+
+	// A recommendation.reviewed audit event must have been written.
+	assertAuditEvent(t, fs, "recommendation.reviewed", domain.ActionApprove, domain.StateDelivered)
+}
+
+// TestReview_Reject verifies that POSTing action=reject drives the
+// recommendation to REJECTED and redirects to the queue.
+func TestReview_Reject(t *testing.T) {
+	fs := newFakeStoreForReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+
+	rec := postReview(t, h, testRecID, domain.ActionReject, "")
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("reject: want 303, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	if got := fs.updatedStates[testRecID]; got != domain.StateRejected {
+		t.Fatalf("reject: want state REJECTED, got %q", got)
+	}
+
+	// Verify final_content is nil (patients must never see a rejected rec's content).
+	if r, ok := fs.recsByID[testRecID]; ok && r.FinalContent != nil {
+		t.Error("reject: final_content must remain nil for REJECTED recommendations")
+	}
+
+	assertAuditEvent(t, fs, "recommendation.reviewed", domain.ActionReject, domain.StateRejected)
+}
+
+// TestReview_Modify verifies that POSTing action=modify with final_content:
+//   - Drives the recommendation to DELIVERED
+//   - Sets final_content to the physician's edited value
+//   - Redirects to the queue
+func TestReview_Modify(t *testing.T) {
+	fs := newFakeStoreForReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+	editedContent := "Take ibuprofen 400 mg twice daily"
+
+	rec := postReview(t, h, testRecID, domain.ActionModify, editedContent)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("modify: want 303, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	if got := fs.updatedStates[testRecID]; got != domain.StateDelivered {
+		t.Fatalf("modify: want state DELIVERED, got %q", got)
+	}
+
+	// final_content must equal the physician's edited text.
+	r := fs.recsByID[testRecID]
+	if r.FinalContent == nil {
+		t.Fatal("modify: final_content must be set after delivery")
+	}
+	if *r.FinalContent != editedContent {
+		t.Fatalf("modify: final_content = %q, want %q", *r.FinalContent, editedContent)
+	}
+
+	assertAuditEvent(t, fs, "recommendation.reviewed", domain.ActionModify, domain.StateDelivered)
+}
+
+// TestReview_ModifyMissingFinalContent verifies that a modify action without
+// final_content is rejected (400) and state is not mutated.
+func TestReview_ModifyMissingFinalContent(t *testing.T) {
+	fs := newFakeStoreForReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+
+	rec := postReview(t, h, testRecID, domain.ActionModify, "")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("modify without content: want 400, got %d", rec.Code)
+	}
+	// State must not have changed.
+	if _, changed := fs.updatedStates[testRecID]; changed {
+		t.Error("modify without content: state must not be mutated")
+	}
+}
+
+// TestReview_UnlicensedPhysician verifies that an unlicensed physician:
+//   - Receives a 403 response with the queue re-rendered
+//   - Does NOT mutate state
+//   - Has a recommendation.review_rejected audit event written
+func TestReview_UnlicensedPhysician(t *testing.T) {
+	// Physician licensed in NY, patient in CA.
+	fs := newFakeStoreForReview([]string{"NY"}, "CA")
+	h := buildHandler(t, fs)
+
+	rec := postReview(t, h, testRecID, domain.ActionApprove, "")
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("unlicensed: want 403, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	// The recommendation state must NOT have been updated.
+	if _, changed := fs.updatedStates[testRecID]; changed {
+		t.Error("unlicensed: state must not be mutated when physician is unlicensed")
+	}
+
+	// A review_rejected audit event must have been written.
+	found := false
+	for _, e := range fs.auditEvents {
+		if e.EventType == "recommendation.review_rejected" {
+			var meta map[string]any
+			if err := json.Unmarshal(e.Metadata, &meta); err == nil {
+				if meta["reason"] == "unlicensed_state" {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("unlicensed: expected recommendation.review_rejected audit event with reason=unlicensed_state")
+	}
+
+	// Queue page must be re-rendered (not a redirect).
+	body := rec.Body.String()
+	if !strings.Contains(body, "not licensed in the patient") {
+		t.Error("unlicensed: response body must contain physician-facing error message")
+	}
+}
+
+// TestReview_NotOwnPatient verifies that a physician cannot act on a
+// recommendation belonging to a patient outside their care relationship.
+func TestReview_NotOwnPatient(t *testing.T) {
+	// testPhysID2 is NOT in testPhysID's recsByPhys.
+	fs := newFakeStoreForReview([]string{"CA"}, "CA")
+	// Change the rec to belong to phys2's patient.
+	unrelatedRec := store.Recommendation{
+		ID:           uuid.MustParse("66666666-0000-0000-0000-000000000006"),
+		TenantID:     testTenantID,
+		PatientID:    testPatientID2,
+		State:        domain.StatePendingReview,
+		PayloadType:  "guidance",
+		DraftContent: "Another recommendation",
+	}
+	fs.recsByID[unrelatedRec.ID] = unrelatedRec
+	// testPhysID's recsByPhys does NOT include unrelatedRec, so GetRecommendationForPhysician returns 404.
+
+	h := buildHandler(t, fs)
+
+	form := url.Values{"action": {"approve"}}
+	req := httptest.NewRequest(http.MethodPost,
+		"/web/recommendations/"+unrelatedRec.ID.String()+"/review",
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("not-own-patient: want 404, got %d", rec.Code)
+	}
+}
+
+// TestReview_InvalidRecID verifies that a non-UUID recommendation id returns 400.
+func TestReview_InvalidRecID(t *testing.T) {
+	fs := newFakeStoreForReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+
+	form := url.Values{"action": {"approve"}}
+	req := httptest.NewRequest(http.MethodPost, "/web/recommendations/not-a-uuid/review",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid id: want 400, got %d", rec.Code)
+	}
+}
+
+// TestReview_QueueShowsActionForms verifies that the queue page renders Approve,
+// Reject, and Modify controls for a PENDING_REVIEW recommendation.
+func TestReview_QueueShowsActionForms(t *testing.T) {
+	rec := store.Recommendation{
+		ID:           testRecID,
+		TenantID:     testTenantID,
+		PatientID:    testPatientID,
+		State:        domain.StatePendingReview,
+		PayloadType:  "guidance",
+		DraftContent: "Take vitamin D",
+	}
+	fs := &fakeStore{
+		physicians: map[string]store.Physician{},
+		queueRecs:  []store.Recommendation{rec},
+	}
+	h := buildHandler(t, fs)
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/queue", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("queue with rec: want 200, got %d", rw.Code)
+	}
+	body := rw.Body.String()
+
+	// Must contain review action forms.
+	if !strings.Contains(body, `value="approve"`) {
+		t.Error("queue must contain an approve action")
+	}
+	if !strings.Contains(body, `value="reject"`) {
+		t.Error("queue must contain a reject action")
+	}
+	if !strings.Contains(body, `value="modify"`) {
+		t.Error("queue must contain a modify action")
+	}
+	// final_content textarea for the modify flow.
+	if !strings.Contains(body, `name="final_content"`) {
+		t.Error("queue must contain a final_content input for the modify flow")
+	}
+}
+
+// assertAuditEvent is a helper that verifies the fakeStore has an audit event
+// of the given type with matching action and new_state metadata fields.
+func assertAuditEvent(t *testing.T, fs *fakeStore, eventType, action, newState string) {
+	t.Helper()
+	for _, e := range fs.auditEvents {
+		if e.EventType != eventType {
+			continue
+		}
+		var meta map[string]any
+		if err := json.Unmarshal(e.Metadata, &meta); err != nil {
+			continue
+		}
+		if meta["action"] == action && meta["new_state"] == newState {
+			return
+		}
+	}
+	t.Errorf("expected audit event type=%q action=%q new_state=%q; got events: %v",
+		eventType, action, newState, auditEventSummary(fs))
+}
+
+func auditEventSummary(fs *fakeStore) []string {
+	var out []string
+	for _, e := range fs.auditEvents {
+		out = append(out, e.EventType+":"+string(e.Metadata))
+	}
+	return out
 }
 
 // Prevent unused import error — errors is used in fakeStore implementations.

--- a/backend/internal/web/web_test.go
+++ b/backend/internal/web/web_test.go
@@ -42,11 +42,16 @@ var testSecret = []byte("web-test-secret-32-bytes!!!!!!!")
 
 // ---- fake store ----------------------------------------------------------------
 
-// fakeStore implements just the two store methods the web package calls so
-// tests can run without a database.
+// fakeStore implements the store methods the web package calls so tests can
+// run without a database.
 type fakeStore struct {
-	physicians map[string]store.Physician // keyed by email
-	patients   map[string]store.Patient   // keyed by email
+	physicians      map[string]store.Physician      // keyed by email
+	patients        map[string]store.Patient        // keyed by email
+	panelPatients   []store.Patient                 // returned by ListPatientsByPhysician
+	queueRecs       []store.Recommendation          // returned by ListRecommendationsByPhysician
+	// physicianForPanel / Rec scoping: keyed by physician id string
+	panelByPhys     map[string][]store.Patient
+	recsByPhys      map[string][]store.Recommendation
 }
 
 func (f *fakeStore) GetPhysicianByEmail(_ context.Context, tenant store.TenantID, email string) (store.Physician, error) {
@@ -65,11 +70,69 @@ func (f *fakeStore) GetPatientByEmail(_ context.Context, tenant store.TenantID, 
 	return p, nil
 }
 
+// ListPatientsByPhysician returns patients scoped to tenant + physicianID.
+// Uses panelByPhys if populated, otherwise falls back to panelPatients for
+// simple tests that only have one physician.
+func (f *fakeStore) ListPatientsByPhysician(_ context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.Patient, error) {
+	if f.panelByPhys != nil {
+		key := physicianID.String()
+		rows := f.panelByPhys[key]
+		// Enforce tenant isolation: return only patients with matching tenant.
+		var out []store.Patient
+		for _, p := range rows {
+			if p.TenantID == tenant {
+				out = append(out, p)
+			}
+		}
+		return out, nil
+	}
+	// Simple fallback: filter panelPatients by tenant.
+	var out []store.Patient
+	for _, p := range f.panelPatients {
+		if p.TenantID == tenant {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// ListRecommendationsByPhysician returns PENDING_REVIEW recs scoped to
+// tenant + physicianID. Uses recsByPhys if populated.
+func (f *fakeStore) ListRecommendationsByPhysician(_ context.Context, tenant store.TenantID, physicianID uuid.UUID, state string) ([]store.Recommendation, error) {
+	if f.recsByPhys != nil {
+		key := physicianID.String()
+		rows := f.recsByPhys[key]
+		var out []store.Recommendation
+		for _, r := range rows {
+			if r.TenantID == tenant && r.State == state {
+				out = append(out, r)
+			}
+		}
+		return out, nil
+	}
+	// Simple fallback: filter queueRecs by tenant and state.
+	var out []store.Recommendation
+	for _, r := range f.queueRecs {
+		if r.TenantID == tenant && r.State == state {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
 // storeAdapter wraps fakeStore to satisfy the web.StoreQuerier interface.
 type storeAdapter struct{ f *fakeStore }
 
 func (a *storeAdapter) GetPhysicianByEmail(ctx context.Context, t store.TenantID, e string) (store.Physician, error) {
 	return a.f.GetPhysicianByEmail(ctx, t, e)
+}
+
+func (a *storeAdapter) ListPatientsByPhysician(ctx context.Context, t store.TenantID, physicianID uuid.UUID) ([]store.Patient, error) {
+	return a.f.ListPatientsByPhysician(ctx, t, physicianID)
+}
+
+func (a *storeAdapter) ListRecommendationsByPhysician(ctx context.Context, t store.TenantID, physicianID uuid.UUID, state string) ([]store.Recommendation, error) {
+	return a.f.ListRecommendationsByPhysician(ctx, t, physicianID, state)
 }
 
 // noopAuditWriter discards all audit events for tests that don't need a DB.
@@ -407,6 +470,266 @@ func assertRedirectToLogin(t *testing.T, rec *httptest.ResponseRecorder) {
 	loc := rec.Header().Get("Location")
 	if !strings.Contains(loc, "/web/login") {
 		t.Errorf("expected redirect to /web/login, got %q", loc)
+	}
+}
+
+// ---- panel tests ----------------------------------------------------------------
+
+// testPhysID2 / testTenantID2 represent a second physician in a second tenant
+// used to verify isolation.
+var (
+	testTenantID2 = store.TenantID(uuid.MustParse("dddddddd-0000-0000-0000-000000000004"))
+	testPhysID2   = uuid.MustParse("eeeeeeee-0000-0000-0000-000000000005")
+	testPatientID2 = uuid.MustParse("ffffffff-0000-0000-0000-000000000006")
+)
+
+// TestPanel_Unauthenticated verifies that GET /web/panel without a session
+// cookie redirects to the login form.
+func TestPanel_Unauthenticated(t *testing.T) {
+	h := buildHandler(t, &fakeStore{physicians: map[string]store.Physician{}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/panel", nil)
+	h.ServeHTTP(rec, req)
+	assertRedirectToLogin(t, rec)
+}
+
+// TestPanel_NonPhysician verifies that a patient JWT is rejected for /web/panel.
+func TestPanel_NonPhysician(t *testing.T) {
+	h := buildHandler(t, &fakeStore{physicians: map[string]store.Physician{}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/panel", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPatientID, "patient"))
+	h.ServeHTTP(rec, req)
+	assertRedirectToLogin(t, rec)
+}
+
+// TestPanel_ShowsOnlySessionPhysicianPatients verifies that GET /web/panel
+// renders only the care-relationship patients for the session physician, and
+// does NOT render patients belonging to a second physician in another tenant.
+func TestPanel_ShowsOnlySessionPhysicianPatients(t *testing.T) {
+	phys1Patient := store.Patient{
+		ID:       testPatientID,
+		TenantID: testTenantID,
+		FullName: "Alice Smith",
+		State:    "CA",
+	}
+	phys2Patient := store.Patient{
+		ID:       testPatientID2,
+		TenantID: testTenantID2,
+		FullName: "Bob Jones",
+		State:    "NY",
+	}
+
+	fs := &fakeStore{
+		physicians: map[string]store.Physician{},
+		panelByPhys: map[string][]store.Patient{
+			testPhysID.String():  {phys1Patient},
+			testPhysID2.String(): {phys2Patient},
+		},
+	}
+
+	h := buildHandler(t, fs)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/panel", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Alice Smith") {
+		t.Error("panel must show phys1's patient (Alice Smith)")
+	}
+	// Bob Jones belongs to testPhysID2 under testTenantID2; must not appear.
+	if strings.Contains(body, "Bob Jones") {
+		t.Error("panel must NOT show another physician's patient (Bob Jones)")
+	}
+}
+
+// TestPanel_EmptyPanel verifies that an empty panel renders without error.
+func TestPanel_EmptyPanel(t *testing.T) {
+	fs := &fakeStore{
+		physicians:  map[string]store.Physician{},
+		panelPatients: nil,
+	}
+	h := buildHandler(t, fs)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/panel", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "No active patients") {
+		t.Error("empty panel must show the empty-state message")
+	}
+}
+
+// ---- queue tests ----------------------------------------------------------------
+
+// TestQueue_Unauthenticated verifies that GET /web/queue without a session
+// cookie redirects to the login form.
+func TestQueue_Unauthenticated(t *testing.T) {
+	h := buildHandler(t, &fakeStore{physicians: map[string]store.Physician{}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/queue", nil)
+	h.ServeHTTP(rec, req)
+	assertRedirectToLogin(t, rec)
+}
+
+// TestQueue_NonPhysician verifies that a patient JWT is rejected for /web/queue.
+func TestQueue_NonPhysician(t *testing.T) {
+	h := buildHandler(t, &fakeStore{physicians: map[string]store.Physician{}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/queue", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPatientID, "patient"))
+	h.ServeHTTP(rec, req)
+	assertRedirectToLogin(t, rec)
+}
+
+// TestQueue_ShowsOnlySessionPhysicianRecs verifies that GET /web/queue renders
+// PENDING_REVIEW recommendations for the session physician only, and does NOT
+// render recommendations belonging to a second physician in another tenant.
+func TestQueue_ShowsOnlySessionPhysicianRecs(t *testing.T) {
+	phys1Rec := store.Recommendation{
+		ID:          uuid.MustParse("11111111-0000-0000-0000-000000000001"),
+		TenantID:    testTenantID,
+		PatientID:   testPatientID,
+		State:       "PENDING_REVIEW",
+		PayloadType: "guidance",
+		DraftContent: "Rest and hydrate",
+	}
+	phys2Rec := store.Recommendation{
+		ID:          uuid.MustParse("22222222-0000-0000-0000-000000000002"),
+		TenantID:    testTenantID2,
+		PatientID:   testPatientID2,
+		State:       "PENDING_REVIEW",
+		PayloadType: "prescription",
+		DraftContent: "Take ibuprofen",
+	}
+
+	fs := &fakeStore{
+		physicians: map[string]store.Physician{},
+		recsByPhys: map[string][]store.Recommendation{
+			testPhysID.String():  {phys1Rec},
+			testPhysID2.String(): {phys2Rec},
+		},
+	}
+
+	h := buildHandler(t, fs)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/queue", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Rest and hydrate") {
+		t.Error("queue must show phys1's recommendation draft")
+	}
+	// Take ibuprofen belongs to testPhysID2 / testTenantID2; must not appear.
+	if strings.Contains(body, "Take ibuprofen") {
+		t.Error("queue must NOT show another physician's recommendation")
+	}
+}
+
+// TestQueue_OnlyPendingReview verifies that the queue does not surface
+// recommendations in other states (DRAFT, APPROVED, etc.) even if the fake
+// returns them mixed — i.e. the fake enforces the state filter and the
+// handler passes the correct state argument.
+func TestQueue_OnlyPendingReview(t *testing.T) {
+	pending := store.Recommendation{
+		ID:          uuid.MustParse("33333333-0000-0000-0000-000000000003"),
+		TenantID:    testTenantID,
+		PatientID:   testPatientID,
+		State:       "PENDING_REVIEW",
+		PayloadType: "guidance",
+		DraftContent: "Drink water",
+	}
+	draft := store.Recommendation{
+		ID:          uuid.MustParse("44444444-0000-0000-0000-000000000004"),
+		TenantID:    testTenantID,
+		PatientID:   testPatientID,
+		State:       "DRAFT",
+		PayloadType: "guidance",
+		DraftContent: "This is a draft",
+	}
+
+	// Use simple queueRecs fallback — the fake filters by state.
+	fs := &fakeStore{
+		physicians: map[string]store.Physician{},
+		queueRecs:  []store.Recommendation{pending, draft},
+	}
+
+	h := buildHandler(t, fs)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/queue", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Drink water") {
+		t.Error("queue must show PENDING_REVIEW recommendation")
+	}
+	if strings.Contains(body, "This is a draft") {
+		t.Error("queue must NOT show DRAFT recommendation")
+	}
+}
+
+// TestQueue_EmptyQueue verifies that an empty queue renders without error.
+func TestQueue_EmptyQueue(t *testing.T) {
+	fs := &fakeStore{
+		physicians: map[string]store.Physician{},
+		queueRecs:  nil,
+	}
+	h := buildHandler(t, fs)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/queue", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "No pending recommendations") {
+		t.Error("empty queue must show the empty-state message")
+	}
+}
+
+// TestNavLinks_PanelAndQueue verifies that the layout nav includes links to
+// both /web/panel and /web/queue when viewing authenticated pages.
+func TestNavLinks_PanelAndQueue(t *testing.T) {
+	fs := &fakeStore{
+		physicians: map[string]store.Physician{},
+		panelPatients: nil,
+	}
+	h := buildHandler(t, fs)
+
+	for _, path := range []string{"/web/panel", "/web/queue"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: want 200, got %d", path, rec.Code)
+		}
+		body := rec.Body.String()
+		if !strings.Contains(body, `href="/web/panel"`) {
+			t.Errorf("%s: page must contain nav link to /web/panel", path)
+		}
+		if !strings.Contains(body, `href="/web/queue"`) {
+			t.Errorf("%s: page must contain nav link to /web/queue", path)
+		}
 	}
 }
 

--- a/backend/internal/web/web_test.go
+++ b/backend/internal/web/web_test.go
@@ -1201,6 +1201,77 @@ func auditEventSummary(fs *fakeStore) []string {
 	return out
 }
 
+// TestReview_PhysicianNotFound verifies that when the session actor's physician
+// record cannot be resolved (review.ErrActorNotFound), the web handler redirects
+// to /web/login (treating it as an auth anomaly, not a normal 404).
+func TestReview_PhysicianNotFound(t *testing.T) {
+	// Build a store where the recommendation exists but the physician record does
+	// not (physByID is empty → GetPhysician returns ErrNotFound → ErrActorNotFound).
+	patient := store.Patient{
+		ID:       testPatientID,
+		TenantID: testTenantID,
+		State:    "CA",
+	}
+	rec := store.Recommendation{
+		ID:           testRecID,
+		TenantID:     testTenantID,
+		PatientID:    testPatientID,
+		State:        domain.StatePendingReview,
+		PayloadType:  "guidance",
+		DraftContent: "Drink water",
+	}
+	fs := &fakeStore{
+		physicians:   map[string]store.Physician{},
+		physByID:     map[uuid.UUID]store.Physician{}, // empty → GetPhysician returns ErrNotFound
+		patientsByID: map[uuid.UUID]store.Patient{testPatientID: patient},
+		recsByID:     map[uuid.UUID]store.Recommendation{testRecID: rec},
+		recsByPhys: map[string][]store.Recommendation{
+			testPhysID.String(): {rec},
+		},
+		updatedStates: make(map[uuid.UUID]string),
+	}
+
+	h := buildHandler(t, fs)
+	resp := postReview(t, h, testRecID, domain.ActionApprove, "")
+
+	// Physician-not-found is an auth/session anomaly → redirect to login.
+	if resp.Code != http.StatusSeeOther && resp.Code != http.StatusFound {
+		t.Fatalf("physician not found: want redirect (302/303), got %d", resp.Code)
+	}
+	loc := resp.Header().Get("Location")
+	if !strings.Contains(loc, "/web/login") {
+		t.Fatalf("physician not found: expected redirect to /web/login, got %q", loc)
+	}
+	// State must not have been mutated.
+	if _, changed := fs.updatedStates[testRecID]; changed {
+		t.Error("physician not found: state must not be mutated")
+	}
+}
+
+// TestReview_ExactlyOneAuditEvent verifies that a successful web review
+// produces exactly ONE recommendation.reviewed audit event — the atomic event
+// written by review.Execute — and not a second out-of-transaction event.
+func TestReview_ExactlyOneAuditEvent(t *testing.T) {
+	fs := newFakeStoreForReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+
+	resp := postReview(t, h, testRecID, domain.ActionApprove, "")
+	if resp.Code != http.StatusSeeOther {
+		t.Fatalf("approve: want 303, got %d (body: %s)", resp.Code, resp.Body.String())
+	}
+
+	var count int
+	for _, e := range fs.auditEvents {
+		if e.EventType == "recommendation.reviewed" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 recommendation.reviewed audit event, got %d (events: %v)",
+			count, auditEventSummary(fs))
+	}
+}
+
 // Prevent unused import error — errors is used in fakeStore implementations.
 var _ = errors.New
 var _ = fmt.Sprintf

--- a/backend/internal/web/web_test.go
+++ b/backend/internal/web/web_test.go
@@ -1,0 +1,415 @@
+package web_test
+
+// web_test.go — httptest-based tests for the physician web app (task 5.1).
+//
+// Tests that do NOT need a real database use a fake store (fakeStore below)
+// so they run without TEST_DATABASE_URL.  The DB-bound tests follow the same
+// skip-when-unset pattern used by the rest of the backend test suite.
+//
+// Covered:
+//   - TestLoginForm_GET               — GET /web/login returns 200 with a form
+//   - TestLoginSubmit_MissingFields    — POST /web/login with blank fields → 400
+//   - TestLoginSubmit_BadTenantID      — POST /web/login with garbled tenant_id → 400
+//   - TestLoginSubmit_InvalidCreds     — POST /web/login bad password → 401, opaque
+//   - TestLoginSubmit_PatientCreds     — POST /web/login with patient actor → 401
+//   - TestLoginSubmit_Success          — POST /web/login ok → 303, HttpOnly cookie set
+//   - TestRequireWebAuth_NoCookie      — authenticated route without cookie → redirect login
+//   - TestRequireWebAuth_BadCookie     — authenticated route with tampered JWT → redirect login
+//   - TestRequireWebAuth_NonPhysician  — authenticated route with patient JWT → redirect login
+//   - TestRequireWebAuth_ValidPhysician — authenticated route with valid physician JWT → 200
+//   - TestMiddlewareExtractsTenantAndIdentity — claims extracted into context correctly
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/markolonius/housecall/backend/internal/store"
+	"github.com/markolonius/housecall/backend/internal/web"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// testSecret is the HMAC key used across all in-memory tests.
+var testSecret = []byte("web-test-secret-32-bytes!!!!!!!")
+
+// ---- fake store ----------------------------------------------------------------
+
+// fakeStore implements just the two store methods the web package calls so
+// tests can run without a database.
+type fakeStore struct {
+	physicians map[string]store.Physician // keyed by email
+	patients   map[string]store.Patient   // keyed by email
+}
+
+func (f *fakeStore) GetPhysicianByEmail(_ context.Context, tenant store.TenantID, email string) (store.Physician, error) {
+	p, ok := f.physicians[email]
+	if !ok || p.TenantID != tenant {
+		return store.Physician{}, store.ErrNotFound
+	}
+	return p, nil
+}
+
+func (f *fakeStore) GetPatientByEmail(_ context.Context, tenant store.TenantID, email string) (store.Patient, error) {
+	p, ok := f.patients[email]
+	if !ok || p.TenantID != tenant {
+		return store.Patient{}, store.ErrNotFound
+	}
+	return p, nil
+}
+
+// storeAdapter wraps fakeStore to satisfy the web.StoreQuerier interface.
+type storeAdapter struct{ f *fakeStore }
+
+func (a *storeAdapter) GetPhysicianByEmail(ctx context.Context, t store.TenantID, e string) (store.Physician, error) {
+	return a.f.GetPhysicianByEmail(ctx, t, e)
+}
+
+// noopAuditWriter discards all audit events for tests that don't need a DB.
+type noopAuditWriter struct{}
+
+func (n *noopAuditWriter) Write(_ context.Context, _ store.TenantID, _ string, _ *uuid.UUID, _ string, _ map[string]any) {
+}
+
+// ---- test helpers ---------------------------------------------------------------
+
+func mustHashPassword(t *testing.T, password string) string {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	return string(h)
+}
+
+// buildHandler creates a web.Handler backed by the given fakeStore and mounts
+// it on a fresh chi router, returning the router ready for httptest.
+func buildHandler(t *testing.T, fs *fakeStore) http.Handler {
+	t.Helper()
+	h, err := web.NewWithQuerier(&storeAdapter{fs}, testSecret, &noopAuditWriter{})
+	if err != nil {
+		t.Fatalf("web.NewWithQuerier: %v", err)
+	}
+	r := chi.NewRouter()
+	h.Mount(r)
+	return r
+}
+
+// makeCookie issues a signed session cookie for the given claims without
+// going through the login form, so auth-middleware tests can inject cookies
+// directly.
+func makeCookie(t *testing.T, tenantID store.TenantID, actorID uuid.UUID, actorType string) *http.Cookie {
+	t.Helper()
+	token, err := web.IssueTestToken(testSecret, tenantID, actorID, actorType)
+	if err != nil {
+		t.Fatalf("issue test token: %v", err)
+	}
+	return &http.Cookie{Name: "hc_session", Value: token}
+}
+
+func makeExpiredCookie(t *testing.T, tenantID store.TenantID, actorID uuid.UUID, actorType string) *http.Cookie {
+	t.Helper()
+	token, err := web.IssueTestTokenWithTTL(testSecret, tenantID, actorID, actorType, -time.Minute)
+	if err != nil {
+		t.Fatalf("issue expired test token: %v", err)
+	}
+	return &http.Cookie{Name: "hc_session", Value: token}
+}
+
+// ---- tests -----------------------------------------------------------------------
+
+var (
+	testTenantID  = store.TenantID(uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001"))
+	testPhysID    = uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000002")
+	testPatientID = uuid.MustParse("cccccccc-0000-0000-0000-000000000003")
+)
+
+func newFakeStoreWithPhysician(t *testing.T, password string) *fakeStore {
+	return &fakeStore{
+		physicians: map[string]store.Physician{
+			"doc@clinic.example": {
+				ID:           testPhysID,
+				TenantID:     testTenantID,
+				Email:        "doc@clinic.example",
+				PasswordHash: mustHashPassword(t, password),
+			},
+		},
+	}
+}
+
+// TestLoginForm_GET verifies that GET /web/login returns 200 and renders an HTML form.
+func TestLoginForm_GET(t *testing.T) {
+	h := buildHandler(t, &fakeStore{physicians: map[string]store.Physician{}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/login", nil)
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "<form") {
+		t.Error("expected a <form> element in the login page")
+	}
+	if !strings.Contains(body, "tenant_id") {
+		t.Error("expected tenant_id field in the login page")
+	}
+}
+
+// TestLoginSubmit_MissingFields verifies that a POST with blank fields returns 400.
+func TestLoginSubmit_MissingFields(t *testing.T) {
+	h := buildHandler(t, &fakeStore{})
+	form := url.Values{"tenant_id": {""}, "email": {""}, "password": {""}}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/web/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+// TestLoginSubmit_BadTenantID verifies that a non-UUID tenant_id returns 400.
+func TestLoginSubmit_BadTenantID(t *testing.T) {
+	h := buildHandler(t, &fakeStore{})
+	form := url.Values{"tenant_id": {"not-a-uuid"}, "email": {"doc@clinic.example"}, "password": {"secret"}}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/web/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+// TestLoginSubmit_InvalidCreds verifies that wrong password returns 401 with an
+// opaque message (no enumeration hint).
+func TestLoginSubmit_InvalidCreds(t *testing.T) {
+	h := buildHandler(t, newFakeStoreWithPhysician(t, "correct-password"))
+	form := url.Values{
+		"tenant_id": {testTenantID.String()},
+		"email":     {"doc@clinic.example"},
+		"password":  {"wrong-password"},
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/web/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "doc@clinic.example") {
+		t.Error("response must not echo back the email (enumeration risk)")
+	}
+}
+
+// TestLoginSubmit_UnknownEmail verifies that an unknown email returns 401 with the
+// same opaque message (prevents account enumeration).
+func TestLoginSubmit_UnknownEmail(t *testing.T) {
+	h := buildHandler(t, newFakeStoreWithPhysician(t, "correct-password"))
+	form := url.Values{
+		"tenant_id": {testTenantID.String()},
+		"email":     {"unknown@clinic.example"},
+		"password":  {"correct-password"},
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/web/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", rec.Code)
+	}
+}
+
+// TestLoginSubmit_Success verifies that correct physician credentials:
+//   - Return a 303 redirect to /web/queue
+//   - Set a session cookie that is HttpOnly
+func TestLoginSubmit_Success(t *testing.T) {
+	const password = "Str0ng!Password#99"
+	h := buildHandler(t, newFakeStoreWithPhysician(t, password))
+	form := url.Values{
+		"tenant_id": {testTenantID.String()},
+		"email":     {"doc@clinic.example"},
+		"password":  {password},
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/web/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("want 303, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/web/queue" {
+		t.Fatalf("want redirect to /web/queue, got %q", loc)
+	}
+
+	// Find the session cookie.
+	var sessionCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hc_session" {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("expected hc_session cookie to be set")
+	}
+	if !sessionCookie.HttpOnly {
+		t.Error("session cookie must be HttpOnly")
+	}
+	if !sessionCookie.Secure {
+		t.Error("session cookie must be Secure")
+	}
+	if sessionCookie.SameSite != http.SameSiteLaxMode && sessionCookie.SameSite != http.SameSiteStrictMode {
+		t.Errorf("session cookie SameSite must be Lax or Strict, got %v", sessionCookie.SameSite)
+	}
+	if sessionCookie.Value == "" {
+		t.Error("session cookie must carry a token value")
+	}
+}
+
+// TestRequireWebAuth_NoCookie verifies that an unauthenticated request to a
+// protected route redirects to the login form.
+func TestRequireWebAuth_NoCookie(t *testing.T) {
+	h := buildHandlerWithProtectedRoute(t, &fakeStore{physicians: map[string]store.Physician{}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/protected", nil)
+	h.ServeHTTP(rec, req)
+	assertRedirectToLogin(t, rec)
+}
+
+// TestRequireWebAuth_BadCookie verifies that a tampered JWT redirects to login.
+func TestRequireWebAuth_BadCookie(t *testing.T) {
+	h := buildHandlerWithProtectedRoute(t, &fakeStore{physicians: map[string]store.Physician{}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/protected", nil)
+	req.AddCookie(&http.Cookie{Name: "hc_session", Value: "tampered.header.value"})
+	h.ServeHTTP(rec, req)
+	assertRedirectToLogin(t, rec)
+}
+
+// TestRequireWebAuth_ExpiredCookie verifies that an expired JWT redirects to login
+// and clears the stale cookie.
+func TestRequireWebAuth_ExpiredCookie(t *testing.T) {
+	h := buildHandlerWithProtectedRoute(t, &fakeStore{physicians: map[string]store.Physician{}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/protected", nil)
+	req.AddCookie(makeExpiredCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rec, req)
+	assertRedirectToLogin(t, rec)
+
+	// Expired cookie should be cleared (MaxAge < 0 or empty value).
+	cleared := false
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hc_session" && (c.MaxAge < 0 || c.Value == "") {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Error("expected stale hc_session cookie to be cleared on expiry redirect")
+	}
+}
+
+// TestRequireWebAuth_NonPhysician verifies that a valid JWT for a patient
+// (non-physician actor) is rejected with a redirect to login.
+func TestRequireWebAuth_NonPhysician(t *testing.T) {
+	h := buildHandlerWithProtectedRoute(t, &fakeStore{physicians: map[string]store.Physician{}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/protected", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPatientID, "patient"))
+	h.ServeHTTP(rec, req)
+	assertRedirectToLogin(t, rec)
+}
+
+// TestRequireWebAuth_ValidPhysician verifies that a valid physician JWT reaches
+// the protected handler (returns 200).
+func TestRequireWebAuth_ValidPhysician(t *testing.T) {
+	h := buildHandlerWithProtectedRoute(t, &fakeStore{physicians: map[string]store.Physician{}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/protected", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+}
+
+// TestMiddlewareExtractsTenantAndIdentity verifies that requireWebAuth injects
+// the correct tenant_id and actor_id into the request context.
+func TestMiddlewareExtractsTenantAndIdentity(t *testing.T) {
+	var gotClaims web.WebClaims
+	var claimsOK bool
+
+	// Build the middleware-only handler directly (no Mount, no chi router needed).
+	inner := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotClaims, claimsOK = web.WebClaimsFromCtx(req.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+	h := buildProtectedHandler(t, &fakeStore{}, inner)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/probe", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	if !claimsOK {
+		t.Fatal("claims were not injected into context")
+	}
+	if gotClaims.TenantID != testTenantID {
+		t.Errorf("want tenant %s, got %s", testTenantID, gotClaims.TenantID)
+	}
+	if gotClaims.ActorID != testPhysID {
+		t.Errorf("want actorID %s, got %s", testPhysID, gotClaims.ActorID)
+	}
+	if gotClaims.ActorType != "physician" {
+		t.Errorf("want actorType physician, got %s", gotClaims.ActorType)
+	}
+}
+
+// ---- helpers for protected route tests ------------------------------------------
+
+// buildProtectedHandler wraps inner with the requireWebAuth middleware from a
+// freshly constructed Handler, without mounting any chi router.
+func buildProtectedHandler(t *testing.T, fs *fakeStore, inner http.Handler) http.Handler {
+	t.Helper()
+	h, err := web.NewWithQuerier(&storeAdapter{fs}, testSecret, &noopAuditWriter{})
+	if err != nil {
+		t.Fatalf("web.NewWithQuerier: %v", err)
+	}
+	return web.ExportedRequireWebAuth(h)(inner)
+}
+
+// buildHandlerWithProtectedRoute wraps a 200-OK handler with requireWebAuth.
+// It does NOT call h.Mount so there is no chi router path conflict.
+func buildHandlerWithProtectedRoute(t *testing.T, fs *fakeStore) http.Handler {
+	t.Helper()
+	return buildProtectedHandler(t, fs, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func assertRedirectToLogin(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if rec.Code != http.StatusSeeOther && rec.Code != http.StatusFound {
+		t.Fatalf("expected redirect (302/303), got %d", rec.Code)
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.Contains(loc, "/web/login") {
+		t.Errorf("expected redirect to /web/login, got %q", loc)
+	}
+}
+
+// Prevent unused import error — errors is used in fakeStore implementations.
+var _ = errors.New
+var _ = fmt.Sprintf

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -133,8 +133,8 @@ a forced model failure produces no recommendation and an audit event.
 - [x] Base `html/template` layout
 
 ### Task 5.2: Panel & queue
-- [ ] `GET /panel` — the physician's active care relationships
-- [ ] `GET /queue` — `PENDING_REVIEW` recommendations for their patients only
+- [x] `GET /panel` — the physician's active care relationships
+- [x] `GET /queue` — `PENDING_REVIEW` recommendations for their patients only
 
 ### Task 5.3: Review actions
 - [ ] `approve` / `reject` / `modify` (htmx) → Core API review endpoint

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -137,8 +137,8 @@ a forced model failure produces no recommendation and an audit event.
 - [x] `GET /queue` — `PENDING_REVIEW` recommendations for their patients only
 
 ### Task 5.3: Review actions
-- [ ] `approve` / `reject` / `modify` (htmx) → Core API review endpoint
-- [ ] `modify` allows editing `final_content` before delivery
+- [x] `approve` / `reject` / `modify` (htmx) → Core API review endpoint
+- [x] `modify` allows editing `final_content` before delivery
 
 **Validation**: a physician can log in, see only their patients' pending
 recommendations, and drive each of the three actions.

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -129,8 +129,8 @@ a forced model failure produces no recommendation and an audit event.
 ## Phase 5: Physician Web App
 
 ### Task 5.1: Auth & shell
-- [ ] `internal/web` — login form, session cookie wrapping the JWT
-- [ ] Base `html/template` layout
+- [x] `internal/web` — login form, session cookie wrapping the JWT
+- [x] Base `html/template` layout
 
 ### Task 5.2: Panel & queue
 - [ ] `GET /panel` — the physician's active care relationships


### PR DESCRIPTION
## Phase 5 — Physician Web App

Server-rendered, physician-only web app in `backend/internal/web`: login + session, patient panel, pending-review queue, and the approve/reject/modify review actions — all driving the same domain state machine the Core API uses.

### Tasks (all tester PASS + reviewer APPROVE)
- [x] **5.1 Auth & shell** — `internal/web` login form, JWT session cookie (HttpOnly/Secure/SameSite), `html/template` base layout, physician-only `requireWebAuth` middleware
- [x] **5.2 Panel & queue** — `GET /web/panel` (active care relationships), `GET /web/queue` (`PENDING_REVIEW` recs), both physician+tenant scoped via `ListPatientsByPhysician` / `ListRecommendationsByPhysician`
- [x] **5.3 Review actions** — `approve` / `reject` / `modify` posted from the queue; `modify` edits `final_content` before delivery

### Design highlight — shared review path (no state-machine drift)
5.3 extracted a transport-agnostic `internal/review.Execute` that **both** the Core API handler and the web handler call. Added `store.TxWriter`/`TxnW` so the atomic state+audit transaction stays testable without a DB. The API's observable behavior (status codes, opaque errors, single atomic `recommendation.reviewed` audit event) is unchanged.

### Clinical invariants preserved
- Tenant + physician isolation: recommendations resolved via `GetRecommendationForPhysician` (care-relationship JOIN, 404 if not their patient); tenant_id + physician_id only from the verified session.
- State machine: every transition via `domain.Transition`; `DELIVERED` only from `APPROVED`/`MODIFIED`; patient-visible `final_content` set only on the delivering write.
- State-licensing: physician unlicensed in the patient's state → rejected, state unchanged, audit written.
- Atomic state change + audit in one `TxnW`; exactly one `recommendation.reviewed` event per review.
- No PHI in logs or audit metadata (ids/enums only); `html/template` auto-escaping intact; session/JWT verification not weakened.

### Validation
- `go build ./... && go vet ./...` clean
- Full suite **227 tests pass**; `-race` clean on `internal/web`, `internal/review`, `internal/api`
- DB-bound API review tests run against the test Postgres (incl. `TestHandler_UnlicensedPhysicianReview_IsAudited`, `TestHandler_PhysicianNotFound_Returns403`)

### Beads closed
- HouseCall-8z9 (5.1) — issue #29
- HouseCall-j41 (5.2) — issue #28
- HouseCall-vq9 (5.3) — issue #27

### Reviewer follow-ups filed (non-blocking, deferred)
- Extract a shared `jwtutil` package so web stops reimplementing the API's HS256 verify (do before Phase 6 iOS adds a third token consumer); switch both verifiers to `hmac.Equal`.
- Stop selecting `password_hash` into the web panel read model (credential-adjacent field in template context; not rendered today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)