### PR TITLE
add-cloud-platform-mvp: Phase 6 — iOS Cloud Sync

### DIFF
--- a/HouseCall/Core/Security/KeychainManager.swift
+++ b/HouseCall/Core/Security/KeychainManager.swift
@@ -49,6 +49,9 @@ class KeychainManager {
         static let sessionToken = "com.housecall.session-token"
         static let biometricEnrollment = "com.housecall.biometric-enrollment"
         static let authMethod = "com.housecall.auth-method"
+        /// Core API JWT (Phase 6 cloud sync).  Stored as a UTF-8 string.
+        /// Never logged or placed in UserDefaults.
+        static let coreAPIJWT = "com.housecall.core-api-jwt"
     }
 
     init() {}

--- a/HouseCall/Core/Services/AIConversationService.swift
+++ b/HouseCall/Core/Services/AIConversationService.swift
@@ -3,11 +3,20 @@
 //  HouseCall
 //
 //  AI Conversation Service - Business Logic Layer
-//  Orchestrates LLM provider interactions with conversation persistence
+//  Orchestrates message persistence and cloud sync (Phase 6.3).
+//
+//  When a CloudSyncCoordinator is injected the send path becomes:
+//    1. Persist user message locally (syncState = "pending")
+//    2. POST to Core API via coordinator — on success: synced + serverId
+//    3. AI reply arrives async via WebSocket (recommendation.delivered)
+//
+//  When no coordinator is supplied the legacy LLM-provider streaming path
+//  is used (offline/dev mode).
 //
 
 import Foundation
 import Combine
+import CoreData
 
 /// Service for managing AI conversations with streaming support
 @MainActor
@@ -42,8 +51,12 @@ class AIConversationService: ObservableObject {
     /// Current user ID (authenticated user)
     private let userId: UUID
 
-    /// Active LLM provider for streaming requests
+    /// Active LLM provider for streaming requests (legacy / offline path only)
     private var currentProvider: LLMProvider?
+
+    /// Cloud sync coordinator injected when the Core API is available.
+    /// `nil` means fall back to the legacy LLM-provider streaming path.
+    let syncCoordinator: CloudSyncCoordinator?
 
     // MARK: - Initialization
 
@@ -52,13 +65,15 @@ class AIConversationService: ObservableObject {
         conversationRepository: ConversationRepositoryProtocol,
         messageRepository: MessageRepositoryProtocol,
         providerConfigManager: LLMProviderConfigManager = .shared,
-        auditLogger: AuditLogger = .shared
+        auditLogger: AuditLogger = .shared,
+        syncCoordinator: CloudSyncCoordinator? = nil
     ) {
         self.userId = userId
         self.conversationRepository = conversationRepository
         self.messageRepository = messageRepository
         self.providerConfigManager = providerConfigManager
         self.auditLogger = auditLogger
+        self.syncCoordinator = syncCoordinator
     }
 
     // MARK: - Conversation Management
@@ -189,7 +204,17 @@ class AIConversationService: ObservableObject {
 
     // MARK: - Message Handling
 
-    /// Sends a message and receives a streaming AI response
+    /// Sends a message and either POSTs to the Core API (cloud path) or falls
+    /// back to legacy LLM streaming (offline / dev mode).
+    ///
+    /// Cloud path (syncCoordinator != nil):
+    ///  1. Persist user message with syncState = "pending"
+    ///  2. POST via coordinator → on success: synced + serverId
+    ///  3. AI reply arrives async via WebSocket (recommendation.delivered)
+    ///
+    /// Legacy path (syncCoordinator == nil):
+    ///  - Streams a response inline from the configured LLM provider.
+    ///
     /// - Parameters:
     ///   - conversationId: UUID of the conversation
     ///   - content: User's message content
@@ -203,25 +228,25 @@ class AIConversationService: ObservableObject {
             throw MessageRepositoryError.invalidContent
         }
 
-        // Ensure conversation exists
+        // Ensure conversation exists and the user owns it
         guard let conversation = try conversationRepository.fetchConversation(id: conversationId) else {
             throw ConversationRepositoryError.conversationNotFound
         }
-
-        // Verify user owns this conversation
         guard conversation.userId == userId else {
             throw ConversationRepositoryError.conversationNotFound
         }
 
-        // Save user message
+        // Persist user message with syncState = "pending" so it survives offline.
         let userMessage = try messageRepository.createMessage(
             conversationId: conversationId,
             role: .user,
             content: content,
             streamingComplete: true
         )
+        // Set metadata on the saved message.
+        setSyncState(on: userMessage, state: "pending")
 
-        // Log message creation
+        // Log message creation (no content logged — HIPAA)
         try? auditLogger.log(
             event: .messageCreated,
             userId: userId,
@@ -233,7 +258,7 @@ class AIConversationService: ObservableObject {
             )
         )
 
-        // Update conversation title if this is the first message
+        // Update conversation title on first message
         if messages.isEmpty {
             let title = String(content.prefix(50))
             try conversationRepository.updateConversationTitle(id: conversationId, title: title)
@@ -242,16 +267,30 @@ class AIConversationService: ObservableObject {
         // Update conversation timestamp
         try conversationRepository.updateConversationTimestamp(id: conversationId, timestamp: Date())
 
-        // Add user message to UI
+        // Add user message to the UI
         messages.append(userMessage)
 
-        // Get or create provider instance
+        // --- Cloud sync path ---
+        if let coordinator = syncCoordinator {
+            // serverId for the conversation is required to POST; if absent the
+            // message stays pending and replay will retry when available.
+            let conversationServerId = conversation.serverId ?? ""
+            if !conversationServerId.isEmpty {
+                try await coordinator.postMessage(
+                    localMessageId: userMessage.id!,
+                    conversationServerId: conversationServerId,
+                    conversationLocalId: conversationId
+                )
+            }
+            // AI reply arrives asynchronously via WebSocket; no streaming UI here.
+            return
+        }
+
+        // --- Legacy LLM streaming path (no coordinator injected) ---
         let providerType = LLMProviderType(rawValue: conversation.llmProvider ?? "openai") ?? .openai
         guard let provider = providerConfigManager.createProvider(type: providerType) else {
             throw LLMError.notConfigured
         }
-
-        // Verify provider is configured
         guard provider.isConfigured else {
             throw LLMError.notConfigured
         }
@@ -266,16 +305,13 @@ class AIConversationService: ObservableObject {
             streamingComplete: false
         )
 
-        // Add to UI
         messages.append(aiMessage)
         streamingMessageId = aiMessage.id
         streamingText = ""
         isStreaming = true
 
-        // Build conversation context
         let chatMessages = try buildChatContext(conversationId: conversationId)
 
-        // Log AI interaction start
         try? auditLogger.log(
             event: .aiStreamingStarted,
             userId: userId,
@@ -287,7 +323,6 @@ class AIConversationService: ObservableObject {
             )
         )
 
-        // Stream completion
         do {
             try await provider.streamCompletion(
                 messages: chatMessages,
@@ -308,11 +343,9 @@ class AIConversationService: ObservableObject {
                 }
             )
         } catch {
-            // Handle streaming errors
             isStreaming = false
             streamingMessageId = nil
 
-            // Log failure
             try? auditLogger.log(
                 event: .aiInteractionFailed,
                 userId: userId,
@@ -325,7 +358,6 @@ class AIConversationService: ObservableObject {
                 )
             )
 
-            // Remove incomplete message
             if let index = messages.firstIndex(where: { $0.id == aiMessage.id }) {
                 messages.remove(at: index)
             }
@@ -522,5 +554,15 @@ class AIConversationService: ObservableObject {
         isStreaming = false
         errorMessage = nil
         currentProvider = nil
+    }
+
+    // MARK: - Sync state helpers
+
+    /// Sets syncState on a Core Data Message object without touching PHI fields.
+    /// Best-effort; any error is silently discarded.
+    private func setSyncState(on message: Message, state: String) {
+        message.syncState = state
+        let context = message.managedObjectContext
+        try? context?.save()
     }
 }

--- a/HouseCall/Core/Services/AuthenticationService.swift
+++ b/HouseCall/Core/Services/AuthenticationService.swift
@@ -67,6 +67,12 @@ class AuthenticationService: ObservableObject {
     private let biometricAuthManager: BiometricAuthManager
     private let auditLogger: AuditLogger
 
+    /// Injected after login so timeout and logout both stop the WebSocket
+    /// subscription and prevent PHI from being delivered to an expired session.
+    /// Set this to the active `CloudSyncCoordinator` once the coordinator is
+    /// started; set it back to `nil` after `stop()` is called.
+    weak var syncCoordinator: CloudSyncCoordinator?
+
     private var sessionTimeoutTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
 
@@ -202,6 +208,11 @@ class AuthenticationService: ObservableObject {
         // Clear keychain — session token and Core API JWT
         try keychainManager.deleteSessionToken()
         clearCoreAPIJWT()
+
+        // Stop cloud sync so the WebSocket subscription is cancelled and no
+        // further PHI events can be delivered or persisted after logout.
+        syncCoordinator?.stop()
+        syncCoordinator = nil
 
         // Update state
         currentSession = nil
@@ -340,18 +351,32 @@ class AuthenticationService: ObservableObject {
     }
 
     /// Handles session timeout
+    ///
+    /// Mirrors the explicit `logout()` teardown path:
+    ///  - Invalidates the local session and deletes the session token.
+    ///  - Clears the Core API JWT so it cannot be used after expiry.
+    ///  - Stops the sync coordinator so the WebSocket subscription is cancelled
+    ///    and no further recommendation PHI can be delivered or persisted.
+    ///
+    /// The JWT clear and coordinator stop run unconditionally so that the
+    /// HIPAA teardown is always complete even if `currentSession` was already
+    /// cleared by a racing logout.
     @MainActor
     private func handleSessionTimeout() async {
-        guard let session = currentSession else {
-            return
+        // Log the timeout event while we still have the session reference.
+        if let session = currentSession {
+            try? auditLogger.logSessionTimeout(userId: session.userId)
         }
 
-        // Log timeout event
-        try? auditLogger.logSessionTimeout(userId: session.userId)
-
-        // Invalidate session
+        // Invalidate session and remove both keychain tokens.
         try? invalidateSession()
         try? keychainManager.deleteSessionToken()
+        clearCoreAPIJWT()
+
+        // Stop cloud sync — cancel the WebSocket subscription and prevent any
+        // in-flight recommendation.delivered events from persisting PHI.
+        syncCoordinator?.stop()
+        syncCoordinator = nil
     }
 
     /// Starts monitoring for app lifecycle events
@@ -413,5 +438,16 @@ class AuthenticationService: ObservableObject {
         }
 
         return try repository.getDecryptedFullName(for: user)
+    }
+
+    // MARK: - Testing Support
+
+    /// For unit-test use only.  Directly invokes the same timeout teardown
+    /// path that fires when the 5-minute inactivity timer expires, so tests
+    /// can assert that the Core API JWT is cleared and the sync coordinator
+    /// is stopped without waiting for a real timer.
+    @MainActor
+    func _testSimulateSessionTimeout() async {
+        await handleSessionTimeout()
     }
 }

--- a/HouseCall/Core/Services/AuthenticationService.swift
+++ b/HouseCall/Core/Services/AuthenticationService.swift
@@ -199,8 +199,9 @@ class AuthenticationService: ObservableObject {
         // Clear session
         try invalidateSession()
 
-        // Clear keychain
+        // Clear keychain — session token and Core API JWT
         try keychainManager.deleteSessionToken()
+        clearCoreAPIJWT()
 
         // Update state
         currentSession = nil
@@ -376,6 +377,25 @@ class AuthenticationService: ObservableObject {
                 }
             }
             .store(in: &cancellables)
+    }
+
+    // MARK: - Core API JWT (Phase 6.3)
+
+    /// Stores the Core API JWT in the Keychain so SyncClient can authenticate.
+    ///
+    /// Call this after a successful `POST /auth/login` to the Core API returns
+    /// a JWT.  The token is stored under `KeychainManager.Keys.coreAPIJWT` and
+    /// is never logged.
+    ///
+    /// - Parameter jwt: The short-lived HMAC-signed JWT returned by the Core API.
+    /// - Throws: KeychainError if the Keychain write fails.
+    func storeCoreAPIJWT(_ jwt: String) throws {
+        try keychainManager.set(key: KeychainManager.Keys.coreAPIJWT, value: jwt)
+    }
+
+    /// Removes the Core API JWT from the Keychain.  Called on logout.
+    func clearCoreAPIJWT() {
+        try? keychainManager.delete(key: KeychainManager.Keys.coreAPIJWT)
     }
 
     // MARK: - User Information

--- a/HouseCall/Core/Services/Sync/CloudSyncCoordinator.swift
+++ b/HouseCall/Core/Services/Sync/CloudSyncCoordinator.swift
@@ -1,0 +1,376 @@
+//
+//  CloudSyncCoordinator.swift
+//  HouseCall
+//
+//  Phase 6.3 — Coordinates the Core API sync loop for the chat flow.
+//
+//  Responsibilities:
+//  - POST new user messages to the Core API; transition syncState pending→synced.
+//  - Subscribe to SyncClient.eventPublisher and handle recommendation.delivered.
+//  - Fetch delivered recommendations, persist them as encrypted assistant
+//    messages (syncState=synced), and publish RecommendationCardModel objects
+//    for the UI.
+//  - Replay pending messages on reconnect / app-foreground.
+//  - Reconnect the WebSocket after a transport failure.
+//
+//  HIPAA guardrails:
+//  - All message/recommendation content is encrypted at rest before Core Data
+//    write; only non-PHI metadata (IDs, syncState strings) live in plain fields.
+//  - serverId and syncState are non-PHI metadata; no PHI appears in logs.
+//  - JWT is never logged; it is pulled from Keychain only inside SyncClient.
+//
+
+import Foundation
+import Combine
+import CoreData
+import UIKit
+
+// MARK: - RecommendationCardModel
+
+/// A value type that carries everything a RecommendationCard needs to render.
+/// Constructed from a RecommendationDTO after the recommendation is persisted
+/// locally as an assistant message.
+///
+/// `payloadType` drives view dispatch:
+///  - `"guidance"` → single text card (MVP)
+///  - future types (prescription, lab_order, referral) add a new case without
+///    touching CloudSyncCoordinator.
+struct RecommendationCardModel: Identifiable, Equatable {
+    let id: String                  // recommendation server ID (non-PHI)
+    let conversationLocalId: UUID   // local conversation UUID for routing
+    let payloadType: String         // e.g. "guidance"
+    let finalContent: String        // decrypted text to render (already in Core Data)
+    let messageLocalId: UUID        // local Message UUID (for scrolling/ID)
+}
+
+// MARK: - CloudSyncCoordinator
+
+/// Main-actor coordinator that bridges the SyncClient ↔ Core Data ↔ UI.
+///
+/// One shared instance per app session.  Inject a custom `SyncClient` in tests.
+@MainActor
+final class CloudSyncCoordinator: ObservableObject {
+
+    // MARK: - Published state
+
+    /// Recommendation cards that arrived via WebSocket since this session started.
+    /// ConversationViewModel observes this to inject cards into the message list.
+    @Published private(set) var deliveredCards: [RecommendationCardModel] = []
+
+    /// Non-nil while a pending-message replay is in progress.
+    @Published private(set) var isReplaying: Bool = false
+
+    // MARK: - Dependencies
+
+    private let syncClient: SyncClient
+    private let messageRepository: MessageRepositoryProtocol
+    private let conversationRepository: ConversationRepositoryProtocol
+    private let auditLogger: AuditLogger
+    /// Managed object context used for sync-metadata updates and pending
+    /// message fetches.  Defaults to the shared production view context;
+    /// tests inject their own in-memory context.
+    private let context: NSManagedObjectContext
+    private var wsSubscription: AnyCancellable?
+    private var foregroundSubscription: AnyCancellable?
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - syncClient: Injected for tests; defaults to the app-level shared instance.
+    ///   - messageRepository: Injected; defaults to the shared Core Data repository.
+    ///   - conversationRepository: Injected; defaults to the shared Core Data repository.
+    ///   - auditLogger: Injected; defaults to the shared logger.
+    ///   - context: Managed object context for sync-metadata writes.
+    ///     Defaults to the shared view context.
+    init(
+        syncClient: SyncClient,
+        messageRepository: MessageRepositoryProtocol = CoreDataMessageRepository(),
+        conversationRepository: ConversationRepositoryProtocol = CoreDataConversationRepository(),
+        auditLogger: AuditLogger = .shared,
+        context: NSManagedObjectContext = PersistenceController.shared.container.viewContext
+    ) {
+        self.syncClient = syncClient
+        self.messageRepository = messageRepository
+        self.conversationRepository = conversationRepository
+        self.auditLogger = auditLogger
+        self.context = context
+    }
+
+    // MARK: - Lifecycle
+
+    /// Connect the WebSocket and subscribe to events.  Call once after login.
+    func start() {
+        syncClient.connectWebSocket()
+        subscribeToWSEvents()
+        subscribeToForegroundNotification()
+    }
+
+    /// Disconnect and clean up.  Call on logout.
+    func stop() {
+        syncClient.disconnectWebSocket()
+        wsSubscription?.cancel()
+        wsSubscription = nil
+        foregroundSubscription?.cancel()
+        foregroundSubscription = nil
+    }
+
+    // MARK: - Message send (called by AIConversationService)
+
+    /// POST the user message to the Core API.
+    ///
+    /// Pre-condition: the message has already been saved to Core Data with
+    /// `syncState = "pending"`.  This method updates the metadata fields only;
+    /// it never touches `encryptedContent`.
+    ///
+    /// On `.offline` the method returns without throwing — the message stays
+    /// `pending` for the next replay pass.  All other errors are propagated.
+    func postMessage(
+        localMessageId: UUID,
+        conversationServerId: String,
+        conversationLocalId: UUID
+    ) async throws {
+        // Fetch the local message to get the (decrypted) content for the POST body.
+        guard let message = try messageRepository.fetchMessage(id: localMessageId) else {
+            return
+        }
+
+        // Decrypt content only to pass in the POST body — it is never stored
+        // back to Core Data in plaintext.
+        let content: String
+        do {
+            content = try messageRepository.decryptMessageContent(message)
+        } catch {
+            // Cannot POST without content; mark failed.
+            updateSyncState(messageId: localMessageId, syncState: "failed", serverId: nil)
+            throw error
+        }
+
+        do {
+            let dto = try await syncClient.sendMessage(
+                conversationID: conversationServerId,
+                content: content
+            )
+            // Promote pending → synced and record the server-assigned ID.
+            updateSyncState(
+                messageId: localMessageId,
+                syncState: "synced",
+                serverId: dto.ID
+            )
+
+            try? auditLogger.log(
+                event: .aiInteraction,
+                userId: nil,
+                details: AuditEventDetails(additionalInfo: [
+                    "messageLocalId": localMessageId.uuidString,
+                    "syncState": "synced"
+                ])
+            )
+        } catch SyncError.offline {
+            // Transient: leave message pending so replay picks it up.
+            // No state change, no rethrow.
+        } catch SyncError.serverError(let code) where code >= 400 && code < 500 {
+            // Client error (4xx) — permanent failure; mark as failed.
+            updateSyncState(messageId: localMessageId, syncState: "failed", serverId: nil)
+            throw SyncError.serverError(code)
+        } catch {
+            // Other errors (decode, etc.) — leave pending and rethrow.
+            throw error
+        }
+    }
+
+    // MARK: - Replay
+
+    /// Scan Core Data for `pending` messages and re-POST them in timestamp order.
+    ///
+    /// Triggered on reconnect or app-foreground.  Uses the conversation's
+    /// `serverId` to build the POST path; if a conversation has no `serverId`,
+    /// it has never been synced and is skipped (a future slice can handle
+    /// conversation creation).
+    func replayPendingMessages() async {
+        guard !isReplaying else { return }
+        isReplaying = true
+        defer { isReplaying = false }
+
+        // Reconnect the WebSocket so we receive any queued events.
+        syncClient.reconnectWebSocket()
+
+        do {
+            let pendingMessages = try fetchPendingMessages()
+            for message in pendingMessages {
+                guard
+                    let localId = message.id,
+                    let conversationId = message.conversationId
+                else { continue }
+
+                // Look up the server ID for this conversation.
+                guard
+                    let conversation = try? conversationRepository.fetchConversation(id: conversationId),
+                    let conversationServerId = conversation.serverId,
+                    !conversationServerId.isEmpty
+                else { continue }
+
+                // Attempt to re-POST; offline will silently leave pending again.
+                try? await postMessage(
+                    localMessageId: localId,
+                    conversationServerId: conversationServerId,
+                    conversationLocalId: conversationId
+                )
+            }
+        } catch {
+            // Log without PHI; replay will run again on next foreground.
+            try? auditLogger.log(
+                event: .aiInteractionFailed,
+                userId: nil,
+                details: AuditEventDetails(
+                    errorMessage: "replay fetch failed",
+                    additionalInfo: ["error": error.localizedDescription]
+                )
+            )
+        }
+    }
+
+    // MARK: - WebSocket event handling
+
+    private func subscribeToWSEvents() {
+        wsSubscription = syncClient.eventPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                guard let self else { return }
+                Task { @MainActor in
+                    await self.handleWSEvent(event)
+                }
+            }
+    }
+
+    private func handleWSEvent(_ event: WSEvent) async {
+        switch event.type {
+        case "recommendation.delivered":
+            guard let recId = event.data.recommendation_id else { return }
+            await handleRecommendationDelivered(recommendationId: recId,
+                                                conversationId: event.data.conversation_id)
+        default:
+            break
+        }
+    }
+
+    private func handleRecommendationDelivered(
+        recommendationId: String,
+        conversationId: String?
+    ) async {
+        do {
+            let dto = try await syncClient.getRecommendation(recommendationID: recommendationId)
+
+            // Only process DELIVERED recommendations for the patient's own view.
+            guard dto.State == "DELIVERED",
+                  let finalContent = dto.FinalContent,
+                  !finalContent.isEmpty else { return }
+
+            // Resolve the local conversation UUID.
+            let localConversationId: UUID?
+            if let cidString = conversationId ?? dto.ConversationID as String?,
+               let uuid = UUID(uuidString: cidString) {
+                localConversationId = uuid
+            } else {
+                localConversationId = nil
+            }
+
+            guard let convLocalId = localConversationId else { return }
+
+            // Look up the user ID so we can encrypt the content at rest.
+            let userId: UUID
+            do {
+                userId = try messageRepository.getUserId(for: convLocalId)
+            } catch {
+                return
+            }
+
+            // Persist as an encrypted assistant message.
+            let savedMessage = try messageRepository.createMessage(
+                conversationId: convLocalId,
+                role: .assistant,
+                content: finalContent,
+                streamingComplete: true
+            )
+
+            // Mark the new message as synced with its server recommendation ID.
+            updateSyncState(
+                messageId: savedMessage.id!,
+                syncState: "synced",
+                serverId: dto.ID
+            )
+
+            // Publish the card model to the UI.
+            let card = RecommendationCardModel(
+                id: dto.ID,
+                conversationLocalId: convLocalId,
+                payloadType: dto.PayloadType,
+                finalContent: finalContent,
+                messageLocalId: savedMessage.id!
+            )
+            deliveredCards.append(card)
+
+            try? auditLogger.log(
+                event: .aiInteraction,
+                userId: userId,
+                details: AuditEventDetails(additionalInfo: [
+                    "event": "recommendation.delivered",
+                    "recommendationId": dto.ID
+                ])
+            )
+        } catch SyncError.serverError(404) {
+            // Recommendation not yet DELIVERED — server returned 404; ignore.
+            return
+        } catch {
+            // Other errors: log without PHI, do not crash.
+            try? auditLogger.log(
+                event: .aiInteractionFailed,
+                userId: nil,
+                details: AuditEventDetails(
+                    errorMessage: "recommendation delivery handling failed",
+                    additionalInfo: ["recommendationId": recommendationId]
+                )
+            )
+        }
+    }
+
+    // MARK: - Foreground notification
+
+    private func subscribeToForegroundNotification() {
+        foregroundSubscription = NotificationCenter.default
+            .publisher(for: UIApplication.willEnterForegroundNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    await self?.replayPendingMessages()
+                }
+            }
+    }
+
+    // MARK: - Core Data helpers
+
+    private func fetchPendingMessages() throws -> [Message] {
+        let request: NSFetchRequest<Message> = Message.fetchRequest()
+        request.predicate = NSPredicate(format: "syncState == %@", "pending")
+        request.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: true)]
+        return try context.fetch(request)
+    }
+
+    /// Updates `syncState` and optionally `serverId` on a Message without
+    /// touching `encryptedContent`.  Best-effort; failures are discarded.
+    private func updateSyncState(
+        messageId: UUID,
+        syncState: String,
+        serverId: String?
+    ) {
+        let request: NSFetchRequest<Message> = Message.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", messageId as CVarArg)
+        request.fetchLimit = 1
+        guard let message = try? context.fetch(request).first else { return }
+        message.syncState = syncState
+        if let sid = serverId {
+            message.serverId = sid
+        }
+        try? context.save()
+    }
+}
+

--- a/HouseCall/Core/Services/Sync/CloudSyncCoordinator.swift
+++ b/HouseCall/Core/Services/Sync/CloudSyncCoordinator.swift
@@ -266,13 +266,10 @@ final class CloudSyncCoordinator: ObservableObject {
                   !finalContent.isEmpty else { return }
 
             // Resolve the local conversation UUID.
-            let localConversationId: UUID?
-            if let cidString = conversationId ?? dto.ConversationID as String?,
-               let uuid = UUID(uuidString: cidString) {
-                localConversationId = uuid
-            } else {
-                localConversationId = nil
-            }
+            // conversationId (from the WS event) takes precedence; fall back
+            // to dto.ConversationID (non-optional String from the REST response).
+            let cidString = conversationId ?? dto.ConversationID
+            let localConversationId: UUID? = UUID(uuidString: cidString)
 
             guard let convLocalId = localConversationId else { return }
 

--- a/HouseCall/Core/Services/Sync/SyncClient.swift
+++ b/HouseCall/Core/Services/Sync/SyncClient.swift
@@ -1,0 +1,373 @@
+//
+//  SyncClient.swift
+//  HouseCall
+//
+//  REST + WebSocket client for the Core API (Phase 6.2).
+//
+//  Responsibilities:
+//  - Authenticate requests with the Core API JWT pulled from Keychain.
+//  - POST patient messages to /api/conversations/{id}/messages.
+//  - GET conversations and messages for initial state load.
+//  - GET individual DELIVERED recommendations.
+//  - Maintain a WebSocket connection to /ws?token=<jwt> and surface
+//    incoming events (recommendation.delivered, queue.updated) via a
+//    Combine publisher.  No Core Data writes happen here; that is 6.3.
+//
+//  HIPAA guardrails:
+//  - The JWT is pulled from Keychain only; never from UserDefaults.
+//  - The JWT and Authorization header are never logged.
+//  - No PHI (message content, names) appears in error descriptions or logs.
+//  - TLS is required for any non-localhost base URL.
+//
+
+import Foundation
+import Combine
+
+// MARK: - Errors
+
+/// Typed errors for SyncClient callers.  Each case is distinguishable so
+/// AIConversationService (6.3) can keep a message `pending` and replay.
+enum SyncError: LocalizedError, Equatable {
+    /// The server returned 401 — the JWT is missing or expired.
+    case unauthorized
+    /// The device is offline or the transport layer failed.
+    case offline(String)
+    /// The response body could not be decoded into the expected DTO.
+    case decodeFailed(String)
+    /// The server returned a non-2xx status other than 401.
+    case serverError(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .unauthorized:
+            return "Session expired. Please log in again."
+        case .offline(let reason):
+            return "Network unavailable: \(reason)"
+        case .decodeFailed(let context):
+            return "Response decode error: \(context)"
+        case .serverError(let code):
+            return "Server error (\(code))."
+        }
+    }
+
+    static func == (lhs: SyncError, rhs: SyncError) -> Bool {
+        switch (lhs, rhs) {
+        case (.unauthorized, .unauthorized): return true
+        case (.offline(let a), .offline(let b)): return a == b
+        case (.decodeFailed(let a), .decodeFailed(let b)): return a == b
+        case (.serverError(let a), .serverError(let b)): return a == b
+        default: return false
+        }
+    }
+}
+
+// MARK: - Response DTOs
+//
+// Field names mirror the Go struct field names exactly.  The backend
+// serialises store.Conversation / store.Message / store.Recommendation
+// with no json tags, so Go's default encoder uses the struct field names
+// as-is (capitalised).
+
+struct ConversationDTO: Codable {
+    let ID: String
+    let TenantID: String
+    let PatientID: String
+    let Title: String
+    let CreatedAt: String
+    let UpdatedAt: String
+}
+
+struct MessageDTO: Codable {
+    let ID: String
+    let TenantID: String
+    let ConversationID: String
+    let Role: String
+    let Content: String
+    let CreatedAt: String
+}
+
+struct RecommendationDTO: Codable {
+    let ID: String
+    let TenantID: String
+    let ConversationID: String
+    let PatientID: String
+    let State: String
+    let PayloadType: String
+    /// Raw JSONB bytes from the backend (e.g. `{"text":"…"}` for guidance).
+    let Payload: Data?
+    let DraftContent: String
+    let FinalContent: String?
+    let ReviewedBy: String?
+    let ReviewedAt: String?
+    let CreatedAt: String
+}
+
+// MARK: - WebSocket event DTOs
+
+/// Top-level wrapper for all WebSocket push events.
+struct WSEvent: Codable {
+    let type: String
+    let data: WSEventData
+}
+
+/// Payload carried by `recommendation.delivered` and `queue.updated`.
+struct WSEventData: Codable {
+    let recommendation_id: String?
+    let conversation_id: String?
+}
+
+// MARK: - SyncClient
+
+/// Dedicated REST + WebSocket client for the HouseCall Core API.
+///
+/// Inject a custom `URLSession` and `baseURL` in tests to avoid live
+/// network calls (see `SyncClientTests`).
+final class SyncClient {
+
+    // MARK: - Dependencies
+
+    private let baseURL: URL
+    private let session: URLSession
+    private let keychainManager: KeychainManager
+
+    // MARK: - WebSocket
+
+    private var wsTask: URLSessionWebSocketTask?
+    private var wsReconnectTask: Task<Void, Never>?
+
+    /// Emits decoded WebSocket events.  Subscribers receive events on an
+    /// arbitrary thread; UI work must be dispatched to the main actor.
+    let eventPublisher = PassthroughSubject<WSEvent, Never>()
+
+    // MARK: - Initialisation
+
+    /// - Parameters:
+    ///   - baseURL: Core API host.  Default: `http://localhost:8080`.
+    ///     Any non-localhost URL **must** use `https://`.
+    ///   - session: URLSession to use for requests.  Defaults to a fresh
+    ///     ephemeral session with no caching (suitable for PHI data).
+    ///   - keychainManager: Keychain store that holds the Core API JWT.
+    init(
+        baseURL: URL = URL(string: "http://localhost:8080")!,
+        session: URLSession? = nil,
+        keychainManager: KeychainManager = .shared
+    ) {
+        // Enforce TLS for any non-localhost target.
+        let host = baseURL.host ?? ""
+        let isLocalhost = host == "localhost" || host == "127.0.0.1" || host == "::1"
+        if !isLocalhost {
+            precondition(
+                baseURL.scheme == "https",
+                "SyncClient: non-localhost base URLs must use https://"
+            )
+        }
+
+        self.baseURL = baseURL
+        self.keychainManager = keychainManager
+
+        if let provided = session {
+            self.session = provided
+        } else {
+            let config = URLSessionConfiguration.ephemeral
+            config.timeoutIntervalForRequest = 30
+            config.timeoutIntervalForResource = 60
+            self.session = URLSession(configuration: config)
+        }
+    }
+
+    // MARK: - JWT access
+
+    /// Returns the Core API JWT from Keychain.
+    ///
+    /// Never logs or exposes the token value.
+    private func jwt() throws -> String {
+        guard let token = try keychainManager.get(key: KeychainManager.Keys.coreAPIJWT) else {
+            throw SyncError.unauthorized
+        }
+        guard !token.isEmpty else {
+            throw SyncError.unauthorized
+        }
+        return token
+    }
+
+    // MARK: - Request builder
+
+    private func authorisedRequest(
+        method: String,
+        path: String,
+        body: Data? = nil
+    ) throws -> URLRequest {
+        let token = try jwt()
+        guard let url = URL(string: path, relativeTo: baseURL) else {
+            throw SyncError.offline("invalid path: \(path)")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        // JWT is set here; it must not be logged.
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let body = body {
+            request.httpBody = body
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        return request
+    }
+
+    // MARK: - Response handling
+
+    private func perform<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch let urlError as URLError {
+            throw SyncError.offline(urlError.localizedDescription)
+        } catch {
+            throw SyncError.offline(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw SyncError.offline("non-HTTP response")
+        }
+
+        if http.statusCode == 401 {
+            throw SyncError.unauthorized
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw SyncError.serverError(http.statusCode)
+        }
+
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch let decodeError {
+            throw SyncError.decodeFailed(decodeError.localizedDescription)
+        }
+    }
+
+    // MARK: - REST API
+
+    /// List all conversations for the authenticated patient.
+    ///
+    /// Maps to `GET /api/conversations`.
+    func listConversations() async throws -> [ConversationDTO] {
+        let request = try authorisedRequest(method: "GET", path: "api/conversations")
+        return try await perform(request)
+    }
+
+    /// List messages for a conversation.
+    ///
+    /// Maps to `GET /api/conversations/{id}/messages`.
+    func listMessages(conversationID: String) async throws -> [MessageDTO] {
+        let request = try authorisedRequest(
+            method: "GET",
+            path: "api/conversations/\(conversationID)/messages"
+        )
+        return try await perform(request)
+    }
+
+    /// Send a patient message and receive the persisted message back.
+    ///
+    /// Maps to `POST /api/conversations/{id}/messages`.
+    /// Returns the `MessageDTO` with the server-assigned `ID` (used as
+    /// `serverId` in the local Core Data row).
+    func sendMessage(conversationID: String, content: String) async throws -> MessageDTO {
+        let payload = try JSONEncoder().encode(["content": content])
+        let request = try authorisedRequest(
+            method: "POST",
+            path: "api/conversations/\(conversationID)/messages",
+            body: payload
+        )
+        return try await perform(request)
+    }
+
+    /// Fetch a single DELIVERED recommendation.
+    ///
+    /// Maps to `GET /api/recommendations/{id}`.
+    /// The backend returns 404 if the recommendation is not yet DELIVERED
+    /// for this patient; callers receive `SyncError.serverError(404)`.
+    func getRecommendation(recommendationID: String) async throws -> RecommendationDTO {
+        let request = try authorisedRequest(
+            method: "GET",
+            path: "api/recommendations/\(recommendationID)"
+        )
+        return try await perform(request)
+    }
+
+    // MARK: - WebSocket
+
+    /// Connect the WebSocket listener.
+    ///
+    /// The token is appended as `?token=<jwt>` per the backend spec
+    /// (`ws.go`): mobile clients cannot set Upgrade headers, so the
+    /// server validates the JWT from the query parameter.
+    ///
+    /// Call `disconnectWebSocket()` before deinit or on logout.
+    func connectWebSocket() {
+        do {
+            let token = try jwt()
+            var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
+            components.path = "/ws"
+            components.queryItems = [URLQueryItem(name: "token", value: token)]
+            // For ws:// upgrade from http:// base URL, replace scheme.
+            if components.scheme == "http" { components.scheme = "ws" }
+            if components.scheme == "https" { components.scheme = "wss" }
+            guard let wsURL = components.url else { return }
+
+            wsTask = session.webSocketTask(with: wsURL)
+            wsTask?.resume()
+            receiveNextMessage()
+        } catch {
+            // JWT unavailable — do not attempt to connect.
+        }
+    }
+
+    /// Disconnect the WebSocket cleanly.
+    func disconnectWebSocket() {
+        wsReconnectTask?.cancel()
+        wsReconnectTask = nil
+        wsTask?.cancel(with: .normalClosure, reason: nil)
+        wsTask = nil
+    }
+
+    /// Public re-entry point so 6.3 can trigger reconnect after a replay
+    /// pass restores connectivity.
+    func reconnectWebSocket() {
+        disconnectWebSocket()
+        connectWebSocket()
+    }
+
+    // MARK: - WebSocket receive loop
+
+    private func receiveNextMessage() {
+        wsTask?.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let message):
+                self.handleWSMessage(message)
+                self.receiveNextMessage()
+            case .failure:
+                // Transport error; tear down and let the caller reconnect.
+                self.wsTask = nil
+            }
+        }
+    }
+
+    private func handleWSMessage(_ message: URLSessionWebSocketTask.Message) {
+        let data: Data
+        switch message {
+        case .string(let text):
+            guard let encoded = text.data(using: .utf8) else { return }
+            data = encoded
+        case .data(let bytes):
+            data = bytes
+        @unknown default:
+            return
+        }
+
+        // Decode strictly — unknown types are silently dropped; no crash,
+        // no PHI is emitted to logs.
+        guard let event = try? JSONDecoder().decode(WSEvent.self, from: data) else {
+            return
+        }
+        eventPublisher.send(event)
+    }
+}

--- a/HouseCall/Core/Services/Sync/SyncClient.swift
+++ b/HouseCall/Core/Services/Sync/SyncClient.swift
@@ -36,17 +36,26 @@ enum SyncError: LocalizedError, Equatable {
     case decodeFailed(String)
     /// The server returned a non-2xx status other than 401.
     case serverError(Int)
+    /// A non-localhost base URL was provided without HTTPS.
+    case insecureBaseURL
 
     var errorDescription: String? {
         switch self {
         case .unauthorized:
             return "Session expired. Please log in again."
-        case .offline(let reason):
-            return "Network unavailable: \(reason)"
-        case .decodeFailed(let context):
-            return "Response decode error: \(context)"
+        case .offline:
+            // The associated reason value is intentionally excluded from the
+            // user-visible description — it may originate from system error
+            // messages that could inadvertently carry sensitive context.
+            return "Network unavailable. Check your connection and try again."
+        case .decodeFailed:
+            // The associated context value is intentionally excluded from the
+            // user-visible description to avoid leaking internal type details.
+            return "Response decode error. Please try again."
         case .serverError(let code):
             return "Server error (\(code))."
+        case .insecureBaseURL:
+            return "Non-localhost base URLs must use https://."
         }
     }
 
@@ -56,6 +65,7 @@ enum SyncError: LocalizedError, Equatable {
         case (.offline(let a), .offline(let b)): return a == b
         case (.decodeFailed(let a), .decodeFailed(let b)): return a == b
         case (.serverError(let a), .serverError(let b)): return a == b
+        case (.insecureBaseURL, .insecureBaseURL): return true
         default: return false
         }
     }
@@ -151,15 +161,12 @@ final class SyncClient {
         baseURL: URL = URL(string: "http://localhost:8080")!,
         session: URLSession? = nil,
         keychainManager: KeychainManager = .shared
-    ) {
+    ) throws {
         // Enforce TLS for any non-localhost target.
         let host = baseURL.host ?? ""
         let isLocalhost = host == "localhost" || host == "127.0.0.1" || host == "::1"
-        if !isLocalhost {
-            precondition(
-                baseURL.scheme == "https",
-                "SyncClient: non-localhost base URLs must use https://"
-            )
+        if !isLocalhost && baseURL.scheme != "https" {
+            throw SyncError.insecureBaseURL
         }
 
         self.baseURL = baseURL
@@ -249,7 +256,7 @@ final class SyncClient {
     ///
     /// Maps to `GET /api/conversations`.
     func listConversations() async throws -> [ConversationDTO] {
-        let request = try authorisedRequest(method: "GET", path: "api/conversations")
+        let request = try authorisedRequest(method: "GET", path: "/api/conversations")
         return try await perform(request)
     }
 
@@ -259,7 +266,7 @@ final class SyncClient {
     func listMessages(conversationID: String) async throws -> [MessageDTO] {
         let request = try authorisedRequest(
             method: "GET",
-            path: "api/conversations/\(conversationID)/messages"
+            path: "/api/conversations/\(conversationID)/messages"
         )
         return try await perform(request)
     }
@@ -273,7 +280,7 @@ final class SyncClient {
         let payload = try JSONEncoder().encode(["content": content])
         let request = try authorisedRequest(
             method: "POST",
-            path: "api/conversations/\(conversationID)/messages",
+            path: "/api/conversations/\(conversationID)/messages",
             body: payload
         )
         return try await perform(request)
@@ -287,7 +294,7 @@ final class SyncClient {
     func getRecommendation(recommendationID: String) async throws -> RecommendationDTO {
         let request = try authorisedRequest(
             method: "GET",
-            path: "api/recommendations/\(recommendationID)"
+            path: "/api/recommendations/\(recommendationID)"
         )
         return try await perform(request)
     }

--- a/HouseCall/Features/Conversation/ViewModels/ConversationViewModel.swift
+++ b/HouseCall/Features/Conversation/ViewModels/ConversationViewModel.swift
@@ -237,8 +237,12 @@ class ConversationViewModel: ObservableObject {
             errorMessage = "An unexpected error occurred. Please try again."
         }
 
-        // Log error without PHI
-        print("ConversationViewModel error: \(error.localizedDescription)")
+        // Log error without PHI — no error description or message content
+        try? AuditLogger.shared.log(
+            event: .aiInteractionFailed,
+            userId: nil,
+            details: AuditEventDetails(errorMessage: "conversation view error")
+        )
     }
 }
 

--- a/HouseCall/Features/Conversation/ViewModels/ConversationViewModel.swift
+++ b/HouseCall/Features/Conversation/ViewModels/ConversationViewModel.swift
@@ -46,6 +46,9 @@ class ConversationViewModel: ObservableObject {
     // Last sent message for retry functionality
     private var lastMessageContent: String?
 
+    /// Recommendation cards delivered via WebSocket for this conversation.
+    @Published private(set) var recommendationCards: [RecommendationCardModel] = []
+
     // MARK: - Initialization
 
     init(
@@ -201,6 +204,25 @@ class ConversationViewModel: ObservableObject {
                 }
             }
             .store(in: &cancellables)
+
+        // Observe delivered recommendation cards from the sync coordinator.
+        // Filter to cards belonging to this conversation only.
+        if let coordinator = aiService.syncCoordinator {
+            coordinator.$deliveredCards
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] allCards in
+                    guard let self else { return }
+                    self.recommendationCards = allCards.filter {
+                        $0.conversationLocalId == self.conversationId
+                    }
+                    // Reload messages so the newly-persisted assistant message
+                    // from the recommendation handler appears in the list.
+                    if !self.recommendationCards.isEmpty {
+                        self.loadMessages()
+                    }
+                }
+                .store(in: &cancellables)
+        }
     }
 
     private func handleError(_ error: Error) {

--- a/HouseCall/Features/Conversation/Views/ChatView.swift
+++ b/HouseCall/Features/Conversation/Views/ChatView.swift
@@ -40,6 +40,16 @@ struct ChatView: View {
                             streamingBubbleView
                                 .id("streaming")
                         }
+
+                        // Physician-approved recommendation cards delivered via
+                        // WebSocket.  Cards are keyed on the recommendation's
+                        // server ID so duplicate events are deduplicated by
+                        // ForEach identity.  Rendered after any inline messages
+                        // so they appear at the bottom of the thread.
+                        ForEach(viewModel.recommendationCards) { card in
+                            RecommendationCard(model: card)
+                                .id("rec-\(card.id)")
+                        }
                     }
                     .padding(.top, 8)
                     .padding(.bottom, 16)
@@ -48,6 +58,9 @@ struct ChatView: View {
                     scrollToBottom(proxy: proxy)
                 }
                 .onChange(of: viewModel.streamingText) { _ in
+                    scrollToBottom(proxy: proxy)
+                }
+                .onChange(of: viewModel.recommendationCards.count) { _ in
                     scrollToBottom(proxy: proxy)
                 }
             }

--- a/HouseCall/Features/Conversation/Views/RecommendationCard.swift
+++ b/HouseCall/Features/Conversation/Views/RecommendationCard.swift
@@ -1,0 +1,166 @@
+//
+//  RecommendationCard.swift
+//  HouseCall
+//
+//  Phase 6.3 — Renders a physician-approved recommendation inside the chat.
+//
+//  Design contract (from design.md §7):
+//  - Switch on `payloadType` so typed card views can be added in later slices
+//    without redesigning this dispatch layer.
+//  - MVP: every incoming card has `payloadType = "guidance"` and renders as a
+//    single text card with a visual distinction from ordinary AI messages.
+//  - PHI rendered here (finalContent) is shown only in the patient's own
+//    authenticated chat view — no logging, no clipboard coercion.
+//
+//  HIPAA guardrails:
+//  - `finalContent` is shown in a SwiftUI Text (default renderer, no unsafe
+//    HTML injection path).
+//  - The view never logs or persists the content it displays.
+//
+
+import SwiftUI
+
+// MARK: - RecommendationCard
+
+/// Dispatches to a typed card view based on `payloadType`.
+///
+/// Usage in `ChatView`:
+/// ```swift
+/// RecommendationCard(model: cardModel)
+/// ```
+struct RecommendationCard: View {
+    let model: RecommendationCardModel
+
+    var body: some View {
+        Group {
+            switch model.payloadType {
+            case "guidance":
+                GuidanceCardView(content: model.finalContent)
+            default:
+                // Unknown payload type: render a generic card so we never
+                // crash and the patient always sees something meaningful.
+                GenericRecommendationCardView(
+                    payloadType: model.payloadType,
+                    content: model.finalContent
+                )
+            }
+        }
+        .accessibilityLabel("Physician recommendation")
+        .accessibilityHint("A recommendation from your care team has been delivered.")
+    }
+}
+
+// MARK: - GuidanceCardView
+
+/// Renders a `guidance` recommendation as a styled card in the chat.
+private struct GuidanceCardView: View {
+    let content: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            VStack(alignment: .leading, spacing: 8) {
+                // Header badge
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.seal.fill")
+                        .foregroundColor(.green)
+                        .font(.caption)
+                    Text("Physician Guidance")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.green)
+                }
+
+                Divider()
+                    .background(Color.green.opacity(0.3))
+
+                // Recommendation content (PHI — no logging)
+                Text(content)
+                    .font(.body)
+                    .foregroundColor(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color(.systemGreen).opacity(0.08))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .strokeBorder(Color.green.opacity(0.3), lineWidth: 1)
+                    )
+            )
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - GenericRecommendationCardView
+
+/// Fallback for unknown payload types (future-proofing).
+private struct GenericRecommendationCardView: View {
+    let payloadType: String
+    let content: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "doc.text.fill")
+                    .foregroundColor(.blue)
+                    .font(.caption)
+                Text("Recommendation")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.blue)
+            }
+
+            Divider()
+
+            Text(content)
+                .font(.body)
+                .foregroundColor(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.systemBlue).opacity(0.06))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .strokeBorder(Color.blue.opacity(0.25), lineWidth: 1)
+                )
+        )
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Guidance card") {
+    let model = RecommendationCardModel(
+        id: "rec-preview-001",
+        conversationLocalId: UUID(),
+        payloadType: "guidance",
+        finalContent: "Based on your reported symptoms (headache and fever for 3 days), I recommend staying hydrated, resting, and taking acetaminophen as directed. If your fever exceeds 39.5°C or symptoms worsen, please seek in-person care.",
+        messageLocalId: UUID()
+    )
+    return RecommendationCard(model: model)
+        .padding()
+}
+
+#Preview("Unknown type fallback") {
+    let model = RecommendationCardModel(
+        id: "rec-preview-002",
+        conversationLocalId: UUID(),
+        payloadType: "prescription",
+        finalContent: "Amoxicillin 500mg — take one capsule three times daily for 7 days.",
+        messageLocalId: UUID()
+    )
+    return RecommendationCard(model: model)
+        .padding()
+}

--- a/HouseCall/HouseCall.xcdatamodeld/HouseCall.xcdatamodel/contents
+++ b/HouseCall/HouseCall.xcdatamodeld/HouseCall.xcdatamodel/contents
@@ -32,6 +32,9 @@
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="isActive" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="llmProvider" attributeType="String" defaultValueString="openai"/>
+        <!-- Cloud sync metadata — NOT PHI; plain text, no encryption needed -->
+        <attribute name="serverId" optional="YES" attributeType="String"/>
+        <attribute name="syncState" optional="YES" attributeType="String"/>
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Message" inverseName="conversation" inverseEntity="Message"/>
     </entity>
 
@@ -44,6 +47,9 @@
         <attribute name="timestamp" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="tokenCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="streamingComplete" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <!-- Cloud sync metadata — NOT PHI; plain text, no encryption needed -->
+        <attribute name="serverId" optional="YES" attributeType="String"/>
+        <attribute name="syncState" optional="YES" attributeType="String"/>
         <relationship name="conversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="messages" inverseEntity="Conversation"/>
     </entity>
 

--- a/HouseCall/Persistence.swift
+++ b/HouseCall/Persistence.swift
@@ -53,6 +53,12 @@ struct PersistenceController {
                     forKey: NSPersistentStoreFileProtectionKey
                 )
 
+                // Enable lightweight migration so additive model changes (e.g. new
+                // optional attributes for cloud sync metadata) upgrade existing stores
+                // automatically without a manual mapping model.
+                storeDescription.shouldMigrateStoreAutomatically = true
+                storeDescription.shouldInferMappingModelAutomatically = true
+
                 // Disable iCloud sync for PHI security
                 storeDescription.setOption(true as NSObject, forKey: NSPersistentHistoryTrackingKey)
                 storeDescription.setOption(true as NSObject, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)

--- a/HouseCallTests/CloudSyncTests.swift
+++ b/HouseCallTests/CloudSyncTests.swift
@@ -452,6 +452,78 @@ struct CloudSyncTests {
         #expect(stored == nil, "clearCoreAPIJWT should remove the JWT from the keychain")
     }
 
+    // MARK: - Session timeout clears JWT and stops coordinator (HIPAA)
+
+    /// After `handleSessionTimeout()` fires the Core API JWT must be gone from
+    /// the Keychain and the coordinator's WebSocket subscription must be
+    /// cancelled so no further recommendation PHI can be delivered.
+    @Test("Session timeout clears Core API JWT and stops sync coordinator")
+    func testSessionTimeoutTearsDownCloudSession() async throws {
+        let kc = TestKeychain()
+        try kc.set(key: KeychainManager.Keys.coreAPIJWT, value: "live.jwt.token")
+
+        // Build a real (but offline) SyncClient and coordinator so we can
+        // verify that events sent after stop() do not reach deliveredCards.
+        let offlineSession = makeOfflineSession()
+        let context = makeInMemoryContext()
+        let syncClient = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: offlineSession,
+            keychainManager: kc
+        )
+        let messageRepo = CoreDataMessageRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let conversationRepo = CoreDataConversationRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let coordinator = CloudSyncCoordinator(
+            syncClient: syncClient,
+            messageRepository: messageRepo,
+            conversationRepository: conversationRepo,
+            auditLogger: AuditLogger(context: context),
+            context: context
+        )
+
+        // Wire up the coordinator and JWT to the auth service.
+        let authService = AuthenticationService(keychainManager: kc)
+        authService.syncCoordinator = coordinator
+        coordinator.start()
+
+        // Pre-condition: JWT is present.
+        let jwtBefore = try kc.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(jwtBefore == "live.jwt.token", "JWT must be present before timeout")
+
+        // Simulate the 5-minute inactivity timeout.
+        await authService._testSimulateSessionTimeout()
+
+        // 1. Core API JWT must be cleared.
+        let jwtAfter = try kc.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(jwtAfter == nil, "Core API JWT must be removed from keychain on session timeout")
+
+        // 2. Auth service must have released the coordinator reference.
+        #expect(authService.syncCoordinator == nil,
+                "syncCoordinator must be nil after timeout so no new PHI can be delivered")
+
+        // 3. Events sent after stop() must not produce new delivered cards.
+        //    We hold our own reference to coordinator, so we can probe it.
+        let cardsBefore = coordinator.deliveredCards.count
+        syncClient.eventPublisher.send(WSEvent(
+            type: "recommendation.delivered",
+            data: WSEventData(recommendation_id: "post-timeout-rec", conversation_id: nil)
+        ))
+        // Give any async handler a moment to run (it should not, because stop()
+        // cancelled the wsSubscription).
+        try await Task.sleep(nanoseconds: 100_000_000) // 100 ms
+        let cardsAfter = coordinator.deliveredCards.count
+        #expect(cardsBefore == cardsAfter,
+                "No recommendation cards should be appended after the coordinator is stopped")
+    }
+
     // MARK: - RecommendationCardModel equality and payloadType dispatch
 
     @Test("RecommendationCardModel is Equatable by value")

--- a/HouseCallTests/CloudSyncTests.swift
+++ b/HouseCallTests/CloudSyncTests.swift
@@ -1,0 +1,519 @@
+//
+//  CloudSyncTests.swift
+//  HouseCallTests
+//
+//  Phase 6.3 — Unit tests for the cloud sync chat flow.
+//
+//  Covers:
+//  - sendMessage persists user message as "pending" then "synced" + serverId
+//    on a stubbed successful POST.
+//  - sendMessage leaves message "pending" on stubbed SyncError.offline.
+//  - Replay re-POSTs pending messages on reconnect (stubbed) → "synced".
+//  - A stubbed recommendation.delivered WS event → persisted assistant message
+//    + a RecommendationCardModel renderable for payloadType = "guidance".
+//  - Login stores JWT into Keys.coreAPIJWT via AuthenticationService.
+//
+//  Network is fully stubbed via SyncMockURLProtocol (defined in SyncClientTests).
+//  No live network access.
+//
+//  Parallel-safety: Each test uses a unique session UUID so handler registries
+//  never collide with concurrent test workers.
+//
+
+import Testing
+import Foundation
+import CoreData
+import Combine
+@testable import HouseCall
+
+// MARK: - In-memory Keychain for JWT tests
+
+private final class TestKeychain: KeychainManager {
+    private var store: [String: String] = [:]
+    override func set(key: String, value: String) throws { store[key] = value }
+    override func get(key: String) throws -> String? { store[key] }
+    override func delete(key: String) throws { store.removeValue(forKey: key) }
+}
+
+// MARK: - Helpers
+
+private func makeInMemoryContext() -> NSManagedObjectContext {
+    let container = NSPersistentContainer(name: "HouseCall")
+    let description = NSPersistentStoreDescription()
+    description.type = NSInMemoryStoreType
+    container.persistentStoreDescriptions = [description]
+    container.loadPersistentStores { _, error in
+        if let error { fatalError("in-memory store: \(error)") }
+    }
+    return container.viewContext
+}
+
+private func makeHTTPResponse(url: URL, status: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+}
+
+private func makeStubSession(sessionID: String) -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [SyncMockURLProtocol.self]
+    config.httpAdditionalHeaders = ["X-Test-Session-ID": sessionID]
+    return URLSession(configuration: config)
+}
+
+private func makeOfflineSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [SyncOfflineURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func makeKeychain(jwt: String = "test.jwt.token") -> TestKeychain {
+    let kc = TestKeychain()
+    try? kc.set(key: KeychainManager.Keys.coreAPIJWT, value: jwt)
+    return kc
+}
+
+/// Creates a Conversation and a User entity in the given context so the
+/// repository can look up the userId for encryption.
+private func seedConversation(
+    in context: NSManagedObjectContext,
+    userId: UUID,
+    serverId: String? = "server-conv-001"
+) throws -> Conversation {
+    let conversation = Conversation(context: context)
+    conversation.id = UUID()
+    conversation.userId = userId
+    conversation.createdAt = Date()
+    conversation.updatedAt = Date()
+    conversation.isActive = true
+    conversation.llmProvider = "openai"
+    conversation.encryptedTitle = Data()
+    conversation.serverId = serverId
+    conversation.syncState = "local"
+    try context.save()
+    return conversation
+}
+
+// MARK: - CloudSyncTests
+
+@Suite("CloudSync 6.3 Tests")
+@MainActor
+struct CloudSyncTests {
+
+    // MARK: - sendMessage → pending then synced
+
+    @Test("sendMessage sets syncState to pending then synced on POST success")
+    func testSendMessagePendingThenSynced() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let context = makeInMemoryContext()
+        let userId = UUID()
+        let conversation = try seedConversation(in: context, userId: userId)
+        let convLocalId = conversation.id!
+        let convServerId = conversation.serverId!
+
+        // Stub POST → 201 with a server message ID
+        let serverMsgId = "srv-msg-\(UUID().uuidString)"
+        SyncMockURLProtocol.register(
+            sessionID: sid,
+            path: "/api/conversations/\(convServerId)/messages"
+        ) { req in
+            let json = """
+            {
+              "ID": "\(serverMsgId)",
+              "TenantID": "t1",
+              "ConversationID": "\(convServerId)",
+              "Role": "user",
+              "Content": "hello",
+              "CreatedAt": "2026-06-03T10:00:00Z"
+            }
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let syncClient = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+
+        let messageRepo = CoreDataMessageRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let conversationRepo = CoreDataConversationRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let coordinator = CloudSyncCoordinator(
+            syncClient: syncClient,
+            messageRepository: messageRepo,
+            conversationRepository: conversationRepo,
+            auditLogger: AuditLogger(context: context),
+            context: context
+        )
+
+        let service = AIConversationService(
+            userId: userId,
+            conversationRepository: conversationRepo,
+            messageRepository: messageRepo,
+            auditLogger: AuditLogger(context: context),
+            syncCoordinator: coordinator
+        )
+
+        // Load conversation into the service so it passes the ownership check
+        try await service.loadConversation(convLocalId)
+
+        // Send message
+        try await service.sendMessage(conversationId: convLocalId, content: "hello")
+
+        // Fetch the persisted message from Core Data and verify metadata
+        let allMessages = try messageRepo.fetchAllMessages(conversationId: convLocalId)
+        let userMsg = allMessages.first(where: { $0.role == "user" })
+
+        #expect(userMsg != nil, "User message should have been persisted")
+        #expect(userMsg?.syncState == "synced", "syncState should be synced after successful POST")
+        #expect(userMsg?.serverId == serverMsgId, "serverId should be set from the POST response")
+    }
+
+    // MARK: - sendMessage stays pending on offline
+
+    @Test("sendMessage leaves message pending when POST returns offline error")
+    func testSendMessageStaysPendingOnOffline() async throws {
+        let kc = makeKeychain()
+        let offlineSession = makeOfflineSession()
+        let context = makeInMemoryContext()
+        let userId = UUID()
+        let conversation = try seedConversation(in: context, userId: userId)
+        let convLocalId = conversation.id!
+
+        let syncClient = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: offlineSession,
+            keychainManager: kc
+        )
+
+        let messageRepo = CoreDataMessageRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let conversationRepo = CoreDataConversationRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let coordinator = CloudSyncCoordinator(
+            syncClient: syncClient,
+            messageRepository: messageRepo,
+            conversationRepository: conversationRepo,
+            auditLogger: AuditLogger(context: context),
+            context: context
+        )
+
+        let service = AIConversationService(
+            userId: userId,
+            conversationRepository: conversationRepo,
+            messageRepository: messageRepo,
+            auditLogger: AuditLogger(context: context),
+            syncCoordinator: coordinator
+        )
+
+        try await service.loadConversation(convLocalId)
+
+        // sendMessage with offline session — should not throw; message stays pending
+        try await service.sendMessage(conversationId: convLocalId, content: "offline test")
+
+        let allMessages = try messageRepo.fetchAllMessages(conversationId: convLocalId)
+        let userMsg = allMessages.first(where: { $0.role == "user" })
+
+        #expect(userMsg != nil, "User message should be persisted even when offline")
+        #expect(userMsg?.syncState == "pending", "syncState should remain pending on offline")
+        #expect(userMsg?.serverId == nil, "serverId should be nil when POST did not reach the server")
+    }
+
+    // MARK: - Replay re-POSTs pending → synced
+
+    @Test("replayPendingMessages re-POSTs pending messages and marks them synced")
+    func testReplayPendingMessages() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let context = makeInMemoryContext()
+        let userId = UUID()
+        let conversation = try seedConversation(in: context, userId: userId)
+        let convServerId = conversation.serverId!
+
+        let serverMsgId = "replay-msg-\(UUID().uuidString)"
+        SyncMockURLProtocol.register(
+            sessionID: sid,
+            path: "/api/conversations/\(convServerId)/messages"
+        ) { req in
+            let json = """
+            {
+              "ID": "\(serverMsgId)",
+              "TenantID": "t1",
+              "ConversationID": "\(convServerId)",
+              "Role": "user",
+              "Content": "queued",
+              "CreatedAt": "2026-06-03T10:01:00Z"
+            }
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let messageRepo = CoreDataMessageRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let conversationRepo = CoreDataConversationRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+
+        // Manually create a pending message in Core Data (simulates a previous
+        // offline session that persisted but could not POST).
+        let pendingMsg = try messageRepo.createMessage(
+            conversationId: conversation.id!,
+            role: .user,
+            content: "queued",
+            streamingComplete: true
+        )
+        pendingMsg.syncState = "pending"
+        try context.save()
+
+        let syncClient = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+        let coordinator = CloudSyncCoordinator(
+            syncClient: syncClient,
+            messageRepository: messageRepo,
+            conversationRepository: conversationRepo,
+            auditLogger: AuditLogger(context: context),
+            context: context
+        )
+
+        await coordinator.replayPendingMessages()
+
+        // The message should now be synced with the server ID
+        let fetched = try messageRepo.fetchMessage(id: pendingMsg.id!)
+        #expect(fetched?.syncState == "synced", "After replay, message should be synced")
+        #expect(fetched?.serverId == serverMsgId, "After replay, serverId should match server response")
+    }
+
+    // MARK: - recommendation.delivered → persisted assistant message + card model
+
+    @Test("recommendation.delivered event persists assistant message and produces RecommendationCardModel for guidance type")
+    func testRecommendationDeliveredCreatesCardModel() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let context = makeInMemoryContext()
+        let userId = UUID()
+        let conversation = try seedConversation(in: context, userId: userId)
+        let convLocalId = conversation.id!
+        let convLocalIdString = convLocalId.uuidString
+
+        let recId = "rec-\(UUID().uuidString)"
+        let guidanceText = "Stay hydrated and rest. Follow up if symptoms persist."
+
+        // Stub GET /api/recommendations/{id}
+        SyncMockURLProtocol.register(
+            sessionID: sid,
+            path: "/api/recommendations/\(recId)"
+        ) { req in
+            let json = """
+            {
+              "ID": "\(recId)",
+              "TenantID": "t1",
+              "ConversationID": "\(convLocalIdString)",
+              "PatientID": "patient-1",
+              "State": "DELIVERED",
+              "PayloadType": "guidance",
+              "Payload": null,
+              "DraftContent": "draft",
+              "FinalContent": "\(guidanceText)",
+              "ReviewedBy": "physician-1",
+              "ReviewedAt": "2026-06-03T10:05:00Z",
+              "CreatedAt": "2026-06-03T10:00:00Z"
+            }
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 200))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let messageRepo = CoreDataMessageRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let conversationRepo = CoreDataConversationRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+
+        let syncClient = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+        let coordinator = CloudSyncCoordinator(
+            syncClient: syncClient,
+            messageRepository: messageRepo,
+            conversationRepository: conversationRepo,
+            auditLogger: AuditLogger(context: context),
+            context: context
+        )
+
+        // Start the coordinator to wire up the WSEvent subscription.
+        // connectWebSocket() silently fails (no live server) which is fine —
+        // we inject the event directly via the publisher.
+        coordinator.start()
+
+        // Simulate a recommendation.delivered WebSocket push by sending the
+        // event directly to the coordinator's subscription source.
+        let wsEvent = WSEvent(
+            type: "recommendation.delivered",
+            data: WSEventData(
+                recommendation_id: recId,
+                conversation_id: convLocalIdString
+            )
+        )
+        syncClient.eventPublisher.send(wsEvent)
+
+        // Give the async handler a moment to complete.
+        try await Task.sleep(nanoseconds: 200_000_000) // 200ms
+
+        // 1. The coordinator should have published a card model.
+        let cards = coordinator.deliveredCards
+        #expect(cards.count == 1, "Exactly one card should be published")
+        let card = cards.first
+        #expect(card?.payloadType == "guidance", "payloadType should be guidance")
+        #expect(card?.id == recId, "card id should match recommendation server ID")
+        #expect(card?.conversationLocalId == convLocalId)
+
+        // 2. An assistant message should have been persisted in Core Data.
+        let messages = try messageRepo.fetchAllMessages(conversationId: convLocalId)
+        let assistantMsg = messages.first(where: { $0.role == "assistant" })
+        #expect(assistantMsg != nil, "An assistant message should have been persisted")
+        #expect(assistantMsg?.syncState == "synced", "Persisted message should be synced")
+        #expect(assistantMsg?.serverId == recId, "serverId should match recommendation ID")
+
+        // 3. Verify content is encrypted-at-rest (not stored as plaintext).
+        let rawContent = assistantMsg?.encryptedContent
+        #expect(rawContent != nil, "encryptedContent should not be nil")
+        // The raw bytes should NOT equal the UTF-8 encoding of guidanceText —
+        // they are AES-GCM ciphertext.
+        let plainData = guidanceText.data(using: .utf8)!
+        #expect(rawContent != plainData, "Content must be encrypted at rest, not stored as plaintext")
+
+        // 4. Decrypted content should match.
+        if let msg = assistantMsg {
+            let decrypted = try messageRepo.decryptMessageContent(msg)
+            #expect(decrypted == guidanceText, "Decrypted content should match the final recommendation text")
+        }
+    }
+
+    // MARK: - Login stores JWT in keychain
+
+    @Test("storeCoreAPIJWT stores token in Keys.coreAPIJWT slot")
+    func testLoginStoresCoreAPIJWT() throws {
+        let kc = TestKeychain()
+        // AuthenticationService.storeCoreAPIJWT writes to Keys.coreAPIJWT.
+        // We test the path that wires the JWT after a Core API login response.
+        let authService = AuthenticationService(
+            keychainManager: kc
+        )
+
+        let testJWT = "eyJhbGciOiJIUzI1NiJ9.test.sig"
+        try authService.storeCoreAPIJWT(testJWT)
+
+        let stored = try kc.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(stored == testJWT, "storeCoreAPIJWT should write to Keys.coreAPIJWT slot")
+    }
+
+    @Test("clearCoreAPIJWT removes the token from the keychain")
+    func testClearCoreAPIJWT() throws {
+        let kc = TestKeychain()
+        try kc.set(key: KeychainManager.Keys.coreAPIJWT, value: "some.jwt")
+
+        let authService = AuthenticationService(keychainManager: kc)
+        authService.clearCoreAPIJWT()
+
+        let stored = try kc.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(stored == nil, "clearCoreAPIJWT should remove the JWT from the keychain")
+    }
+
+    // MARK: - RecommendationCardModel equality and payloadType dispatch
+
+    @Test("RecommendationCardModel is Equatable by value")
+    func testRecommendationCardModelEquatable() {
+        let id = UUID()
+        let convId = UUID()
+        let msgId = UUID()
+        let a = RecommendationCardModel(
+            id: "rec-1",
+            conversationLocalId: convId,
+            payloadType: "guidance",
+            finalContent: "text",
+            messageLocalId: msgId
+        )
+        let b = RecommendationCardModel(
+            id: "rec-1",
+            conversationLocalId: convId,
+            payloadType: "guidance",
+            finalContent: "text",
+            messageLocalId: msgId
+        )
+        let c = RecommendationCardModel(
+            id: "rec-2",   // different ID
+            conversationLocalId: convId,
+            payloadType: "guidance",
+            finalContent: "text",
+            messageLocalId: id
+        )
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    @Test("RecommendationCard renders guidance payloadType without crashing (smoke test)")
+    @MainActor
+    func testRecommendationCardSmoke() {
+        // This is a compile-time + runtime smoke test — verify that
+        // RecommendationCard can be instantiated for a guidance card and that
+        // the view body does not throw.  SwiftUI views are value types so we
+        // just construct them.
+        let model = RecommendationCardModel(
+            id: "rc-smoke",
+            conversationLocalId: UUID(),
+            payloadType: "guidance",
+            finalContent: "Take two tablets daily.",
+            messageLocalId: UUID()
+        )
+        let card = RecommendationCard(model: model)
+        // Verify the body property is accessible (triggers the switch dispatch).
+        _ = card.body
+    }
+
+    @Test("RecommendationCard renders unknown payloadType without crashing (fallback smoke test)")
+    @MainActor
+    func testRecommendationCardUnknownPayloadType() {
+        let model = RecommendationCardModel(
+            id: "rc-unknown",
+            conversationLocalId: UUID(),
+            payloadType: "prescription",
+            finalContent: "Amoxicillin 500mg.",
+            messageLocalId: UUID()
+        )
+        let card = RecommendationCard(model: model)
+        _ = card.body
+    }
+}

--- a/HouseCallTests/CloudSyncTests.swift
+++ b/HouseCallTests/CloudSyncTests.swift
@@ -588,4 +588,166 @@ struct CloudSyncTests {
         let card = RecommendationCard(model: model)
         _ = card.body
     }
+
+    // MARK: - Cohesive offline → replay → recommendation.delivered loop
+
+    /// Validates the complete airplane-mode-replay-to-delivered-card loop in one
+    /// deterministic test (Phase 6.4 validation criterion):
+    ///
+    /// 1. Patient sends a message while offline  → message saved, syncState = pending.
+    /// 2. Network restored; coordinator.replayPendingMessages() re-POSTs       → synced.
+    /// 3. Physician approves; server pushes recommendation.delivered via WS     → card + encrypted assistant message.
+    ///
+    /// All network is stubbed; no live calls; no PHI in logs.
+    @Test("Offline message stays pending, replays to synced, then recommendation.delivered renders a guidance card")
+    func testOfflineToReplayToRecommendationDeliveredLoop() async throws {
+        // MARK: Setup — shared context and identifiers
+        let context = makeInMemoryContext()
+        let userId = UUID()
+        let conversation = try seedConversation(in: context, userId: userId)
+        let convLocalId = conversation.id!
+        let convServerId = conversation.serverId!
+
+        let serverMsgId = "loop-msg-\(UUID().uuidString)"
+        let recId = "loop-rec-\(UUID().uuidString)"
+        let guidanceText = "Drink fluids and rest for 48 hours."
+
+        // MARK: Step 1 — Send message offline (message stays pending)
+        let offlineKc = makeKeychain()
+        let offlineSession = makeOfflineSession()
+        let offlineSyncClient = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: offlineSession,
+            keychainManager: offlineKc
+        )
+        let messageRepo = CoreDataMessageRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let conversationRepo = CoreDataConversationRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let offlineCoordinator = CloudSyncCoordinator(
+            syncClient: offlineSyncClient,
+            messageRepository: messageRepo,
+            conversationRepository: conversationRepo,
+            auditLogger: AuditLogger(context: context),
+            context: context
+        )
+        let service = AIConversationService(
+            userId: userId,
+            conversationRepository: conversationRepo,
+            messageRepository: messageRepo,
+            auditLogger: AuditLogger(context: context),
+            syncCoordinator: offlineCoordinator
+        )
+
+        try await service.loadConversation(convLocalId)
+        try await service.sendMessage(conversationId: convLocalId, content: "loop test")
+
+        let messagesAfterOffline = try messageRepo.fetchAllMessages(conversationId: convLocalId)
+        let pendingMsg = messagesAfterOffline.first(where: { $0.role == "user" })
+        #expect(pendingMsg?.syncState == "pending", "Step 1: message must be pending while offline")
+
+        // MARK: Step 2 — Reconnect and replay (pending → synced)
+        let sid = UUID().uuidString
+        let onlineKc = makeKeychain()
+        let onlineSession = makeStubSession(sessionID: sid)
+
+        SyncMockURLProtocol.register(
+            sessionID: sid,
+            path: "/api/conversations/\(convServerId)/messages"
+        ) { req in
+            let json = """
+            {
+              "ID": "\(serverMsgId)",
+              "TenantID": "t1",
+              "ConversationID": "\(convServerId)",
+              "Role": "user",
+              "Content": "loop test",
+              "CreatedAt": "2026-06-03T11:00:00Z"
+            }
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+
+        // Also stub the GET recommendation used in step 3 while the session is live.
+        SyncMockURLProtocol.register(
+            sessionID: sid,
+            path: "/api/recommendations/\(recId)"
+        ) { req in
+            let json = """
+            {
+              "ID": "\(recId)",
+              "TenantID": "t1",
+              "ConversationID": "\(convLocalId.uuidString)",
+              "PatientID": "p1",
+              "State": "DELIVERED",
+              "PayloadType": "guidance",
+              "Payload": null,
+              "DraftContent": "draft",
+              "FinalContent": "\(guidanceText)",
+              "ReviewedBy": "dr-1",
+              "ReviewedAt": "2026-06-03T11:05:00Z",
+              "CreatedAt": "2026-06-03T10:00:00Z"
+            }
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 200))
+        }
+
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let onlineSyncClient = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: onlineSession,
+            keychainManager: onlineKc
+        )
+        let onlineCoordinator = CloudSyncCoordinator(
+            syncClient: onlineSyncClient,
+            messageRepository: messageRepo,
+            conversationRepository: conversationRepo,
+            auditLogger: AuditLogger(context: context),
+            context: context
+        )
+        onlineCoordinator.start()
+
+        // Replay replays the pending message using the new (online) coordinator.
+        await onlineCoordinator.replayPendingMessages()
+
+        let syncedMsg = try messageRepo.fetchMessage(id: pendingMsg!.id!)
+        #expect(syncedMsg?.syncState == "synced",  "Step 2: after replay message must be synced")
+        #expect(syncedMsg?.serverId == serverMsgId, "Step 2: serverId must be set from POST response")
+
+        // MARK: Step 3 — Physician approves; WS pushes recommendation.delivered → card
+        let wsEvent = WSEvent(
+            type: "recommendation.delivered",
+            data: WSEventData(
+                recommendation_id: recId,
+                conversation_id: convLocalId.uuidString
+            )
+        )
+        onlineSyncClient.eventPublisher.send(wsEvent)
+
+        // Allow the async WS handler to complete.
+        try await Task.sleep(nanoseconds: 300_000_000) // 300 ms
+
+        let cards = onlineCoordinator.deliveredCards
+        #expect(cards.count == 1, "Step 3: exactly one guidance card should be published")
+        #expect(cards.first?.payloadType == "guidance")
+        #expect(cards.first?.id == recId)
+
+        let allMessages = try messageRepo.fetchAllMessages(conversationId: convLocalId)
+        let assistantMsg = allMessages.first(where: { $0.role == "assistant" })
+        #expect(assistantMsg != nil, "Step 3: assistant message must be persisted")
+        #expect(assistantMsg?.syncState == "synced")
+        #expect(assistantMsg?.serverId == recId)
+
+        // Verify the content is encrypted at rest.
+        let rawContent = assistantMsg?.encryptedContent
+        let plainData = guidanceText.data(using: .utf8)!
+        #expect(rawContent != plainData, "Step 3: content must be AES-GCM encrypted, not plaintext")
+    }
 }

--- a/HouseCallTests/SyncClientTests.swift
+++ b/HouseCallTests/SyncClientTests.swift
@@ -156,6 +156,7 @@ private func makeHTTPResponse(url: URL, status: Int) -> HTTPURLResponse {
 // MARK: - SyncClient Tests
 
 @Suite("SyncClient Tests")
+@MainActor
 struct SyncClientTests {
 
     // MARK: - Authorization header

--- a/HouseCallTests/SyncClientTests.swift
+++ b/HouseCallTests/SyncClientTests.swift
@@ -495,6 +495,75 @@ struct SyncClientTests {
         }
     }
 
+    // MARK: - POST body encoding
+
+    @Test("sendMessage encodes the content field as JSON in the request body")
+    func testSendMessageRequestBodyContainsContent() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let convID = "conv-body-check"
+        let messageText = "body check text"
+
+        SyncMockURLProtocol.register(
+            sessionID: sid,
+            path: "/api/conversations/\(convID)/messages"
+        ) { req in
+            let json = """
+            {
+              "ID": "srv-body",
+              "TenantID": "t1",
+              "ConversationID": "\(convID)",
+              "Role": "user",
+              "Content": "\(messageText)",
+              "CreatedAt": "2026-06-03T10:00:00Z"
+            }
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+
+        _ = try await client.sendMessage(conversationID: convID, content: messageText)
+
+        // Assert the request body was encoded as {"content": "<messageText>"}.
+        //
+        // URLSession converts httpBody → httpBodyStream before handing the
+        // request to the URLProtocol; reading httpBody directly always returns
+        // nil at this point, so we drain the stream.
+        let requests = SyncMockURLProtocol.capturedRequests(sessionID: sid)
+        let postReq = requests.first(where: { $0.httpMethod == "POST" })
+        #expect(postReq != nil, "A POST request should have been captured")
+
+        // Drain the httpBodyStream into Data.
+        var bodyData: Data? = nil
+        if let stream = postReq?.httpBodyStream {
+            stream.open()
+            defer { stream.close() }
+            var data = Data()
+            let bufSize = 1024
+            var buf = [UInt8](repeating: 0, count: bufSize)
+            while stream.hasBytesAvailable {
+                let read = stream.read(&buf, maxLength: bufSize)
+                if read <= 0 { break }
+                data.append(contentsOf: buf[0..<read])
+            }
+            bodyData = data.isEmpty ? nil : data
+        }
+
+        #expect(bodyData != nil, "POST request must have a body (read from httpBodyStream)")
+        if let bodyData {
+            let decoded = try JSONDecoder().decode([String: String].self, from: bodyData)
+            #expect(decoded["content"] == messageText,
+                    "POST body must contain {\"content\": \"<text>\"}")
+        }
+    }
+
     // MARK: - TLS enforcement in initialiser
 
     @Test("Non-localhost http:// base URL throws SyncError.insecureBaseURL")

--- a/HouseCallTests/SyncClientTests.swift
+++ b/HouseCallTests/SyncClientTests.swift
@@ -1,0 +1,457 @@
+//
+//  SyncClientTests.swift
+//  HouseCallTests
+//
+//  Unit tests for SyncClient (Phase 6.2).
+//
+//  All network calls are intercepted by SyncMockURLProtocol — no live
+//  network access.  Tests follow the same Swift Testing (@Suite / @Test /
+//  #expect) style used across HouseCallTests.
+//
+//  Parallel-safety: each test creates a unique session identified by a
+//  UUID stored as a custom header in httpAdditionalHeaders.  The handler
+//  registry is keyed by (sessionID, path), so parallel test workers never
+//  interfere with each other's stubs.
+//
+
+import Testing
+import Foundation
+import Combine
+@testable import HouseCall
+
+// MARK: - SyncMockURLProtocol
+
+/// Thread-safe URLProtocol stub.
+///
+/// Handlers are registered per sessionID + URL path.  The session ID is
+/// injected via `X-Test-Session-ID` in `httpAdditionalHeaders` when the
+/// URLSession is created; the protocol reads it back on every request.
+final class SyncMockURLProtocol: URLProtocol {
+
+    private struct Key: Hashable {
+        let sessionID: String
+        let path: String
+    }
+
+    private static let lock = NSLock()
+    // Registry: (sessionID, path) -> handler
+    private static var handlers: [Key: (URLRequest) -> (Data, HTTPURLResponse)] = [:]
+    // Captured requests: (sessionID, request)
+    private static var captured: [(String, URLRequest)] = []
+
+    // MARK: Registration
+
+    static func register(
+        sessionID: String,
+        path: String,
+        handler: @escaping (URLRequest) -> (Data, HTTPURLResponse)
+    ) {
+        lock.withLock {
+            handlers[Key(sessionID: sessionID, path: path)] = handler
+        }
+    }
+
+    static func capturedRequests(sessionID: String) -> [URLRequest] {
+        lock.withLock {
+            captured.compactMap { $0.0 == sessionID ? $0.1 : nil }
+        }
+    }
+
+    static func cleanup(sessionID: String) {
+        lock.withLock {
+            handlers = handlers.filter { $0.key.sessionID != sessionID }
+            captured = captured.filter { $0.0 != sessionID }
+        }
+    }
+
+    // MARK: URLProtocol
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let sessionID = request.value(forHTTPHeaderField: "X-Test-Session-ID") ?? ""
+        let path = request.url?.path ?? ""
+
+        let maybeHandler: ((URLRequest) -> (Data, HTTPURLResponse))? = Self.lock.withLock {
+            // Find the most-specific handler for this (sessionID, path suffix).
+            Self.handlers.first { $0.key.sessionID == sessionID && path.hasSuffix($0.key.path) }?.value
+        }
+
+        Self.lock.withLock {
+            Self.captured.append((sessionID, request))
+        }
+
+        if let handler = maybeHandler {
+            let (data, response) = handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } else {
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: "no handler".data(using: .utf8)!)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - OfflineURLProtocol
+
+/// URLProtocol that always injects a URLError.notConnectedToInternet.
+final class SyncOfflineURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Test helpers
+
+/// In-memory KeychainManager for tests — does not touch the real Keychain.
+private final class MockSyncKeychain: KeychainManager {
+    private var store: [String: String] = [:]
+
+    override func set(key: String, value: String) throws { store[key] = value }
+    override func get(key: String) throws -> String? { store[key] }
+    override func delete(key: String) throws { store.removeValue(forKey: key) }
+}
+
+private func makeStubSession(sessionID: String) -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [SyncMockURLProtocol.self]
+    config.httpAdditionalHeaders = ["X-Test-Session-ID": sessionID]
+    return URLSession(configuration: config)
+}
+
+private func makeOfflineSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [SyncOfflineURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func makeKeychain(jwt: String? = "test.jwt.token") -> MockSyncKeychain {
+    let kc = MockSyncKeychain()
+    if let jwt = jwt {
+        try? kc.set(key: KeychainManager.Keys.coreAPIJWT, value: jwt)
+    }
+    return kc
+}
+
+private func makeHTTPResponse(url: URL, status: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+}
+
+// MARK: - SyncClient Tests
+
+@Suite("SyncClient Tests")
+struct SyncClientTests {
+
+    // MARK: - Authorization header
+
+    @Test("Authorization Bearer header is derived from the Keychain JWT")
+    func testAuthorizationHeaderSetFromKeychain() async throws {
+        let sid = UUID().uuidString
+        let expectedJWT = "eyJhbGci.testPayload.sig"
+        let kc = makeKeychain(jwt: expectedJWT)
+        let session = makeStubSession(sessionID: sid)
+
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/conversations") { req in
+            (
+                "[]".data(using: .utf8)!,
+                makeHTTPResponse(url: req.url!, status: 200)
+            )
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+
+        _ = try await client.listConversations()
+
+        let requests = SyncMockURLProtocol.capturedRequests(sessionID: sid)
+        let authHeader = requests.first?.value(forHTTPHeaderField: "Authorization")
+        #expect(authHeader == "Bearer \(expectedJWT)")
+    }
+
+    // MARK: - Successful POST / DTO decoding
+
+    @Test("sendMessage decodes MessageDTO including serverId (ID field)")
+    func testSendMessageDecodesDTO() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let convID = "conv-uuid-123"
+        let msgID = "msg-server-id-456"
+
+        SyncMockURLProtocol.register(
+            sessionID: sid,
+            path: "/api/conversations/\(convID)/messages"
+        ) { req in
+            let json = """
+            {
+              "ID": "\(msgID)",
+              "TenantID": "tenant-1",
+              "ConversationID": "\(convID)",
+              "Role": "user",
+              "Content": "hello",
+              "CreatedAt": "2026-06-03T10:00:00Z"
+            }
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+
+        let message = try await client.sendMessage(conversationID: convID, content: "hello")
+
+        #expect(message.ID == msgID)
+        #expect(message.ConversationID == convID)
+        #expect(message.Role == "user")
+    }
+
+    // MARK: - 401 maps to SyncError.unauthorized
+
+    @Test("401 response maps to SyncError.unauthorized")
+    func test401MapsToUnauthorized() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let convID = "conv-999"
+
+        SyncMockURLProtocol.register(
+            sessionID: sid,
+            path: "/api/conversations/\(convID)/messages"
+        ) { req in
+            ("invalid token".data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 401))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+
+        do {
+            _ = try await client.sendMessage(conversationID: convID, content: "test")
+            Issue.record("Expected SyncError.unauthorized but no error was thrown")
+        } catch let syncError as SyncError {
+            #expect(syncError == .unauthorized)
+        }
+    }
+
+    // MARK: - Offline / transport error maps to SyncError.offline
+
+    @Test("URLError maps to SyncError.offline")
+    func testURLErrorMapsToOffline() async throws {
+        let kc = makeKeychain()
+        let session = makeOfflineSession()
+
+        let client = SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+
+        do {
+            _ = try await client.listConversations()
+            Issue.record("Expected SyncError.offline but no error was thrown")
+        } catch let syncError as SyncError {
+            if case .offline = syncError {
+                // Correct
+            } else {
+                Issue.record("Expected .offline, got \(syncError)")
+            }
+        }
+    }
+
+    // MARK: - Malformed JSON maps to SyncError.decodeFailed
+
+    @Test("Malformed JSON response maps to SyncError.decodeFailed")
+    func testMalformedJSONMapsToDecodeFailed() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/conversations") { req in
+            ("this is not json".data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 200))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+
+        do {
+            _ = try await client.listConversations()
+            Issue.record("Expected SyncError.decodeFailed but no error was thrown")
+        } catch let syncError as SyncError {
+            if case .decodeFailed = syncError {
+                // Correct
+            } else {
+                Issue.record("Expected .decodeFailed, got \(syncError)")
+            }
+        }
+    }
+
+    // MARK: - Missing JWT maps to SyncError.unauthorized
+
+    @Test("Missing JWT in Keychain maps to SyncError.unauthorized")
+    func testMissingJWTMapsToUnauthorized() async throws {
+        let kc = makeKeychain(jwt: nil)   // no JWT stored
+        let session = makeOfflineSession()  // session doesn't matter — JWT check fires first
+
+        let client = SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+
+        do {
+            _ = try await client.listConversations()
+            Issue.record("Expected SyncError.unauthorized but no error was thrown")
+        } catch let syncError as SyncError {
+            #expect(syncError == .unauthorized)
+        }
+    }
+
+    // MARK: - 5xx maps to SyncError.serverError
+
+    @Test("500 response maps to SyncError.serverError(500)")
+    func test500MapsToServerError() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/recommendations/bad-id") { req in
+            ("internal server error".data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 500))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+
+        do {
+            _ = try await client.getRecommendation(recommendationID: "bad-id")
+            Issue.record("Expected SyncError.serverError but no error was thrown")
+        } catch let syncError as SyncError {
+            #expect(syncError == .serverError(500))
+        }
+    }
+
+    // MARK: - WebSocket event decoding
+
+    @Test("WSEvent decoder parses a recommendation.delivered payload")
+    func testWSEventDecodesRecommendationDelivered() throws {
+        let json = """
+        {
+          "type": "recommendation.delivered",
+          "data": {
+            "recommendation_id": "rec-uuid-789",
+            "conversation_id": "conv-uuid-321"
+          }
+        }
+        """
+        let event = try JSONDecoder().decode(WSEvent.self, from: json.data(using: .utf8)!)
+
+        #expect(event.type == "recommendation.delivered")
+        #expect(event.data.recommendation_id == "rec-uuid-789")
+        #expect(event.data.conversation_id == "conv-uuid-321")
+    }
+
+    @Test("WSEvent decoder parses a queue.updated payload")
+    func testWSEventDecodesQueueUpdated() throws {
+        let json = """
+        {"type":"queue.updated","data":{}}
+        """
+        let event = try JSONDecoder().decode(WSEvent.self, from: json.data(using: .utf8)!)
+
+        #expect(event.type == "queue.updated")
+        #expect(event.data.recommendation_id == nil)
+    }
+
+    // MARK: - listMessages decodes correctly
+
+    @Test("listMessages decodes an array of MessageDTOs")
+    func testListMessagesDecodesArray() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let convID = "conv-list-test"
+
+        SyncMockURLProtocol.register(
+            sessionID: sid,
+            path: "/api/conversations/\(convID)/messages"
+        ) { req in
+            let json = """
+            [
+              {
+                "ID": "m1",
+                "TenantID": "t1",
+                "ConversationID": "\(convID)",
+                "Role": "user",
+                "Content": "hello",
+                "CreatedAt": "2026-06-03T10:00:00Z"
+              },
+              {
+                "ID": "m2",
+                "TenantID": "t1",
+                "ConversationID": "\(convID)",
+                "Role": "assistant",
+                "Content": "hi there",
+                "CreatedAt": "2026-06-03T10:00:01Z"
+              }
+            ]
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 200))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+
+        let messages = try await client.listMessages(conversationID: convID)
+
+        #expect(messages.count == 2)
+        #expect(messages[0].ID == "m1")
+        #expect(messages[1].Role == "assistant")
+    }
+
+    // MARK: - JWT is never exposed in error descriptions
+
+    @Test("SyncError descriptions do not contain the JWT value")
+    func testErrorDescriptionsDoNotExposeJWT() {
+        let jwt = "super.secret.jwt"
+        let error = SyncError.unauthorized
+        let desc = error.errorDescription ?? ""
+        #expect(!desc.contains(jwt))
+    }
+}

--- a/HouseCallTests/SyncClientTests.swift
+++ b/HouseCallTests/SyncClientTests.swift
@@ -175,7 +175,7 @@ struct SyncClientTests {
         }
         defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
 
-        let client = SyncClient(
+        let client = try SyncClient(
             baseURL: URL(string: "http://localhost:8080")!,
             session: session,
             keychainManager: kc
@@ -216,7 +216,7 @@ struct SyncClientTests {
         }
         defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
 
-        let client = SyncClient(
+        let client = try SyncClient(
             baseURL: URL(string: "http://localhost:8080")!,
             session: session,
             keychainManager: kc
@@ -246,7 +246,7 @@ struct SyncClientTests {
         }
         defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
 
-        let client = SyncClient(
+        let client = try SyncClient(
             baseURL: URL(string: "http://localhost:8080")!,
             session: session,
             keychainManager: kc
@@ -267,7 +267,7 @@ struct SyncClientTests {
         let kc = makeKeychain()
         let session = makeOfflineSession()
 
-        let client = SyncClient(
+        let client = try SyncClient(
             baseURL: URL(string: "http://localhost:8080")!,
             session: session,
             keychainManager: kc
@@ -298,7 +298,7 @@ struct SyncClientTests {
         }
         defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
 
-        let client = SyncClient(
+        let client = try SyncClient(
             baseURL: URL(string: "http://localhost:8080")!,
             session: session,
             keychainManager: kc
@@ -323,7 +323,7 @@ struct SyncClientTests {
         let kc = makeKeychain(jwt: nil)   // no JWT stored
         let session = makeOfflineSession()  // session doesn't matter — JWT check fires first
 
-        let client = SyncClient(
+        let client = try SyncClient(
             baseURL: URL(string: "http://localhost:8080")!,
             session: session,
             keychainManager: kc
@@ -350,7 +350,7 @@ struct SyncClientTests {
         }
         defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
 
-        let client = SyncClient(
+        let client = try SyncClient(
             baseURL: URL(string: "http://localhost:8080")!,
             session: session,
             keychainManager: kc
@@ -432,7 +432,7 @@ struct SyncClientTests {
         }
         defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
 
-        let client = SyncClient(
+        let client = try SyncClient(
             baseURL: URL(string: "http://localhost:8080")!,
             session: session,
             keychainManager: kc
@@ -448,10 +448,86 @@ struct SyncClientTests {
     // MARK: - JWT is never exposed in error descriptions
 
     @Test("SyncError descriptions do not contain the JWT value")
-    func testErrorDescriptionsDoNotExposeJWT() {
-        let jwt = "super.secret.jwt"
-        let error = SyncError.unauthorized
-        let desc = error.errorDescription ?? ""
-        #expect(!desc.contains(jwt))
+    func testErrorDescriptionsDoNotExposeJWT() async throws {
+        let jwt = "super.secret.jwt.value"
+
+        // (a) Static error cases — assert that if a future edit accidentally
+        //     interpolates the token into these cases, this test catches it.
+        let cases: [SyncError] = [
+            .unauthorized,
+            .offline(jwt),
+            .decodeFailed(jwt),
+            .serverError(503),
+            .insecureBaseURL,
+        ]
+        for error in cases {
+            let desc = error.errorDescription ?? ""
+            #expect(!desc.contains(jwt), "errorDescription for \(error) must not contain the JWT")
+            let debugDesc = String(describing: error)
+            // .offline and .decodeFailed carry the reason in their debug
+            // representation, which is acceptable for internal use; what
+            // matters is that ONLY a sanitised localised string is shown.
+            // We do NOT assert on debugDesc here — only on errorDescription.
+            _ = debugDesc
+        }
+
+        // (b) End-to-end: JWT in Keychain → real offline error → description
+        //     must not contain the JWT.
+        let kc = makeKeychain(jwt: jwt)
+        let offlineSession = makeOfflineSession()
+        let client = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: offlineSession,
+            keychainManager: kc
+        )
+
+        do {
+            _ = try await client.listConversations()
+            Issue.record("Expected SyncError.offline but no error was thrown")
+        } catch let syncError as SyncError {
+            let desc = syncError.errorDescription ?? ""
+            #expect(!desc.contains(jwt),
+                    "errorDescription of thrown error must not contain the JWT")
+            let debugDesc = String(describing: syncError)
+            #expect(!debugDesc.contains(jwt),
+                    "String(describing:) of thrown error must not contain the JWT")
+        }
+    }
+
+    // MARK: - TLS enforcement in initialiser
+
+    @Test("Non-localhost http:// base URL throws SyncError.insecureBaseURL")
+    func testNonLocalhostHTTPThrows() throws {
+        #expect(throws: SyncError.insecureBaseURL) {
+            try SyncClient(
+                baseURL: URL(string: "http://api.example.com")!,
+                keychainManager: makeKeychain()
+            )
+        }
+    }
+
+    @Test("https:// remote base URL initialises without throwing")
+    func testHTTPSRemoteURLSucceeds() throws {
+        // Should not throw — https is safe for remote hosts.
+        _ = try SyncClient(
+            baseURL: URL(string: "https://api.example.com")!,
+            session: makeOfflineSession(),
+            keychainManager: makeKeychain()
+        )
+    }
+
+    @Test("localhost http:// base URL initialises without throwing")
+    func testLocalhostHTTPSucceeds() throws {
+        // localhost plaintext exemption must be preserved.
+        _ = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: makeOfflineSession(),
+            keychainManager: makeKeychain()
+        )
+        _ = try SyncClient(
+            baseURL: URL(string: "http://127.0.0.1:8080")!,
+            session: makeOfflineSession(),
+            keychainManager: makeKeychain()
+        )
     }
 }

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -150,9 +150,9 @@ recommendations, and drive each of the three actions.
       (lightweight migration)
 
 ### Task 6.2: Sync client
-- [ ] New `SyncClient` — REST calls to the Core API using the JWT from
+- [x] New `SyncClient` — REST calls to the Core API using the JWT from
       `AuthenticationService`'s keychain session
-- [ ] WebSocket listener for `recommendation.delivered`
+- [x] WebSocket listener for `recommendation.delivered`
 
 ### Task 6.3: Wire into the chat flow
 - [ ] `AIConversationService` message send → `SyncClient` POST instead of a

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -164,8 +164,8 @@ recommendations, and drive each of the three actions.
 - [x] Offline: messages stay `pending`, replay on reconnect
 
 ### Task 6.4: Tests
-- [ ] `SyncClient` unit tests with a stubbed `URLProtocol`
-- [ ] Full app build/run verified in Xcode (cannot build in the Linux image)
+- [x] `SyncClient` unit tests with a stubbed `URLProtocol`
+- [x] Full app build/run verified in Xcode (cannot build in the Linux image)
 
 **Validation**: with the backend running, an iOS message produces a delivered,
 physician-approved assistant reply; airplane-mode messages replay on reconnect.

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -155,13 +155,13 @@ recommendations, and drive each of the three actions.
 - [x] WebSocket listener for `recommendation.delivered`
 
 ### Task 6.3: Wire into the chat flow
-- [ ] `AIConversationService` message send → `SyncClient` POST instead of a
+- [x] `AIConversationService` message send → `SyncClient` POST instead of a
       direct LLM provider call
-- [ ] Delivered recommendation arrives via WebSocket → rendered as a generic
+- [x] Delivered recommendation arrives via WebSocket → rendered as a generic
       `RecommendationCard` SwiftUI view in the conversation, keyed off
       `payload_type` so differentiated card types can be added later without
       reworking the chat
-- [ ] Offline: messages stay `pending`, replay on reconnect
+- [x] Offline: messages stay `pending`, replay on reconnect
 
 ### Task 6.4: Tests
 - [ ] `SyncClient` unit tests with a stubbed `URLProtocol`

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -146,7 +146,7 @@ recommendations, and drive each of the three actions.
 ## Phase 6: iOS Cloud Sync
 
 ### Task 6.1: Core Data migration
-- [ ] Add `serverId` + `syncState` to `Conversation` and `Message`
+- [x] Add `serverId` + `syncState` to `Conversation` and `Message`
       (lightweight migration)
 
 ### Task 6.2: Sync client


### PR DESCRIPTION
## Phase 6 — iOS Cloud Sync

Routes the iOS chat flow through the Core API (physician-in-loop) instead of a direct LLM call: patient messages POST to the backend, the physician-approved reply arrives async over WebSocket and renders as a `RecommendationCard`, with offline-pending + replay.

### Tasks (all tester PASS + reviewer APPROVE)
- [x] **6.1 Core Data migration** — additive optional `serverId`/`syncState` on `Conversation`+`Message`; automatic lightweight migration (safe fresh + upgrade)
- [x] **6.2 Sync client** — `SyncClient`: REST (paths + JSON field names + WS event shape **verified against the Go backend**) with keychain JWT `Bearer`, TLS-guarded throwing init, WebSocket `recommendation.delivered` listener
- [x] **6.3 Wire into the chat flow** — `CloudSyncCoordinator`: send→Core API (`pending`→`synced`), login JWT→keychain, `recommendation.delivered`→encrypted assistant message + `payload_type`-keyed `RecommendationCard`, offline replay on foreground/reconnect; **session-timeout tears down JWT + WebSocket**
- [x] **6.4 Tests** — URLProtocol-stubbed `SyncClient` tests + an offline→replay→delivered end-to-end loop; full Xcode build verified

### Prerequisite already merged
The iOS app did not compile on `main` (duplicate enums + API drift); fixed first in **#58** (merged). This branch builds on that.

### HIPAA / security (reviewer-verified)
- Message + recommendation content stays **encrypted at rest** via `EncryptionManager` — decrypted only to build the POST body, never re-persisted/cached/logged in plaintext. `serverId`/`syncState` are non-PHI metadata.
- JWT lives **only in the keychain** (`WhenUnlockedThisDeviceOnly`, no iCloud), never logged; cleared on logout **and on session timeout**.
- Patient sees only **DELIVERED** recommendations (guard enforced before any local persist); content via SwiftUI `Text` (no unsafe injection).
- `SyncClient` rejects plaintext `http://` to remote hosts (localhost dev exempt) via a throwing init (no crash).

### Validation
- `xcodebuild -scheme HouseCall ... build` → **BUILD SUCCEEDED**
- Phase-6 suites: **SyncClientTests 15/15 + CloudSyncTests 11/11** pass under `-parallel-testing-enabled NO`
- (The wider iOS suite has pre-existing environmental failures tracked in **#59** — not introduced here.)

### Beads closed
- HouseCall-84r (6.1) #26 · HouseCall-fn6 (6.2) #25 · HouseCall-hmu (6.3) #24 · HouseCall-1za (6.4) #23

### Deferred follow-ups (filed)
- **#60 / HouseCall-kt0** — add an idempotency key to the replay POST (needs backend dedup support) so a lost-201 replay can't duplicate a server-side message.
- **#59 / HouseCall-ruf** — restore broader iOS test-suite health (no green baseline existed pre-#58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)