### PR TITLE
Web hardening: shared jwtutil (#55) + slim panel read model (#56)

### DIFF
--- a/backend/internal/api/jwt.go
+++ b/backend/internal/api/jwt.go
@@ -1,74 +1,34 @@
 package api
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/json"
-	"errors"
-	"strings"
 	"time"
+
+	"github.com/markolonius/housecall/backend/internal/jwtutil"
 )
 
 const tokenTTL = 24 * time.Hour
 
-var errInvalidToken = errors.New("api: invalid token")
+// errInvalidToken is an alias of the shared sentinel so existing api code and
+// errors.Is checks keep working unchanged.
+var errInvalidToken = jwtutil.ErrInvalidToken
 
-// rawClaims is the JSON representation stored in the JWT payload. Field names
-// are kept short to minimise token size.
-type rawClaims struct {
-	TenantID  string `json:"tid"`
-	ActorID   string `json:"sub"`
-	ActorType string `json:"act"` // "patient" | "physician"
-	Exp       int64  `json:"exp"`
-}
+// rawClaims is the JWT payload shape. It aliases jwtutil.Claims so the API and
+// the web app share one definition and can never drift apart.
+type rawClaims = jwtutil.Claims
 
-// issueToken creates an HS256 JWT containing the supplied claims. It uses
-// only stdlib crypto — the Cognito JWKS swap (production) replaces
-// verifyToken without touching issueToken or any domain code.
+// issueToken creates an HS256 JWT containing the supplied claims, delegating to
+// the shared jwtutil implementation. The Cognito JWKS swap (production)
+// replaces verifyToken without touching issueToken or any domain code.
 func issueToken(secret []byte, c AuthClaims) (string, error) {
-	rc := rawClaims{
+	return jwtutil.Issue(secret, rawClaims{
 		TenantID:  c.TenantID.String(),
 		ActorID:   c.ActorID.String(),
 		ActorType: c.ActorType,
-		Exp:       time.Now().Add(tokenTTL).Unix(),
-	}
-	hdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
-	payload, err := json.Marshal(rc)
-	if err != nil {
-		return "", err
-	}
-	enc := hdr + "." + base64.RawURLEncoding.EncodeToString(payload)
-	return enc + "." + jwtSign(secret, enc), nil
+	}, tokenTTL)
 }
 
 // verifyToken validates an HS256 JWT and returns its decoded claims. Returns
 // errInvalidToken for any tamper, format, or expiry issue.
 func verifyToken(secret []byte, token string) (rawClaims, error) {
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return rawClaims{}, errInvalidToken
-	}
-	msg := parts[0] + "." + parts[1]
-	if jwtSign(secret, msg) != parts[2] {
-		return rawClaims{}, errInvalidToken
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return rawClaims{}, errInvalidToken
-	}
-	var rc rawClaims
-	if err := json.Unmarshal(raw, &rc); err != nil {
-		return rawClaims{}, errInvalidToken
-	}
-	if time.Now().Unix() > rc.Exp {
-		return rawClaims{}, errInvalidToken
-	}
-	return rc, nil
-}
-
-func jwtSign(secret []byte, msg string) string {
-	mac := hmac.New(sha256.New, secret)
-	mac.Write([]byte(msg))
-	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return jwtutil.Verify(secret, token)
 }

--- a/backend/internal/jwtutil/jwtutil.go
+++ b/backend/internal/jwtutil/jwtutil.go
@@ -1,0 +1,78 @@
+// Package jwtutil is the single implementation of the HMAC-SHA256 (HS256) JWT
+// issue/verify used by the Core API and the physician web app. Both transports
+// import it so the token format and verification logic cannot drift apart.
+//
+// The claim schema is intentionally tiny (short field names) to keep tokens
+// small. The signing path hardcodes the {"alg":"HS256"} header, so a token can
+// never select a different algorithm; verification recomputes the HMAC and
+// compares in constant time (hmac.Equal).
+//
+// Production note: a Cognito JWKS swap replaces Verify only — Issue and the
+// rest of the codebase are unaffected.
+package jwtutil
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// ErrInvalidToken is returned for any tamper, malformed, or expired token.
+var ErrInvalidToken = errors.New("jwtutil: invalid token")
+
+// Claims is the JSON payload carried in the JWT. Field names are kept short to
+// minimise token size and MUST stay stable across both transports.
+type Claims struct {
+	TenantID  string `json:"tid"`
+	ActorID   string `json:"sub"`
+	ActorType string `json:"act"` // "patient" | "physician"
+	Exp       int64  `json:"exp"`
+}
+
+// Issue creates an HS256 JWT whose Exp is set to now+ttl. The Exp field of the
+// supplied claims is ignored and overwritten.
+func Issue(secret []byte, c Claims, ttl time.Duration) (string, error) {
+	c.Exp = time.Now().Add(ttl).Unix()
+	hdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+	enc := hdr + "." + base64.RawURLEncoding.EncodeToString(payload)
+	return enc + "." + sign(secret, enc), nil
+}
+
+// Verify validates an HS256 JWT and returns its decoded claims. It returns
+// ErrInvalidToken for any format, signature, or expiry problem.
+func Verify(secret []byte, token string) (Claims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return Claims{}, ErrInvalidToken
+	}
+	msg := parts[0] + "." + parts[1]
+	if !hmac.Equal([]byte(sign(secret, msg)), []byte(parts[2])) {
+		return Claims{}, ErrInvalidToken
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return Claims{}, ErrInvalidToken
+	}
+	var c Claims
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return Claims{}, ErrInvalidToken
+	}
+	if time.Now().Unix() > c.Exp {
+		return Claims{}, ErrInvalidToken
+	}
+	return c, nil
+}
+
+func sign(secret []byte, msg string) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(msg))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/backend/internal/jwtutil/jwtutil_test.go
+++ b/backend/internal/jwtutil/jwtutil_test.go
@@ -1,0 +1,77 @@
+package jwtutil
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+var testSecret = []byte("test-secret-key-do-not-use-in-prod")
+
+func sampleClaims() Claims {
+	return Claims{
+		TenantID:  "11111111-1111-1111-1111-111111111111",
+		ActorID:   "22222222-2222-2222-2222-222222222222",
+		ActorType: "physician",
+	}
+}
+
+func TestIssueVerify_RoundTrip(t *testing.T) {
+	tok, err := Issue(testSecret, sampleClaims(), time.Hour)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	got, err := Verify(testSecret, tok)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	want := sampleClaims()
+	if got.TenantID != want.TenantID || got.ActorID != want.ActorID || got.ActorType != want.ActorType {
+		t.Fatalf("claims = %+v, want %+v", got, want)
+	}
+	if got.Exp <= time.Now().Unix() {
+		t.Fatalf("exp not in the future: %d", got.Exp)
+	}
+}
+
+func TestVerify_WrongSecret(t *testing.T) {
+	tok, _ := Issue(testSecret, sampleClaims(), time.Hour)
+	if _, err := Verify([]byte("a-different-secret"), tok); err != ErrInvalidToken {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestVerify_Expired(t *testing.T) {
+	tok, _ := Issue(testSecret, sampleClaims(), -time.Minute)
+	if _, err := Verify(testSecret, tok); err != ErrInvalidToken {
+		t.Fatalf("want ErrInvalidToken for expired token, got %v", err)
+	}
+}
+
+func TestVerify_TamperedPayload(t *testing.T) {
+	tok, _ := Issue(testSecret, sampleClaims(), time.Hour)
+	parts := strings.Split(tok, ".")
+	// Swap in a different payload while keeping the original signature.
+	forged := "eyJ0aWQiOiJ4In0" // {"tid":"x"} base64url, no padding
+	bad := parts[0] + "." + forged + "." + parts[2]
+	if _, err := Verify(testSecret, bad); err != ErrInvalidToken {
+		t.Fatalf("want ErrInvalidToken for tampered payload, got %v", err)
+	}
+}
+
+func TestVerify_Malformed(t *testing.T) {
+	for _, tok := range []string{"", "a.b", "a.b.c.d", "not-a-token"} {
+		if _, err := Verify(testSecret, tok); err != ErrInvalidToken {
+			t.Fatalf("want ErrInvalidToken for %q, got %v", tok, err)
+		}
+	}
+}
+
+func TestVerify_BadSignatureEncoding(t *testing.T) {
+	tok, _ := Issue(testSecret, sampleClaims(), time.Hour)
+	parts := strings.Split(tok, ".")
+	bad := parts[0] + "." + parts[1] + ".####"
+	if _, err := Verify(testSecret, bad); err != ErrInvalidToken {
+		t.Fatalf("want ErrInvalidToken for bad signature, got %v", err)
+	}
+}

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -131,9 +131,12 @@ func (s *Store) CreateCareRelationship(ctx context.Context, tenant TenantID, pat
 	return cr, err
 }
 
-func (s *Store) ListPatientsByPhysician(ctx context.Context, tenant TenantID, physicianID uuid.UUID) ([]Patient, error) {
+// ListPatientsByPhysician returns the slim PanelPatient read model for the
+// physician's active care relationships. It does not select password_hash or
+// email so credentials/extra PHI never enter the web panel's template context.
+func (s *Store) ListPatientsByPhysician(ctx context.Context, tenant TenantID, physicianID uuid.UUID) ([]PanelPatient, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT p.id, p.tenant_id, p.email, p.full_name, p.state, p.password_hash, p.created_at
+		`SELECT p.id, p.tenant_id, p.full_name, p.state
 		   FROM patients p
 		   JOIN care_relationships cr
 		     ON cr.tenant_id = p.tenant_id
@@ -148,10 +151,10 @@ func (s *Store) ListPatientsByPhysician(ctx context.Context, tenant TenantID, ph
 		return nil, err
 	}
 	defer rows.Close()
-	var out []Patient
+	var out []PanelPatient
 	for rows.Next() {
-		var p Patient
-		if err := rows.Scan(&p.ID, &p.TenantID, &p.Email, &p.FullName, &p.State, &p.PasswordHash, &p.CreatedAt); err != nil {
+		var p PanelPatient
+		if err := rows.Scan(&p.ID, &p.TenantID, &p.FullName, &p.State); err != nil {
 			return nil, err
 		}
 		out = append(out, p)

--- a/backend/internal/store/types.go
+++ b/backend/internal/store/types.go
@@ -28,6 +28,17 @@ type Patient struct {
 	CreatedAt    time.Time
 }
 
+// PanelPatient is the slim read model for the physician panel. It deliberately
+// omits PasswordHash (a credential) and Email so neither can reach a
+// physician-facing template's data context — only the fields the panel renders
+// plus the ids needed for scoping/links are loaded.
+type PanelPatient struct {
+	ID       uuid.UUID
+	TenantID TenantID
+	FullName string
+	State    string
+}
+
 type Physician struct {
 	ID             uuid.UUID
 	TenantID       TenantID

--- a/backend/internal/web/export_test.go
+++ b/backend/internal/web/export_test.go
@@ -19,7 +19,7 @@ type WebClaims = webClaims
 // Exposed so web_test can supply a fake without importing store.Store.
 type StoreQuerier interface {
 	GetPhysicianByEmail(ctx context.Context, tenant store.TenantID, email string) (store.Physician, error)
-	ListPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.Patient, error)
+	ListPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.PanelPatient, error)
 	ListRecommendationsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID, state string) ([]store.Recommendation, error)
 
 	// Review action methods (task 5.3).

--- a/backend/internal/web/token.go
+++ b/backend/internal/web/token.go
@@ -1,27 +1,22 @@
 package web
 
-// token.go contains the JWT issue/verify helpers for the web package.
-// The JWT format is identical to the Core API's (api/jwt.go): HS256 with the
-// same rawClaims JSON shape, so a token issued here can be verified by the
-// Core API middleware if needed. The logic is not shared via import because
-// api.issueToken / api.verifyToken are unexported; the implementation is
-// small enough to duplicate without risk of divergence. Any future change to
-// the claim schema must be applied in both places.
+// token.go adapts the shared jwtutil HS256 JWT helpers to the web app's typed
+// session claims. The actual issue/verify logic lives in internal/jwtutil and
+// is shared with the Core API (api/jwt.go) so the token format and verification
+// cannot drift between transports.
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/json"
-	"errors"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/markolonius/housecall/backend/internal/jwtutil"
 	"github.com/markolonius/housecall/backend/internal/store"
 )
 
-var errInvalidWebToken = errors.New("web: invalid token")
+// errInvalidWebToken aliases the shared sentinel so existing web code and
+// errors.Is checks keep working unchanged.
+var errInvalidWebToken = jwtutil.ErrInvalidToken
 
 // sessionTTL mirrors the API token TTL so the cookie and the embedded JWT
 // expire together.
@@ -34,14 +29,9 @@ type webClaims struct {
 	ActorType string // always "physician" for web sessions
 }
 
-// rawWebClaims is the JSON representation stored in the JWT payload. Field
-// names match api/jwt.go rawClaims so tokens are interoperable.
-type rawWebClaims struct {
-	TenantID  string `json:"tid"`
-	ActorID   string `json:"sub"`
-	ActorType string `json:"act"`
-	Exp       int64  `json:"exp"`
-}
+// rawWebClaims is the JSON payload shape, aliased to the shared jwtutil.Claims
+// so the web app and Core API share a single definition.
+type rawWebClaims = jwtutil.Claims
 
 // issueWebToken creates an HS256 JWT with the default session TTL.
 func issueWebToken(secret []byte, c webClaims) (string, error) {
@@ -51,48 +41,15 @@ func issueWebToken(secret []byte, c webClaims) (string, error) {
 // issueWebTokenWithTTL creates an HS256 JWT that expires after ttl from now.
 // A negative ttl produces an already-expired token (useful for tests).
 func issueWebTokenWithTTL(secret []byte, c webClaims, ttl time.Duration) (string, error) {
-	rc := rawWebClaims{
+	return jwtutil.Issue(secret, rawWebClaims{
 		TenantID:  c.TenantID.String(),
 		ActorID:   c.ActorID.String(),
 		ActorType: c.ActorType,
-		Exp:       time.Now().Add(ttl).Unix(),
-	}
-	hdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
-	payload, err := json.Marshal(rc)
-	if err != nil {
-		return "", err
-	}
-	enc := hdr + "." + base64.RawURLEncoding.EncodeToString(payload)
-	return enc + "." + webJWTSign(secret, enc), nil
+	}, ttl)
 }
 
 // verifyWebToken validates an HS256 JWT and returns its decoded claims.
 // Returns errInvalidWebToken for any tamper, format, or expiry issue.
 func verifyWebToken(secret []byte, token string) (rawWebClaims, error) {
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return rawWebClaims{}, errInvalidWebToken
-	}
-	msg := parts[0] + "." + parts[1]
-	if webJWTSign(secret, msg) != parts[2] {
-		return rawWebClaims{}, errInvalidWebToken
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return rawWebClaims{}, errInvalidWebToken
-	}
-	var rc rawWebClaims
-	if err := json.Unmarshal(raw, &rc); err != nil {
-		return rawWebClaims{}, errInvalidWebToken
-	}
-	if time.Now().Unix() > rc.Exp {
-		return rawWebClaims{}, errInvalidWebToken
-	}
-	return rc, nil
-}
-
-func webJWTSign(secret []byte, msg string) string {
-	mac := hmac.New(sha256.New, secret)
-	mac.Write([]byte(msg))
-	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return jwtutil.Verify(secret, token)
 }

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -55,7 +55,7 @@ type Handler struct {
 	// test-injectable interfaces (nil in production).
 	storeQ interface {
 		GetPhysicianByEmail(ctx context.Context, tenant store.TenantID, email string) (store.Physician, error)
-		ListPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.Patient, error)
+		ListPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.PanelPatient, error)
 		ListRecommendationsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID, state string) ([]store.Recommendation, error)
 
 		// Review action methods (task 5.3). These satisfy review.Store so the
@@ -314,7 +314,7 @@ func (h *Handler) writeAudit(ctx context.Context, tenant store.TenantID, actorTy
 
 // listPatientsByPhysician routes to the test-injectable interface if set,
 // otherwise to the concrete store.
-func (h *Handler) listPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.Patient, error) {
+func (h *Handler) listPatientsByPhysician(ctx context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.PanelPatient, error) {
 	if h.storeQ != nil {
 		return h.storeQ.ListPatientsByPhysician(ctx, tenant, physicianID)
 	}
@@ -342,7 +342,7 @@ func (h *Handler) reviewStore() review.Store {
 // ---- panel handler ----
 
 type panelPageData struct {
-	Patients []store.Patient
+	Patients []store.PanelPatient
 }
 
 func (h *Handler) handlePanel(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/web/web_test.go
+++ b/backend/internal/web/web_test.go
@@ -49,10 +49,10 @@ var testSecret = []byte("web-test-secret-32-bytes!!!!!!!")
 type fakeStore struct {
 	physicians    map[string]store.Physician    // keyed by email
 	patients      map[string]store.Patient      // keyed by email
-	panelPatients []store.Patient               // returned by ListPatientsByPhysician
+	panelPatients []store.PanelPatient          // returned by ListPatientsByPhysician
 	queueRecs     []store.Recommendation        // returned by ListRecommendationsByPhysician
 	// physicianForPanel / Rec scoping: keyed by physician id string
-	panelByPhys map[string][]store.Patient
+	panelByPhys map[string][]store.PanelPatient
 	recsByPhys  map[string][]store.Recommendation
 
 	// review action support (task 5.3)
@@ -83,12 +83,12 @@ func (f *fakeStore) GetPatientByEmail(_ context.Context, tenant store.TenantID, 
 // ListPatientsByPhysician returns patients scoped to tenant + physicianID.
 // Uses panelByPhys if populated, otherwise falls back to panelPatients for
 // simple tests that only have one physician.
-func (f *fakeStore) ListPatientsByPhysician(_ context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.Patient, error) {
+func (f *fakeStore) ListPatientsByPhysician(_ context.Context, tenant store.TenantID, physicianID uuid.UUID) ([]store.PanelPatient, error) {
 	if f.panelByPhys != nil {
 		key := physicianID.String()
 		rows := f.panelByPhys[key]
 		// Enforce tenant isolation: return only patients with matching tenant.
-		var out []store.Patient
+		var out []store.PanelPatient
 		for _, p := range rows {
 			if p.TenantID == tenant {
 				out = append(out, p)
@@ -97,7 +97,7 @@ func (f *fakeStore) ListPatientsByPhysician(_ context.Context, tenant store.Tena
 		return out, nil
 	}
 	// Simple fallback: filter panelPatients by tenant.
-	var out []store.Patient
+	var out []store.PanelPatient
 	for _, p := range f.panelPatients {
 		if p.TenantID == tenant {
 			out = append(out, p)
@@ -217,7 +217,7 @@ func (a *storeAdapter) GetPhysicianByEmail(ctx context.Context, t store.TenantID
 	return a.f.GetPhysicianByEmail(ctx, t, e)
 }
 
-func (a *storeAdapter) ListPatientsByPhysician(ctx context.Context, t store.TenantID, physicianID uuid.UUID) ([]store.Patient, error) {
+func (a *storeAdapter) ListPatientsByPhysician(ctx context.Context, t store.TenantID, physicianID uuid.UUID) ([]store.PanelPatient, error) {
 	return a.f.ListPatientsByPhysician(ctx, t, physicianID)
 }
 
@@ -617,13 +617,13 @@ func TestPanel_NonPhysician(t *testing.T) {
 // renders only the care-relationship patients for the session physician, and
 // does NOT render patients belonging to a second physician in another tenant.
 func TestPanel_ShowsOnlySessionPhysicianPatients(t *testing.T) {
-	phys1Patient := store.Patient{
+	phys1Patient := store.PanelPatient{
 		ID:       testPatientID,
 		TenantID: testTenantID,
 		FullName: "Alice Smith",
 		State:    "CA",
 	}
-	phys2Patient := store.Patient{
+	phys2Patient := store.PanelPatient{
 		ID:       testPatientID2,
 		TenantID: testTenantID2,
 		FullName: "Bob Jones",
@@ -632,7 +632,7 @@ func TestPanel_ShowsOnlySessionPhysicianPatients(t *testing.T) {
 
 	fs := &fakeStore{
 		physicians: map[string]store.Physician{},
-		panelByPhys: map[string][]store.Patient{
+		panelByPhys: map[string][]store.PanelPatient{
 			testPhysID.String():  {phys1Patient},
 			testPhysID2.String(): {phys2Patient},
 		},


### PR DESCRIPTION
Two Phase 5 reviewer follow-ups (filed as #55/#56).

## #55 — Shared `internal/jwtutil` (HouseCall-08g)
Phase 5.1 left `web/token.go` reimplementing the API's HS256 issue/verify. Extracted a single `internal/jwtutil` package that **both** `internal/api` and `internal/web` import, so token format + verification can't drift — and Phase 6 (iOS sync), a third token consumer, gets one definition.
- `api.rawClaims` and `web.rawWebClaims` are now type aliases of `jwtutil.Claims`; all callers/tests unchanged.
- Signature comparison switched to `hmac.Equal` (constant-time) in the shared verifier — closes the timing-compare nit flagged in both prior reviews.
- New `jwtutil` tests: round-trip, expiry, tampered payload, wrong secret, malformed, bad-signature encoding.

## #56 — Slim `PanelPatient` read model (HouseCall-p10)
`ListPatientsByPhysician` (web-panel only) selected `password_hash` into `store.Patient`, putting a bcrypt credential into the physician panel template's data context (not rendered today, but a future `{{.PasswordHash}}` would leak it).
- New `store.PanelPatient{ID, TenantID, FullName, State}`; the query now selects only those columns — neither the credential **nor patient email** reaches template context (extra PHI minimization).
- `ListPatientsByPhysician` returns `[]store.PanelPatient`; web interface/handler/tests updated.

## Validation
- `go build ./... && go vet ./...` clean
- Full suite green (jwtutil, api, web, store, domain, review, agent); `-race` clean on jwtutil/api/web/store
- Tenant isolation tests (store + web panel) still pass

Closes #55, closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)