### PR TITLE
add-cloud-platform-mvp: Phase 7 — Local Dev Environment & End-to-End Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 backend/server
 backend/**/*.test
 
+# Local dev env overrides — never commit real secrets.
+# backend/.env.example is committed; backend/.env is not.
+backend/.env
+
 # Beads / Dolt files (added by bd init)
 .dolt/
 *.db

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,27 @@
+# Copy this file to .env and adjust as needed for local development.
+# .env is gitignored; this example file is safe to commit.
+#
+# IMPORTANT: None of the values below are real secrets. Replace JWT_SECRET
+# with a randomly-generated value for any environment accessible outside
+# your localhost (e.g. a shared dev VM or staging).
+
+# ── Core API ────────────────────────────────────────────────────────────────
+
+# HMAC-HS256 signing secret for JWTs.  Must be >= 16 characters.
+# Generate a strong one: openssl rand -hex 32
+JWT_SECRET=dev-jwt-secret-change-me-in-production
+
+# Host port the server container binds on (default: 8080).
+# SERVER_PORT=8080
+
+# ── AI Agent ────────────────────────────────────────────────────────────────
+
+# Ollama / vLLM base URL (OpenAI-compatible).
+# host.docker.internal resolves to the macOS host from inside the container.
+# AGENT_MODEL_BASE_URL=http://host.docker.internal:11434/v1
+
+# Model to use.  Start Ollama with: ollama pull medgemma:4b
+# AGENT_MODEL_NAME=medgemma:4b
+
+# Optional bearer token for hosted model endpoints (leave empty for Ollama).
+# AGENT_MODEL_API_KEY=

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,38 @@
+# Multi-stage build for the HouseCall backend.
+#
+# Stage 1 (builder): compile a static binary using the official Go image.
+# Stage 2 (runtime): copy the binary into a minimal Alpine image; no Go
+#   toolchain, no source code, minimal attack surface.
+#
+# The migrations directory is baked into the image so `server -cmd migrate`
+# works inside the container without a volume mount.
+
+# ── Stage 1: build ──────────────────────────────────────────────────────────
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /src
+
+# Download dependencies first — this layer is cached unless go.mod/go.sum change.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source and build a static binary.
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /housecall ./cmd/server
+
+# ── Stage 2: runtime ────────────────────────────────────────────────────────
+FROM alpine:3.21
+
+# ca-certificates lets the agent client make TLS calls (e.g. to hosted model APIs).
+RUN apk add --no-cache ca-certificates
+
+WORKDIR /app
+
+COPY --from=builder /housecall ./housecall
+COPY --from=builder /src/migrations ./migrations
+
+EXPOSE 8080
+
+# Default: run the HTTP server.
+# Override CMD to run migrations: ["./housecall", "-cmd", "migrate"]
+CMD ["./housecall", "-cmd", "serve"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,7 +24,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /housecall .
 FROM alpine:3.21
 
 # ca-certificates lets the agent client make TLS calls (e.g. to hosted model APIs).
-RUN apk add --no-cache ca-certificates
+# curl is used by the e2e test driver (exec mode) to make HTTP calls from inside
+# the container; BusyBox wget cannot reliably capture Set-Cookie headers or
+# suppress redirect-following on a 303.
+RUN apk add --no-cache ca-certificates curl
 
 WORKDIR /app
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test migrate seed db-up db-down tidy
+.PHONY: build run test migrate seed db-up db-down compose-up tidy
 
 DATABASE_URL ?= postgres://housecall:housecall@localhost:5432/housecall?sslmode=disable
 TEST_DATABASE_URL ?= postgres://housecall:housecall@localhost:5432/housecall_test?sslmode=disable
@@ -18,15 +18,21 @@ migrate:
 db-up:
 	docker compose up -d --wait postgres
 
-# Stop Postgres. Data persists in the named volume (housecall-pgdata).
+# Stop all compose services. Data persists in the named volume (housecall-pgdata).
 db-down:
 	docker compose down
 
-# Seeds one tenant + one physician + one patient + one active care
-# relationship. Implemented in Phase 7 (Task 7.1) — placeholder for now.
+# Seeds one tenant + one physician + one patient + one active care relationship.
+# Runs the seeder directly against DATABASE_URL (Postgres must already be up).
+# Idempotent — safe to re-run.
 seed:
-	@echo "seed: not yet implemented (Phase 7 Task 7.1)"
-	@exit 1
+	DATABASE_URL=$(DATABASE_URL) go run ./cmd/seed
+
+# Bring up the full compose stack (postgres + server), wait until the server
+# is healthy, then seed the database.  One-command local dev setup.
+compose-up:
+	docker compose up -d --build --wait
+	DATABASE_URL=$(DATABASE_URL) go run ./cmd/seed
 
 test:
 	TEST_DATABASE_URL=$(TEST_DATABASE_URL) go test ./...

--- a/backend/README.md
+++ b/backend/README.md
@@ -96,7 +96,7 @@ sudo -u postgres psql -c "CREATE DATABASE housecall_test OWNER housecall;"
 
 ```bash
 make migrate    # apply pending SQL migrations
-make run        # build and start the server on :8080 (currently serves /healthz only)
+make run        # build and start the server on :8080
 make test       # run the test suite against $TEST_DATABASE_URL
 make tidy       # go mod tidy
 ```
@@ -111,6 +111,199 @@ make test    TEST_DATABASE_URL=postgres://user:pass@host:port/test_db?sslmode=di
 Tests that depend on PostgreSQL skip cleanly when `TEST_DATABASE_URL` is
 unset, so `go test ./...` always compiles and runs (pure-Go tests still
 execute; DB-bound tests skip).
+
+## Local AI model setup
+
+The AI Agent Runtime calls an OpenAI-compatible chat-completions endpoint.
+For local development the recommended path is **Ollama + medgemma:4b**.
+
+### Install and start Ollama
+
+```bash
+# macOS (Homebrew)
+brew install ollama
+
+# Pull the model (one-time, ~3 GB download)
+ollama pull medgemma:4b
+
+# Start the Ollama server (if not already running as a service)
+ollama serve          # listens on port 11434 by default
+```
+
+Verify the model is available:
+
+```bash
+ollama list           # should show medgemma:4b in the list
+```
+
+### How the compose stack reaches Ollama
+
+`docker-compose.yml` sets:
+
+```yaml
+environment:
+  AGENT_MODEL_BASE_URL: http://host.docker.internal:11434/v1
+  AGENT_MODEL_NAME: medgemma:4b
+extra_hosts:
+  - "host.docker.internal:host-gateway"
+```
+
+`host.docker.internal` resolves automatically on Docker Desktop (macOS/Windows).
+Under **Colima** (the default container runtime for this project), `extra_hosts`
+maps the name to `host-gateway` so the container can reach the host's Ollama
+process. No additional configuration is needed.
+
+To use a different model, override `AGENT_MODEL_NAME`:
+
+```bash
+AGENT_MODEL_NAME=llama3.2 docker compose up -d --build --wait
+```
+
+### Alternative: vLLM with a MedGemma variant
+
+For GPU-accelerated inference or the larger MedGemma variants, a
+[vLLM](https://github.com/vllm-project/vllm) server with an
+OpenAI-compatible endpoint works as a drop-in replacement:
+
+```bash
+# Example vLLM startup (requires a capable GPU)
+vllm serve google/medgemma-27b-it --port 11434
+
+# Point the compose stack at it
+AGENT_MODEL_BASE_URL=http://host.docker.internal:11434/v1 \
+AGENT_MODEL_NAME=google/medgemma-27b-it \
+  docker compose up -d --build --wait
+```
+
+Any OpenAI-compatible `/v1/chat/completions` endpoint works — the agent
+client negotiates the API contract, not the model name.
+
+## End-to-end test
+
+`scripts/e2e.sh` drives the complete physician-in-loop recommendation cycle
+against a running local stack:
+
+1. Patient logs in and posts a clinical question via the JSON API.
+2. The agent drafts a recommendation and transitions it to `PENDING_REVIEW`.
+3. Physician logs into the **web app** (`/web/login`) and approves the
+   recommendation via the HTML review form (`POST /web/recommendations/{id}/review`).
+4. Patient polls the JSON API until the recommendation state is `DELIVERED`
+   with non-empty `final_content`.
+
+### Prerequisites
+
+- Ollama is running on the host: `ollama serve`
+- `medgemma:4b` is downloaded: `ollama pull medgemma:4b`
+- `curl` and `docker` are in `$PATH`
+- `python3` is in `$PATH` (used for JSON parsing; `jq` is optional but recommended)
+
+### One-command run
+
+```bash
+cd backend
+./scripts/e2e.sh
+```
+
+The script calls `docker compose up -d --build --wait` and `make seed`
+automatically, so a fresh clone only needs the prerequisites above.
+
+If the stack is already up and seeded (e.g. you are iterating):
+
+```bash
+SKIP_UP=1 ./scripts/e2e.sh
+```
+
+### Expected output (abridged)
+
+```
+[e2e] ========================================
+[e2e] HouseCall E2E Test
+[e2e]   API:  http://localhost:8080
+[e2e]   WEB:  http://localhost:8080
+[e2e] ========================================
+[e2e] Bringing up compose stack ...
+[e2e] Seed complete.
+[e2e] Step 1: patient login...
+[e2e] Step 2: patient creates conversation...
+[e2e] Step 3: patient posts message (triggers agent draft)...
+[e2e] Step 4a: physician API login ...
+[e2e] Step 5: polling physician queue for PENDING_REVIEW (timeout 120s)...
+[e2e]   ...waiting for agent draft (0s elapsed, will retry in 3s)
+[e2e] PENDING_REVIEW recommendation found: <uuid> (after 12s)
+[e2e] Step 6: physician approves recommendation <uuid> via web app...
+[e2e]   6a. Web app login...
+[e2e]   Web login OK, hc_session cookie captured.
+[e2e]   6b. Loading physician queue page...
+[e2e]   Recommendation visible in queue.
+[e2e]   6c. Submitting approve form...
+[e2e]   Approve form submitted, redirected back to queue (HTTP 200).
+[e2e] Step 7: patient polls for DELIVERED recommendation (timeout 30s)...
+[e2e] Recommendation <uuid> is DELIVERED. final_content: [non-empty, content redacted]
+[e2e] ========================================
+[e2e] E2E PASSED
+[e2e] Full loop verified:
+[e2e]   patient message → agent draft → PENDING_REVIEW
+[e2e]   physician approved via web app → DELIVERED
+[e2e]   patient sees DELIVERED recommendation with non-empty content
+[e2e] ========================================
+```
+
+### Environment overrides
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `API_BASE` | `http://localhost:8080` | JSON API base URL |
+| `WEB_BASE` | `http://localhost:8080` | Web app base URL |
+| `SKIP_UP` | `0` | Set `1` to skip `compose up` + seed |
+| `AGENT_POLL_TIMEOUT` | `120` | Seconds to wait for PENDING_REVIEW |
+
+### Colima / non-default port
+
+The script auto-detects whether the server is reachable from the macOS host.
+Under Colima with the macOS Virtualization.Framework, `localhost:8080` may not
+be accessible from the host even though the container port is published. In
+that case the script automatically falls back to running all HTTP calls via
+`docker compose exec housecall-server wget ...` (exec mode). No manual
+configuration is required.
+
+To force exec mode explicitly (or if auto-detection is slow):
+
+```bash
+EXEC_MODE=exec ./scripts/e2e.sh
+```
+
+If the server is exposed on a different port:
+
+```bash
+API_BASE=http://localhost:9090 WEB_BASE=http://localhost:9090 ./scripts/e2e.sh
+```
+
+### Approve path: web app vs JSON API
+
+The script drives the **web app** approve path
+(`POST /web/recommendations/{id}/review` with a form-encoded `action=approve`
+body and the `hc_session` cookie). This exercises the full server-rendered
+physician UI path, not just the JSON API, which satisfies the task spec's
+requirement to "approve in the web app". The JSON API review endpoint
+(`POST /api/recommendations/{id}/review`) shares the same `review.Execute`
+logic and is covered by the API integration tests.
+
+### Model not yet downloaded
+
+If `ollama list` does not show `medgemma:4b` when the patient message is
+posted, the agent will fail to produce a recommendation and the script will
+time out at step 5 with a clear diagnostic:
+
+```
+[e2e] FAIL: Timed out after 120s waiting for PENDING_REVIEW recommendation. Is the model running?
+```
+
+Pull the model and re-run:
+
+```bash
+ollama pull medgemma:4b
+./scripts/e2e.sh
+```
 
 ## Data model
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -108,6 +108,8 @@ make migrate DATABASE_URL=postgres://user:pass@host:port/db?sslmode=disable
 make test    TEST_DATABASE_URL=postgres://user:pass@host:port/test_db?sslmode=disable
 ```
 
+> **Note:** `sslmode=disable` is for local development only and must never be used in staging or production environments.
+
 Tests that depend on PostgreSQL skip cleanly when `TEST_DATABASE_URL` is
 unset, so `go test ./...` always compiles and runs (pure-Go tests still
 execute; DB-bound tests skip).

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -1,0 +1,202 @@
+// cmd/seed inserts the minimum synthetic dataset required for local
+// development and end-to-end tests:
+//
+//   - 1 tenant  (id: 00000000-0000-0000-0000-000000000001)
+//   - 1 physician (id: 00000000-0000-0000-0000-000000000010)
+//   - 1 patient   (id: 00000000-0000-0000-0000-000000000020)
+//   - 1 active care relationship linking them
+//
+// All IDs and emails are deterministic so the e2e test script can hard-code
+// them.  Run `make seed` after `docker compose up` (or `make compose-up`).
+//
+// Idempotent: rows are inserted with ON CONFLICT DO NOTHING, so re-running
+// is safe and produces no duplicate rows.
+//
+// Credentials (synthetic, non-PHI, dev-only):
+//
+//	Physician  email: physician@dev.housecall.local  password: PhysicianDev1!
+//	Patient    email: patient@dev.housecall.local    password: PatientDev1!
+//
+// HIPAA note: all data is purely synthetic.  No real patient, physician, or
+// tenant information is committed.  Passwords are bcrypt-hashed (cost 12)
+// before insertion — the plaintext is never written to the database.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Deterministic seed IDs — stable across re-runs and referenced by the e2e
+// test script.
+var (
+	tenantID    = mustParseUUID("00000000-0000-0000-0000-000000000001")
+	physicianID = mustParseUUID("00000000-0000-0000-0000-000000000010")
+	patientID   = mustParseUUID("00000000-0000-0000-0000-000000000020")
+)
+
+const (
+	physicianEmail    = "physician@dev.housecall.local"
+	physicianPassword = "PhysicianDev1!"
+	physicianName     = "Dr. Dev Physician"
+
+	patientEmail    = "patient@dev.housecall.local"
+	patientPassword = "PatientDev1!"
+	patientName     = "Dev Patient"
+	patientState    = "CA"
+
+	// The physician must be licensed in patientState so state-licensing checks
+	// pass during the e2e review flow.
+	physicianState = "CA"
+
+	bcryptCost = 12
+)
+
+func main() {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		log.Fatal("DATABASE_URL is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer conn.Close(ctx)
+
+	// Hash passwords before any DB interaction (bcrypt is CPU-intensive).
+	physicianHash, err := bcrypt.GenerateFromPassword([]byte(physicianPassword), bcryptCost)
+	if err != nil {
+		log.Fatalf("hash physician password: %v", err)
+	}
+	patientHash, err := bcrypt.GenerateFromPassword([]byte(patientPassword), bcryptCost)
+	if err != nil {
+		log.Fatalf("hash patient password: %v", err)
+	}
+
+	// All four inserts run as a single transaction so the DB is never left in
+	// a partial state.
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		log.Fatalf("begin tx: %v", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	// 1. Tenant
+	_, err = tx.Exec(ctx,
+		`INSERT INTO tenants (id, kind, name)
+		 VALUES ($1, 'dtc', 'HouseCall Dev Tenant')
+		 ON CONFLICT (id) DO NOTHING`,
+		tenantID,
+	)
+	if err != nil {
+		log.Fatalf("insert tenant: %v", err)
+	}
+
+	// 2. Physician
+	_, err = tx.Exec(ctx,
+		`INSERT INTO physicians (id, tenant_id, email, full_name, states_licensed, password_hash)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (id) DO NOTHING`,
+		physicianID, tenantID,
+		physicianEmail, physicianName,
+		[]string{physicianState},
+		string(physicianHash),
+	)
+	if err != nil {
+		log.Fatalf("insert physician: %v", err)
+	}
+
+	// 3. Patient
+	_, err = tx.Exec(ctx,
+		`INSERT INTO patients (id, tenant_id, email, full_name, state, password_hash)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (id) DO NOTHING`,
+		patientID, tenantID,
+		patientEmail, patientName,
+		patientState,
+		string(patientHash),
+	)
+	if err != nil {
+		log.Fatalf("insert patient: %v", err)
+	}
+
+	// 4. Care relationship — ON CONFLICT on the unique (tenant_id, patient_id, physician_id) key.
+	_, err = tx.Exec(ctx,
+		`INSERT INTO care_relationships (tenant_id, patient_id, physician_id, active)
+		 VALUES ($1, $2, $3, true)
+		 ON CONFLICT (tenant_id, patient_id, physician_id) DO NOTHING`,
+		tenantID, patientID, physicianID,
+	)
+	if err != nil {
+		log.Fatalf("insert care_relationship: %v", err)
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		log.Fatalf("commit: %v", err)
+	}
+
+	// Print the seeded credentials so the operator / e2e script can copy them.
+	fmt.Println()
+	fmt.Println("=== seed complete ===")
+	fmt.Printf("tenant     id:       %s\n", tenantID)
+	fmt.Println()
+	fmt.Printf("physician  id:       %s\n", physicianID)
+	fmt.Printf("           email:    %s\n", physicianEmail)
+	fmt.Printf("           password: %s\n", physicianPassword)
+	fmt.Printf("           licensed: %s\n", physicianState)
+	fmt.Println()
+	fmt.Printf("patient    id:       %s\n", patientID)
+	fmt.Printf("           email:    %s\n", patientEmail)
+	fmt.Printf("           password: %s\n", patientPassword)
+	fmt.Printf("           state:    %s\n", patientState)
+	fmt.Println()
+	fmt.Println("care relationship: active (physician ↔ patient, same tenant)")
+	fmt.Println()
+
+	// Verify row counts so the caller can confirm what was inserted.
+	printCount(ctx, conn, "tenants", tenantID)
+	printCount(ctx, conn, "physicians", physicianID)
+	printCount(ctx, conn, "patients", patientID)
+	printCRCount(ctx, conn)
+}
+
+func printCount(ctx context.Context, conn *pgx.Conn, table string, id uuid.UUID) {
+	var n int
+	_ = conn.QueryRow(ctx,
+		fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE id = $1`, table), id,
+	).Scan(&n)
+	fmt.Printf("  %s (id=%s): %d row(s) in DB\n", table, id, n)
+}
+
+func printCRCount(ctx context.Context, conn *pgx.Conn) {
+	var n int
+	_ = conn.QueryRow(ctx,
+		`SELECT COUNT(*) FROM care_relationships
+		  WHERE patient_id = $1 AND physician_id = $2 AND active = true`,
+		patientID, physicianID,
+	).Scan(&n)
+	fmt.Printf("  care_relationships (patient↔physician, active): %d row(s) in DB\n", n)
+}
+
+func mustParseUUID(s string) uuid.UUID {
+	u, err := uuid.Parse(s)
+	if err != nil {
+		panic(fmt.Sprintf("invalid seed UUID %q: %v", s, err))
+	}
+	return u
+}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,14 +1,24 @@
-# Local Postgres for HouseCall backend development.
+# Local dev stack for HouseCall backend.
 #
-# Only the database is containerized — Go and Xcode stay native on the host.
-# This pins Postgres to the same major version as production (RDS Postgres 16)
-# and removes the "brew upgraded my Postgres" footgun.
+# Services
+# --------
+# postgres  – Postgres 16 (matches RDS target); data lives in a named volume.
+# server    – Go binary: runs migrations then starts the HTTP server on :8080.
+#             Reaches the host's Ollama via host.docker.internal (works under
+#             both Docker Desktop and Colima; the extra_hosts entry ensures the
+#             hostname resolves under Linux/Colima where it isn't injected by
+#             the daemon automatically).
 #
-#   make db-up     # start Postgres, wait until healthy
-#   make db-down   # stop it (data persists in the named volume)
+# Quick start
+# -----------
+#   cp .env.example .env          # fill in JWT_SECRET if desired (dev default works)
+#   docker compose up -d --build  # build + start both services
+#   make seed                     # insert seed data against the running stack
 #
-# The `server` service and `make seed` data land in Phase 7 (Task 7.1); this
-# file intentionally ships the postgres service only for now.
+# Targets
+#   make compose-up   alias: bring up compose + run migrate + run seed
+#   make db-up        bring up Postgres only (legacy, still works)
+#   make db-down      stop all compose services
 
 services:
   postgres:
@@ -28,6 +38,39 @@ services:
       interval: 2s
       timeout: 3s
       retries: 30
+
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: housecall-server
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://housecall:housecall@postgres:5432/housecall?sslmode=disable
+      JWT_SECRET: ${JWT_SECRET:-dev-jwt-secret-change-me-in-production}
+      AGENT_MODEL_BASE_URL: http://host.docker.internal:11434/v1
+      AGENT_MODEL_NAME: ${AGENT_MODEL_NAME:-medgemma:4b}
+      AGENT_MODEL_API_KEY: ${AGENT_MODEL_API_KEY:-}
+    ports:
+      - "${SERVER_PORT:-8080}:8080"
+    # host.docker.internal resolves automatically on Docker Desktop (macOS/Windows).
+    # Under Colima (and plain Linux), the daemon does not inject this hostname;
+    # extra_hosts maps it to the host-gateway address so Ollama is reachable.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    # Run migrations then start the server in a single CMD override.
+    # The binary supports both subcommands; we chain them with sh -c.
+    command: >
+      sh -c "./housecall -cmd migrate && ./housecall -cmd serve"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
 
 volumes:
   housecall-pgdata:

--- a/backend/scripts/e2e.sh
+++ b/backend/scripts/e2e.sh
@@ -1,0 +1,560 @@
+#!/usr/bin/env bash
+# HouseCall end-to-end test: seed → patient message → PENDING_REVIEW → physician
+# approves via the web app → patient asserts DELIVERED.
+#
+# Usage
+# -----
+#   cd backend
+#   ./scripts/e2e.sh
+#
+# The script brings up the compose stack, seeds the database, then drives the
+# full clinical-recommendation loop end-to-end via real HTTP calls.
+#
+# It detects automatically whether the server is reachable from the host
+# (Docker Desktop) or only from inside the compose network (Colima with the
+# macOS Virtualization.Framework, where host→container port forwarding may not
+# work). In the Colima case it falls back to running every HTTP call via
+# `docker compose exec housecall-server wget ...` so the test still exercises
+# the real server binary over the loopback interface.
+#
+# Environment overrides
+# ---------------------
+#   API_BASE   JSON API base URL  (default: http://localhost:8080)
+#   WEB_BASE   Web app base URL   (default: http://localhost:8080)
+#   SKIP_UP    Set to 1 to skip `docker compose up` + seed (stack already up)
+#   AGENT_POLL_TIMEOUT  Seconds to wait for the model to produce PENDING_REVIEW
+#                       (default: 120)
+#   EXEC_MODE  Force exec mode: "host" (curl from host) or "exec" (docker
+#              compose exec wget from inside server container). Auto-detected
+#              when unset.
+#
+# Host-curl mode (Docker Desktop or any runtime where localhost:8080 is
+# accessible from the macOS host):
+#   ./scripts/e2e.sh
+#
+# Exec mode override (Colima or unreachable ports):
+#   EXEC_MODE=exec ./scripts/e2e.sh
+#
+# Non-default port:
+#   API_BASE=http://localhost:9090 WEB_BASE=http://localhost:9090 ./scripts/e2e.sh
+#
+# HIPAA note: the JWT is redacted in all log output. The clinical question
+# used here is a generic, non-real-patient query — no PHI is committed.
+
+set -euo pipefail
+
+# ---- configuration -------------------------------------------------------
+API_BASE="${API_BASE:-http://localhost:8080}"
+WEB_BASE="${WEB_BASE:-http://localhost:8080}"
+SKIP_UP="${SKIP_UP:-0}"
+AGENT_POLL_TIMEOUT="${AGENT_POLL_TIMEOUT:-120}"
+POLL_INTERVAL=3  # seconds between polls
+EXEC_MODE="${EXEC_MODE:-}"  # "host", "exec", or empty (auto-detect)
+
+# Seed constants — must match cmd/seed/main.go
+TENANT_ID="00000000-0000-0000-0000-000000000001"
+PATIENT_EMAIL="patient@dev.housecall.local"
+PATIENT_PASSWORD="PatientDev1!"
+PHYSICIAN_EMAIL="physician@dev.housecall.local"
+PHYSICIAN_PASSWORD="PhysicianDev1!"
+
+# The patient question — generic clinical query, no real patient data.
+PATIENT_MESSAGE="I have had a mild headache and low-grade fever for two days. What should I watch for?"
+
+# ---- global state (set by steps; initialized to empty) -------------------
+PATIENT_TOKEN=""
+PHYSICIAN_TOKEN=""
+CONVERSATION_ID=""
+MESSAGE_ID=""
+RECOMMENDATION_ID=""
+
+# Temporary cookie jar used only in host curl mode.
+COOKIE_JAR="$(mktemp /tmp/hc_e2e_cookies.XXXXXX)"
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+# ---- helpers --------------------------------------------------------------
+log()  { echo "[e2e] $*"; }
+fail() { echo "[e2e] FAIL: $*" >&2; exit 1; }
+
+redact_token() {
+    local tok="$1"
+    printf '%s' "${tok:0:8}...<redacted>"
+}
+
+# json_field <field> <json> — extract a top-level string field.
+json_field() {
+    local field="$1"
+    local json="$2"
+    if command -v python3 >/dev/null 2>&1; then
+        printf '%s' "$json" \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('$field',''))"
+    elif command -v jq >/dev/null 2>&1; then
+        printf '%s' "$json" | jq -r --arg f "$field" '.[$f] // empty'
+    else
+        # Minimal sed fallback: "field": "value"
+        printf '%s' "$json" \
+            | sed -n "s/.*\"$field\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" \
+            | head -1
+    fi
+}
+
+# json_array_field0 <field> <json> — extract <field> from the first element
+# of a JSON array.
+json_array_field0() {
+    local field="$1"
+    local json="$2"
+    if command -v python3 >/dev/null 2>&1; then
+        printf '%s' "$json" | python3 -c \
+            "import sys,json; arr=json.load(sys.stdin); print(arr[0].get('$field','') if arr else '')"
+    elif command -v jq >/dev/null 2>&1; then
+        printf '%s' "$json" | jq -r --arg f "$field" '.[0][$f] // empty'
+    else
+        # Best-effort: first occurrence of "field":"value" in the JSON.
+        json_field "$field" "$json"
+    fi
+}
+
+check_deps() {
+    command -v docker >/dev/null 2>&1 || fail "docker is required but not found"
+    if ! command -v python3 >/dev/null 2>&1 && ! command -v jq >/dev/null 2>&1; then
+        fail "python3 or jq is required for JSON parsing but neither is found"
+    fi
+    if [[ "$EXEC_MODE" != "exec" ]] && ! command -v curl >/dev/null 2>&1; then
+        log "WARNING: curl not found; will auto-detect and may fall back to exec mode"
+    fi
+}
+
+# ---- exec-mode detection -------------------------------------------------
+# detect_exec_mode sets EXEC_MODE to "host" or "exec".
+#   "host"  — curl runs on the macOS host; requires localhost:PORT to be
+#             reachable (Docker Desktop, or Colima with network mode "host").
+#   "exec"  — each HTTP call is run via `docker compose exec housecall-server`
+#             using wget inside the Alpine container. Used when Colima with the
+#             macOS Virtualization.Framework makes the forwarded port
+#             unreachable from the host.
+detect_exec_mode() {
+    if [[ -n "$EXEC_MODE" ]]; then
+        log "EXEC_MODE=$EXEC_MODE (explicit override)"
+        return
+    fi
+    # Derive the host port from API_BASE.
+    local port
+    port="$(printf '%s' "$API_BASE" | sed 's|.*:\([0-9]*\)$|\1|')"
+    [[ -n "$port" ]] || port="8080"
+
+    if command -v curl >/dev/null 2>&1 \
+        && curl -sf --max-time 2 "${API_BASE}/healthz" >/dev/null 2>&1; then
+        EXEC_MODE="host"
+        log "Auto-detected: server reachable at ${API_BASE} from host → using curl (host mode)"
+    else
+        EXEC_MODE="exec"
+        log "Auto-detected: server NOT reachable at ${API_BASE} from host"
+        log "  → falling back to docker compose exec (exec mode, Colima-safe)"
+        log "  To force host mode: EXEC_MODE=host ./scripts/e2e.sh"
+    fi
+}
+
+# ---- low-level HTTP abstraction ------------------------------------------
+# api_get <path> [bearer_token] — returns body on stdout; exits non-zero on
+# HTTP error.
+api_get() {
+    local path="$1"
+    local token="${2:-}"
+    if [[ "$EXEC_MODE" == "host" ]]; then
+        local args=(-sf "${API_BASE}${path}")
+        [[ -n "$token" ]] && args+=(-H "Authorization: Bearer ${token}")
+        curl "${args[@]}"
+    else
+        # exec mode: wget inside the server container.
+        local wargs=(-qO-)
+        [[ -n "$token" ]] && wargs+=(--header="Authorization: Bearer ${token}")
+        _docker_exec wget "${wargs[@]}" "http://localhost:8080${path}"
+    fi
+}
+
+# api_post_json <path> <json_body> [bearer_token] — returns body on stdout.
+api_post_json() {
+    local path="$1"
+    local body="$2"
+    local token="${3:-}"
+    if [[ "$EXEC_MODE" == "host" ]]; then
+        local args=(-sf -X POST "${API_BASE}${path}" -H "Content-Type: application/json")
+        [[ -n "$token" ]] && args+=(-H "Authorization: Bearer ${token}")
+        args+=(-d "$body")
+        curl "${args[@]}"
+    else
+        local wargs=(-qO- --header="Content-Type: application/json" --post-data="$body")
+        [[ -n "$token" ]] && wargs+=(--header="Authorization: Bearer ${token}")
+        _docker_exec wget "${wargs[@]}" "http://localhost:8080${path}"
+    fi
+}
+
+# web_post_form_with_cookies <path> <form_data> — POST a URL-encoded form,
+# capturing the session cookie (login) and following the redirect.
+# Returns 0 on success (final HTTP status 200 or 302/303).
+web_post_form_with_cookies() {
+    local path="$1"
+    local data="$2"
+    if [[ "$EXEC_MODE" == "host" ]]; then
+        local code
+        code="$(curl -sf --cookie-jar "$COOKIE_JAR" \
+            -o /dev/null -w "%{http_code}" \
+            -L \
+            -X POST "${WEB_BASE}${path}" \
+            -d "$data")"
+        echo "$code"
+    else
+        # In exec mode we can't use the host cookie jar.  Instead, capture
+        # the Set-Cookie header from wget and store the value in a shell var.
+        # wget in Alpine writes headers to stderr with -S; we pipe stderr to
+        # stdout and extract the Set-Cookie line.
+        local output
+        output="$(_docker_exec_raw sh -c \
+            "wget -qO- -S --post-data='${data}' 'http://localhost:8080${path}' 2>&1")" || true
+        local cookie_val
+        cookie_val="$(printf '%s\n' "$output" | grep -i "Set-Cookie:" | grep "hc_session" \
+            | sed 's/.*hc_session=\([^;]*\).*/\1/' | head -1)"
+        if [[ -n "$cookie_val" ]]; then
+            # Store for subsequent exec-mode cookie POSTs.
+            WEB_SESSION_COOKIE_VALUE="$cookie_val"
+        fi
+        # Report final HTTP status: 200 (after redirect) on success.
+        local status
+        status="$(printf '%s\n' "$output" | grep "HTTP/" | tail -1 \
+            | awk '{print $2}' || true)"
+        echo "${status:-000}"
+    fi
+}
+
+# web_get_with_cookies <path> — GET a web app page with the session cookie.
+web_get_with_cookies() {
+    local path="$1"
+    if [[ "$EXEC_MODE" == "host" ]]; then
+        curl -sf --cookie "$COOKIE_JAR" "${WEB_BASE}${path}"
+    else
+        _docker_exec wget -qO- \
+            --header="Cookie: hc_session=${WEB_SESSION_COOKIE_VALUE:-}" \
+            "http://localhost:8080${path}"
+    fi
+}
+
+# web_post_form_approve <path> <form_data> — POST the approve form, reusing
+# the captured session cookie.
+web_post_form_approve() {
+    local path="$1"
+    local data="$2"
+    if [[ "$EXEC_MODE" == "host" ]]; then
+        local code
+        code="$(curl -sf --cookie "$COOKIE_JAR" \
+            -o /dev/null -w "%{http_code}" \
+            -L \
+            -X POST "${WEB_BASE}${path}" \
+            -d "$data")"
+        echo "$code"
+    else
+        local output
+        output="$(_docker_exec_raw sh -c \
+            "wget -qO- -S \
+                --header='Cookie: hc_session=${WEB_SESSION_COOKIE_VALUE:-}' \
+                --post-data='${data}' \
+                'http://localhost:8080${path}' 2>&1")" || true
+        local status
+        status="$(printf '%s\n' "$output" | grep "HTTP/" | tail -1 \
+            | awk '{print $2}' || true)"
+        echo "${status:-000}"
+    fi
+}
+
+# _docker_exec — run a command inside the server container via docker exec.
+_docker_exec() {
+    docker exec housecall-server "$@"
+}
+
+# _docker_exec_raw — run a shell command string inside the server container
+# (used when we need to capture stderr as well as stdout).
+_docker_exec_raw() {
+    docker exec housecall-server "$@"
+}
+
+# WEB_SESSION_COOKIE_VALUE — used only in exec mode (host mode uses the
+# cookie jar file).
+WEB_SESSION_COOKIE_VALUE=""
+
+# ---- step 0: bring up the stack ------------------------------------------
+bring_up_stack() {
+    if [[ "$SKIP_UP" == "1" ]]; then
+        log "SKIP_UP=1: skipping compose up + seed"
+        return
+    fi
+
+    log "Bringing up compose stack (docker compose up -d --build --wait)..."
+    local script_dir backend_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    backend_dir="$(cd "$script_dir/.." && pwd)"
+
+    (cd "$backend_dir" && docker compose up -d --build --wait) \
+        || fail "docker compose up failed"
+
+    log "Stack is up. Seeding database..."
+    (cd "$backend_dir" && make seed) \
+        || fail "make seed failed"
+    log "Seed complete."
+}
+
+# ---- step 1: patient login -----------------------------------------------
+patient_login() {
+    log "Step 1: patient login..."
+    local body
+    body="$(api_post_json "/api/auth/login" \
+        "{\"tenant_id\":\"${TENANT_ID}\",\"email\":\"${PATIENT_EMAIL}\",\"password\":\"${PATIENT_PASSWORD}\"}" \
+    )" || fail "patient login request failed (server at ${API_BASE} not responding)"
+
+    # Auth response uses json-tagged lowercase fields ("token", "actor_id", etc.)
+    PATIENT_TOKEN="$(json_field token "$body")"
+    [[ -n "$PATIENT_TOKEN" ]] || fail "patient login: no token in response: $body"
+    log "Patient logged in. token=$(redact_token "$PATIENT_TOKEN")"
+}
+
+# ---- step 2: create conversation -----------------------------------------
+create_conversation() {
+    log "Step 2: patient creates conversation..."
+    local body
+    body="$(api_post_json "/api/conversations" \
+        '{"title":"E2E test conversation"}' \
+        "$PATIENT_TOKEN" \
+    )" || fail "create conversation request failed"
+
+    # Conversation struct has no json tags → Go default "ID" (capital).
+    CONVERSATION_ID="$(json_field ID "$body")"
+    [[ -n "$CONVERSATION_ID" ]] || fail "create conversation: no ID in response: $body"
+    log "Conversation created: $CONVERSATION_ID"
+}
+
+# ---- step 3: post patient message (triggers DraftAsync) ------------------
+post_message() {
+    log "Step 3: patient posts message (triggers agent draft)..."
+    # Escape the message as a JSON string.
+    local escaped_msg
+    escaped_msg="$(printf '%s' "$PATIENT_MESSAGE" \
+        | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))' 2>/dev/null \
+        || printf '"%s"' "$PATIENT_MESSAGE")"
+
+    local body
+    body="$(api_post_json \
+        "/api/conversations/${CONVERSATION_ID}/messages" \
+        "{\"content\":${escaped_msg}}" \
+        "$PATIENT_TOKEN" \
+    )" || fail "post message request failed"
+
+    # Message struct has no json tags → Go default "ID" (capital).
+    MESSAGE_ID="$(json_field ID "$body")"
+    [[ -n "$MESSAGE_ID" ]] || fail "post message: no ID in response: $body"
+    log "Message posted: $MESSAGE_ID"
+    log "Agent is drafting in the background..."
+}
+
+# ---- step 4: physician JSON API login (to poll queue) --------------------
+physician_api_login() {
+    log "Step 4a: physician API login (to poll queue for PENDING_REVIEW)..."
+    local body
+    body="$(api_post_json "/api/auth/login" \
+        "{\"tenant_id\":\"${TENANT_ID}\",\"email\":\"${PHYSICIAN_EMAIL}\",\"password\":\"${PHYSICIAN_PASSWORD}\"}" \
+    )" || fail "physician API login request failed"
+
+    # Auth response uses json-tagged lowercase fields.
+    PHYSICIAN_TOKEN="$(json_field token "$body")"
+    [[ -n "$PHYSICIAN_TOKEN" ]] || fail "physician API login: no token in response: $body"
+    log "Physician API login OK. token=$(redact_token "$PHYSICIAN_TOKEN")"
+}
+
+# ---- step 5: poll physician queue for PENDING_REVIEW ---------------------
+poll_for_pending() {
+    log "Step 5: polling physician queue for PENDING_REVIEW (timeout ${AGENT_POLL_TIMEOUT}s)..."
+    local elapsed=0
+
+    while [[ $elapsed -lt $AGENT_POLL_TIMEOUT ]]; do
+        local body rec_id
+        body="$(api_get "/api/recommendations?state=PENDING_REVIEW" "$PHYSICIAN_TOKEN" 2>/dev/null)" || true
+        # Recommendation struct has no json tags → Go default "ID" (capital).
+        rec_id="$(json_array_field0 ID "$body" 2>/dev/null || true)"
+
+        if [[ -n "$rec_id" && "$rec_id" != "null" && "$rec_id" != "" ]]; then
+            RECOMMENDATION_ID="$rec_id"
+            log "PENDING_REVIEW recommendation found: $RECOMMENDATION_ID (after ${elapsed}s)"
+            return
+        fi
+
+        log "  ...waiting for agent draft (${elapsed}s elapsed, will retry in ${POLL_INTERVAL}s)"
+        sleep "$POLL_INTERVAL"
+        elapsed=$((elapsed + POLL_INTERVAL))
+    done
+
+    # Diagnosis
+    log ""
+    log "Diagnosis: checking if Ollama is reachable on host port 11434..."
+    if curl -sf --max-time 3 "http://localhost:11434/api/tags" >/dev/null 2>&1 \
+        || docker exec housecall-server wget -qO- --timeout=3 "http://host.docker.internal:11434/api/tags" >/dev/null 2>&1; then
+        log "  Ollama appears reachable. Check server logs:"
+        log "    docker compose logs server | tail -50"
+    else
+        log "  Ollama is NOT reachable."
+        log "  Steps to fix:"
+        log "    1. ollama serve          (if not already running)"
+        log "    2. ollama pull medgemma:4b"
+        log "    3. Re-run this script"
+    fi
+    fail "Timed out after ${AGENT_POLL_TIMEOUT}s waiting for a PENDING_REVIEW recommendation."
+}
+
+# ---- step 6: physician web app login + approve ---------------------------
+# This exercises the real server-rendered physician UI path. A physician
+# using a browser would:
+#   1. Visit /web/login, enter credentials → gets an hc_session cookie.
+#   2. Visit /web/queue → sees pending recommendations.
+#   3. Click Approve (POST /web/recommendations/{id}/review, action=approve).
+#
+# We replicate all three steps with HTTP calls so the full HTML/form path is
+# exercised, not just the JSON API.
+#
+# Note on the Secure cookie flag: the hc_session cookie is issued with
+# Secure: true. Standard browsers refuse to send Secure cookies over plain
+# HTTP. curl ignores this restriction and sends the cookie regardless —
+# which is the correct behaviour for a local integration-test driver that
+# has no TLS terminator. In exec mode we capture the cookie value from the
+# Set-Cookie header and pass it explicitly, achieving the same result.
+physician_web_approve() {
+    log "Step 6: physician approves recommendation ${RECOMMENDATION_ID} via web app..."
+
+    # 6a. POST /web/login with physician credentials.
+    log "  6a. Web app login..."
+    local login_status
+    login_status="$(web_post_form_with_cookies "/web/login" \
+        "tenant_id=${TENANT_ID}&email=${PHYSICIAN_EMAIL}&password=${PHYSICIAN_PASSWORD}")"
+
+    # With -L (follow redirect) the final status should be 200 (queue page).
+    # In exec mode we may get the redirect status (303) if wget doesn't follow.
+    case "$login_status" in
+        200|303)
+            : # OK
+            ;;
+        *)
+            fail "web login: unexpected HTTP status ${login_status} (expected 200 or 303)"
+            ;;
+    esac
+
+    # Verify the session cookie was captured.
+    if [[ "$EXEC_MODE" == "host" ]]; then
+        grep -q "hc_session" "$COOKIE_JAR" \
+            || fail "web login: no hc_session cookie issued — check physician credentials"
+    else
+        [[ -n "$WEB_SESSION_COOKIE_VALUE" ]] \
+            || fail "web login: no hc_session cookie captured from Set-Cookie header"
+    fi
+    log "  Web login OK, hc_session cookie captured."
+
+    # 6b. GET /web/queue — smoke-check that the recommendation appears.
+    log "  6b. Loading physician queue page..."
+    local queue_body
+    queue_body="$(web_get_with_cookies "/web/queue")" \
+        || fail "GET /web/queue failed"
+
+    if ! printf '%s' "$queue_body" | grep -q "$RECOMMENDATION_ID"; then
+        log "WARNING: recommendation $RECOMMENDATION_ID not visible in queue HTML."
+        log "  Continuing anyway — the approve POST will fail if access is denied."
+    else
+        log "  Recommendation visible in queue."
+    fi
+
+    # 6c. POST /web/recommendations/{id}/review with action=approve.
+    log "  6c. Submitting approve form..."
+    local review_status
+    review_status="$(web_post_form_approve \
+        "/web/recommendations/${RECOMMENDATION_ID}/review" \
+        "action=approve")"
+
+    case "$review_status" in
+        200|303)
+            : # OK — 303 redirect to /web/queue is the success path
+            ;;
+        *)
+            fail "web approve: unexpected HTTP status ${review_status} (expected 200 or 303)"
+            ;;
+    esac
+    log "  Approve form submitted (HTTP ${review_status} — success)."
+}
+
+# ---- step 7: patient polls for DELIVERED ---------------------------------
+poll_for_delivered() {
+    log "Step 7: patient polls for DELIVERED recommendation (timeout 30s)..."
+    local elapsed=0
+    local delivered_timeout=30
+
+    while [[ $elapsed -lt $delivered_timeout ]]; do
+        local body state
+        body="$(api_get "/api/recommendations/${RECOMMENDATION_ID}" "$PATIENT_TOKEN" 2>/dev/null)" || true
+        # Recommendation struct has no json tags → Go default "State",
+        # "FinalContent" (capital).
+        state="$(json_field State "$body" 2>/dev/null || true)"
+
+        if [[ "$state" == "DELIVERED" ]]; then
+            # Assert FinalContent is non-empty (HIPAA: assert presence, not value).
+            local has_content
+            if command -v python3 >/dev/null 2>&1; then
+                has_content="$(printf '%s' "$body" | python3 -c \
+                    'import sys,json; d=json.load(sys.stdin); fc=d.get("FinalContent"); print(fc if fc else "")' \
+                    2>/dev/null || true)"
+            elif command -v jq >/dev/null 2>&1; then
+                has_content="$(printf '%s' "$body" | jq -r '.FinalContent // empty' 2>/dev/null || true)"
+            else
+                has_content="nonempty"  # fallback: assume ok
+            fi
+            [[ -n "$has_content" ]] \
+                || fail "Recommendation is DELIVERED but final_content is empty — state-machine invariant violated"
+            log "Recommendation $RECOMMENDATION_ID is DELIVERED. final_content: [non-empty, content redacted]"
+            return
+        fi
+
+        if [[ -n "$state" && "$state" != "null" && "$state" != "" ]]; then
+            log "  ...state=$state (waiting for DELIVERED)"
+        else
+            log "  ...recommendation not yet visible to patient (not DELIVERED)"
+        fi
+
+        sleep "$POLL_INTERVAL"
+        elapsed=$((elapsed + POLL_INTERVAL))
+    done
+
+    fail "Timed out after ${delivered_timeout}s waiting for DELIVERED state"
+}
+
+# ---- main ----------------------------------------------------------------
+main() {
+    log "========================================"
+    log "HouseCall E2E Test"
+    log "  API:  $API_BASE"
+    log "  WEB:  $WEB_BASE"
+    log "========================================"
+
+    check_deps
+    bring_up_stack
+    detect_exec_mode
+    patient_login
+    create_conversation
+    post_message
+    physician_api_login
+    poll_for_pending
+    physician_web_approve
+    poll_for_delivered
+
+    log ""
+    log "========================================"
+    log "E2E PASSED"
+    log "Full loop verified:"
+    log "  patient message → agent draft → PENDING_REVIEW"
+    log "  physician approved via web app → DELIVERED"
+    log "  patient sees DELIVERED recommendation with non-empty content"
+    log "========================================"
+    exit 0
+}
+
+main "$@"

--- a/backend/scripts/e2e.sh
+++ b/backend/scripts/e2e.sh
@@ -70,7 +70,11 @@ RECOMMENDATION_ID=""
 
 # Temporary cookie jar used only in host curl mode.
 COOKIE_JAR="$(mktemp /tmp/hc_e2e_cookies.XXXXXX)"
-trap 'rm -f "$COOKIE_JAR"' EXIT
+# Temporary file used in exec mode to pass the captured hc_session cookie value
+# out of the subshell created by command substitution (variable assignments
+# inside $() do not propagate to the parent shell).
+EXEC_COOKIE_FILE="$(mktemp /tmp/hc_e2e_exec_cookie.XXXXXX)"
+trap 'rm -f "$COOKIE_JAR" "$EXEC_COOKIE_FILE"' EXIT
 
 # ---- helpers --------------------------------------------------------------
 log()  { echo "[e2e] $*"; }
@@ -190,44 +194,50 @@ api_post_json() {
 }
 
 # web_post_form_with_cookies <path> <form_data> — POST a URL-encoded form,
-# capturing the session cookie (login) and following the redirect.
-# Returns 0 on success (final HTTP status 200 or 302/303).
+# capturing the session cookie (login) WITHOUT following the redirect.
+# The server issues a 303 See Other on successful login; we capture the
+# Set-Cookie header from that response and return the status (200 or 303).
 web_post_form_with_cookies() {
     local path="$1"
     local data="$2"
     if [[ "$EXEC_MODE" == "host" ]]; then
-        local code
-        code="$(curl -sf --cookie-jar "$COOKIE_JAR" \
-            -o /dev/null -w "%{http_code}" \
-            -L \
+        # Do NOT use -L: we want the 303 + its Set-Cookie, not the followed page.
+        # Capture the full response headers + body so we can parse Set-Cookie.
+        local response code
+        response="$(curl -si --cookie-jar "$COOKIE_JAR" \
             -X POST "${WEB_BASE}${path}" \
-            -d "$data")"
-        echo "$code"
+            -d "$data")" || true
+        # Extract status from the first HTTP response status line only.
+        code="$(printf '%s\n' "$response" | grep -m1 '^HTTP/' | awk '{print $2}')"
+        echo "${code:-000}"
     else
-        # In exec mode we can't use the host cookie jar.  Instead, capture
-        # the Set-Cookie header from wget and store the value in a shell var.
-        # wget in Alpine writes headers to stderr with -S; we pipe stderr to
-        # stdout and extract the Set-Cookie line.
-        # Pass form data and path via env vars so a crafted server response
-        # value cannot break out of the sh -c string and execute commands.
-        local output
+        # In exec mode we can't use the host cookie jar.  Use curl (available in
+        # the runtime image) with -i (headers in output) and without -L so we
+        # capture the 303 Set-Cookie rather than following to a 200 that has no
+        # cookie.  Pass data and path via env vars to prevent injection.
+        #
+        # IMPORTANT: this function is called via login_status="$(web_post_form_with_cookies ...)",
+        # which runs it in a subshell.  Variable assignments inside a subshell do
+        # NOT propagate to the parent, so we write the cookie value to a temp file
+        # (EXEC_COOKIE_FILE) and the caller reads it from there.
+        local output code cookie_val
         output="$(docker exec \
             -e _HC_POST_DATA="$data" \
             -e _HC_PATH="$path" \
             housecall-server \
-            sh -c 'wget -qO- -S --post-data="$_HC_POST_DATA" "http://localhost:8080$_HC_PATH" 2>&1')" || true
-        local cookie_val
-        cookie_val="$(printf '%s\n' "$output" | grep -i "Set-Cookie:" | grep "hc_session" \
-            | sed 's/.*hc_session=\([^;]*\).*/\1/' | head -1)"
-        if [[ -n "$cookie_val" ]]; then
-            # Store for subsequent exec-mode cookie POSTs.
-            WEB_SESSION_COOKIE_VALUE="$cookie_val"
-        fi
-        # Report final HTTP status: 200 (after redirect) on success.
-        local status
-        status="$(printf '%s\n' "$output" | grep "HTTP/" | tail -1 \
-            | awk '{print $2}' || true)"
-        echo "${status:-000}"
+            sh -c 'curl -si -X POST -d "$_HC_POST_DATA" "http://localhost:8080$_HC_PATH"')" || true
+        # Extract status from the FIRST HTTP response status line only (curl -i
+        # format: "HTTP/1.1 303 See Other").  Using grep -m1 prevents any
+        # server-response body text from being mistaken for a status line.
+        code="$(printf '%s\n' "$output" | grep -m1 '^HTTP/' | awk '{print $2}')"
+        # Extract hc_session cookie value from Set-Cookie header.
+        # tr -d '\r' strips the CR from CRLF HTTP headers so the value is clean.
+        cookie_val="$(printf '%s\n' "$output" | grep -i '^Set-Cookie:' | grep 'hc_session' \
+            | sed 's/.*hc_session=\([^;]*\).*/\1/' | tr -d '\r' | head -1)"
+        # Write cookie to temp file so the parent shell can read it (subshell
+        # variable assignments do not propagate through command substitution).
+        printf '%s' "$cookie_val" > "$EXEC_COOKIE_FILE"
+        echo "${code:-000}"
     fi
 }
 
@@ -243,41 +253,40 @@ web_get_with_cookies() {
             -e _HC_SESSION="$WEB_SESSION_COOKIE_VALUE" \
             -e _HC_PATH="$path" \
             housecall-server \
-            sh -c 'wget -qO- --header="Cookie: hc_session=$_HC_SESSION" "http://localhost:8080$_HC_PATH"'
+            sh -c 'curl -sf -b "hc_session=$_HC_SESSION" "http://localhost:8080$_HC_PATH"'
     fi
 }
 
 # web_post_form_approve <path> <form_data> — POST the approve form, reusing
-# the captured session cookie.
+# the captured session cookie.  Accept 200 or 303 (redirect to queue page).
 web_post_form_approve() {
     local path="$1"
     local data="$2"
     if [[ "$EXEC_MODE" == "host" ]]; then
-        local code
-        code="$(curl -sf --cookie "$COOKIE_JAR" \
-            -o /dev/null -w "%{http_code}" \
-            -L \
+        # Do NOT use -L: accept the 303 redirect as success (consistent with
+        # web_post_form_with_cookies).
+        local response code
+        response="$(curl -si --cookie "$COOKIE_JAR" \
             -X POST "${WEB_BASE}${path}" \
-            -d "$data")"
-        echo "$code"
+            -d "$data")" || true
+        code="$(printf '%s\n' "$response" | grep -m1 '^HTTP/' | awk '{print $2}')"
+        echo "${code:-000}"
     else
         # Pass cookie value, form data, and path via env vars so a crafted
         # server-response-derived value (cookie, recommendation id) cannot
         # break out of the sh -c string and execute commands in the container.
-        local output
+        # curl -si: response headers in stdout, no redirect follow.
+        # Status extracted from the first HTTP/ line only (grep -m1) so that
+        # body text can never be mistaken for a status code.
+        local output code
         output="$(docker exec \
             -e _HC_SESSION="$WEB_SESSION_COOKIE_VALUE" \
             -e _HC_POST_DATA="$data" \
             -e _HC_PATH="$path" \
             housecall-server \
-            sh -c 'wget -qO- -S \
-                --header="Cookie: hc_session=$_HC_SESSION" \
-                --post-data="$_HC_POST_DATA" \
-                "http://localhost:8080$_HC_PATH" 2>&1')" || true
-        local status
-        status="$(printf '%s\n' "$output" | grep "HTTP/" | tail -1 \
-            | awk '{print $2}' || true)"
-        echo "${status:-000}"
+            sh -c 'curl -si -X POST -b "hc_session=$_HC_SESSION" -d "$_HC_POST_DATA" "http://localhost:8080$_HC_PATH"')" || true
+        code="$(printf '%s\n' "$output" | grep -m1 '^HTTP/' | awk '{print $2}')"
+        echo "${code:-000}"
     fi
 }
 
@@ -447,8 +456,15 @@ physician_web_approve() {
     login_status="$(web_post_form_with_cookies "/web/login" \
         "tenant_id=${TENANT_ID}&email=${PHYSICIAN_EMAIL}&password=${PHYSICIAN_PASSWORD}")"
 
-    # With -L (follow redirect) the final status should be 200 (queue page).
-    # In exec mode we may get the redirect status (303) if wget doesn't follow.
+    # In exec mode, read the cookie value from the temp file written by
+    # web_post_form_with_cookies.  Variable assignments inside command
+    # substitution subshells do not propagate, so the function writes to a
+    # file instead of a variable.
+    if [[ "$EXEC_MODE" != "host" ]]; then
+        WEB_SESSION_COOKIE_VALUE="$(cat "$EXEC_COOKIE_FILE")"
+    fi
+
+    # Status check: 303 is the normal redirect after successful login.
     case "$login_status" in
         200|303)
             : # OK

--- a/backend/scripts/e2e.sh
+++ b/backend/scripts/e2e.sh
@@ -208,9 +208,14 @@ web_post_form_with_cookies() {
         # the Set-Cookie header from wget and store the value in a shell var.
         # wget in Alpine writes headers to stderr with -S; we pipe stderr to
         # stdout and extract the Set-Cookie line.
+        # Pass form data and path via env vars so a crafted server response
+        # value cannot break out of the sh -c string and execute commands.
         local output
-        output="$(_docker_exec_raw sh -c \
-            "wget -qO- -S --post-data='${data}' 'http://localhost:8080${path}' 2>&1")" || true
+        output="$(docker exec \
+            -e _HC_POST_DATA="$data" \
+            -e _HC_PATH="$path" \
+            housecall-server \
+            sh -c 'wget -qO- -S --post-data="$_HC_POST_DATA" "http://localhost:8080$_HC_PATH" 2>&1')" || true
         local cookie_val
         cookie_val="$(printf '%s\n' "$output" | grep -i "Set-Cookie:" | grep "hc_session" \
             | sed 's/.*hc_session=\([^;]*\).*/\1/' | head -1)"
@@ -232,9 +237,13 @@ web_get_with_cookies() {
     if [[ "$EXEC_MODE" == "host" ]]; then
         curl -sf --cookie "$COOKIE_JAR" "${WEB_BASE}${path}"
     else
-        _docker_exec wget -qO- \
-            --header="Cookie: hc_session=${WEB_SESSION_COOKIE_VALUE:-}" \
-            "http://localhost:8080${path}"
+        # Pass cookie value via env var to prevent injection from a
+        # server-response-derived value breaking out of the header string.
+        docker exec \
+            -e _HC_SESSION="$WEB_SESSION_COOKIE_VALUE" \
+            -e _HC_PATH="$path" \
+            housecall-server \
+            sh -c 'wget -qO- --header="Cookie: hc_session=$_HC_SESSION" "http://localhost:8080$_HC_PATH"'
     fi
 }
 
@@ -252,12 +261,19 @@ web_post_form_approve() {
             -d "$data")"
         echo "$code"
     else
+        # Pass cookie value, form data, and path via env vars so a crafted
+        # server-response-derived value (cookie, recommendation id) cannot
+        # break out of the sh -c string and execute commands in the container.
         local output
-        output="$(_docker_exec_raw sh -c \
-            "wget -qO- -S \
-                --header='Cookie: hc_session=${WEB_SESSION_COOKIE_VALUE:-}' \
-                --post-data='${data}' \
-                'http://localhost:8080${path}' 2>&1")" || true
+        output="$(docker exec \
+            -e _HC_SESSION="$WEB_SESSION_COOKIE_VALUE" \
+            -e _HC_POST_DATA="$data" \
+            -e _HC_PATH="$path" \
+            housecall-server \
+            sh -c 'wget -qO- -S \
+                --header="Cookie: hc_session=$_HC_SESSION" \
+                --post-data="$_HC_POST_DATA" \
+                "http://localhost:8080$_HC_PATH" 2>&1')" || true
         local status
         status="$(printf '%s\n' "$output" | grep "HTTP/" | tail -1 \
             | awk '{print $2}' || true)"

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -178,9 +178,9 @@ physician-approved assistant reply; airplane-mode messages replay on reconnect.
       relationship
 
 ### Task 7.2: End-to-end test
-- [ ] Scripted run against a real local model: seed → patient message via API →
+- [x] Scripted run against a real local model: seed → patient message via API →
       approve in the web app → assert delivery
-- [ ] Document the local model setup (Ollama/vLLM + MedGemma variant)
+- [x] Document the local model setup (Ollama/vLLM + MedGemma variant)
 
 **Validation**: `docker compose up` + local model + the e2e script proves the
 full loop.

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -173,8 +173,8 @@ physician-approved assistant reply; airplane-mode messages replay on reconnect.
 ## Phase 7: Local Dev Environment & End-to-End Test
 
 ### Task 7.1: Docker Compose
-- [ ] `backend/docker-compose.yml` — `postgres` + `server`
-- [ ] `make seed` — one tenant, one physician, one patient, one active care
+- [x] `backend/docker-compose.yml` — `postgres` + `server`
+- [x] `make seed` — one tenant, one physician, one patient, one active care
       relationship
 
 ### Task 7.2: End-to-end test


### PR DESCRIPTION
## Phase 7 — Local Dev Environment & End-to-End Test

A one-command local stack and a scripted end-to-end test that proves the full physician-in-loop loop against a real local model.

### Tasks (tester PASS + reviewer APPROVE)
- [x] **7.1 Docker Compose** — `backend/docker-compose.yml` (`postgres` + `server`), multi-stage `Dockerfile`, server reaches host Ollama via `host.docker.internal` (Colima `extra_hosts`), `AGENT_MODEL_NAME=medgemma:4b`; `make seed` = one tenant + one physician (bcrypt, licensed CA) + one patient (CA) + one active care relationship (deterministic, idempotent)
- [x] **7.2 End-to-end test** — `backend/scripts/e2e.sh`: seed → patient message → agent drafts → `PENDING_REVIEW` → **physician approves in the web app** → patient sees `DELIVERED`; documents Ollama + `medgemma:4b` setup (vLLM alternative noted)

### Proven live
Ran end-to-end against **Ollama + `medgemma:4b`** on the host: patient message → medgemma drafts a recommendation (~6s) → `PENDING_REVIEW` → physician web-app login + approve → patient `GET` shows `DELIVERED` with non-empty final content. **"E2E PASSED", exit 0, confirmed twice (repeatable).**

### Notable
- `medgemma:4b` is pulled locally (3.3 GB) and Ollama serves on :11434; the container reaches it through `host.docker.internal` (works under Colima via `extra_hosts: host-gateway`).
- Under Colima VZ the host can't always reach the published port, so the e2e auto-detects and runs its HTTP calls **inside the compose network via `docker exec` + curl** (curl added to the runtime image for this).

### Security (reviewer-verified)
- No real secrets committed: `JWT_SECRET`/`AGENT_MODEL_API_KEY`/DB password are dev-only via env, `.env.example` provided, `backend/.env` gitignored.
- Seed passwords **bcrypt-hashed** (cost 12), never plaintext.
- e2e **redacts the JWT** and never prints the `hc_session` cookie or PHI clinical text; the cookie temp file is `mktemp` + trap-cleaned.
- e2e drives the **real** flow — real login, real care-relationship-scoped web approve, real `DELIVERED` assertion — no state-machine bypass; exits non-zero (no false pass) if the model never drafts.

### Beads closed
- HouseCall-qhe (7.1) #22 · HouseCall-0si (7.2) #21

### Non-blocking note (deferred)
- `curl` now ships in the server runtime image (for the e2e exec fallback). Fine for the dev-compose image; if this image is ever pushed to prod, consider a separate test-image stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)