### PR TITLE
add-cloud-platform-mvp: Phase 8 — Documentation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,246 +1,82 @@
 # HouseCall Backend
 
-Go services for the HouseCall platform — Core API, AI Agent Runtime, and the
-server-rendered physician web app (see [`../docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) §2).
-For the MVP the three components ship as one Go binary with package
-boundaries kept clean so the Agent Runtime can be split out later without
-reworking the domain or store layers.
+The Go Core API, AI Agent Runtime, and server-rendered physician web app for the
+HouseCall cloud platform MVP. All three components ship as one binary with clean
+package boundaries so the Agent Runtime can be extracted later without reworking
+the domain or store layers.
 
-**Status:** Phase 1 of `add-cloud-platform-mvp` is complete — Go module
-scaffold, PostgreSQL schema, tenant-scoped store, tenant-isolation tests,
-and a runnable `cmd/server` binary with `/healthz`. Phases 2–8
-(REST + WebSocket, the physician-in-loop state machine, the AI Agent
-Runtime, the physician web app, iOS sync, Docker Compose, e2e) are not
-yet implemented.
+For the overall system design — tenancy model, PHI data flow, state machine, and
+how this backend fits with the iOS app — see
+[`../docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md).
 
-## Layout
+---
 
-```
-backend/
-  cmd/server/        main(): migrate or serve subcommands
-  internal/
-    migrate/         tiny SQL migration runner backed by schema_migrations
-    store/           pgx store; every PHI query takes a TenantID
-  migrations/        0001_init.sql and forward
-  Makefile           build, run, test, migrate
-  go.mod
-```
+## Prerequisites
 
-## Dependencies
+| Tool | Required? | Notes |
+|---|---|---|
+| **Go 1.25+** | Yes | Pinned in `go.mod`; use `mise` or install directly |
+| **Docker** | Yes | Colima works; Docker Desktop works |
+| **`docker compose`** (v2) | Yes | Bundled with Docker Desktop; `brew install docker-compose` for Colima |
+| **Ollama** | For AI path | The AI Agent calls a local model at `localhost:11434` |
+| `curl`, `python3` or `jq` | For e2e test | Standard on macOS; used by `scripts/e2e.sh` |
 
-- `github.com/jackc/pgx/v5` — PostgreSQL driver and connection pool
-- `github.com/go-chi/chi/v5` — HTTP router
-- `github.com/coder/websocket` — WebSocket library (used from Phase 2.3)
-- `github.com/google/uuid` — UUID type
-- Standard library otherwise. No web framework; no ORM.
-
-## Local development
-
-### Prerequisites (managed for you)
-
-Versions are pinned so you don't fight dependency drift:
-
-- **Go** — pinned by [`../.tool-versions`](../.tool-versions) via `mise`, and
-  by the `toolchain` directive in `go.mod`.
-- **Postgres 16** — runs in Docker (`docker-compose.yml`), matching production
-  (RDS Postgres 16). Not installed via brew, so a stray `brew upgrade` can't
-  move it. The container runtime is **Colima** (no Docker Desktop required).
-- **Xcode** — pinned by [`../.xcode-version`](../.xcode-version); install/select
-  with `xcodes`. (Xcode cannot be containerized; it stays native — see
-  [`../docs/WORKFLOW.md`](../docs/WORKFLOW.md).)
-- **colima, docker CLI, docker-compose, gh, jq, mise, xcodes** — declared in
-  [`../Brewfile`](../Brewfile).
-
-### Mac mini quickstart (recommended)
-
-From the repository root, run the one-shot bootstrap. It is idempotent: it
-runs `brew bundle`, pins Go via `mise`, installs `beads`, starts the
-Dockerized Postgres, applies migrations, wires up the beads graph, and runs
-the environment doctor:
+Go must be at least 1.25 (`go.mod` declares `go 1.25.0`). Check with:
 
 ```bash
-scripts/dev-bootstrap.sh
-gh auth login          # if not already authenticated
-scripts/doctor.sh      # green/red preflight; run before each session
+go version
 ```
 
-Then drive development through the orchestrator from an interactive Claude
-Code session (see [`../docs/WORKFLOW.md`](../docs/WORKFLOW.md)):
+---
 
-```
-/run-phase add-cloud-platform-mvp 3
-```
+## Quick start
 
-### Database commands
+The shortest path from clone to a running, seeded stack with the e2e passing.
+
+### 1. Copy the environment file
 
 ```bash
 cd backend
-make db-up      # start Postgres (Docker), wait until healthy
-make db-down    # stop Postgres (data persists in the housecall-pgdata volume)
+cp .env.example .env
+# .env is gitignored; the defaults work for local dev
 ```
 
-The `housecall` and `housecall_test` databases are created automatically on
-first volume init (`docker/initdb/01-create-test-db.sql`).
-
-### One-time setup (manual / Linux, without Docker)
-
-If you are not on macOS, or prefer a host-native Postgres:
+### 2. Pull the AI model (one-time, ~3 GB)
 
 ```bash
-sudo -u postgres psql -c "CREATE USER housecall WITH PASSWORD 'housecall' SUPERUSER;"
-sudo -u postgres psql -c "CREATE DATABASE housecall OWNER housecall;"
-sudo -u postgres psql -c "CREATE DATABASE housecall_test OWNER housecall;"
-```
-
-### Common commands
-
-```bash
-make migrate    # apply pending SQL migrations
-make run        # build and start the server on :8080
-make test       # run the test suite against $TEST_DATABASE_URL
-make tidy       # go mod tidy
-```
-
-Override the connection string when needed:
-
-```bash
-make migrate DATABASE_URL=postgres://user:pass@host:port/db?sslmode=disable
-make test    TEST_DATABASE_URL=postgres://user:pass@host:port/test_db?sslmode=disable
-```
-
-> **Note:** `sslmode=disable` is for local development only and must never be used in staging or production environments.
-
-Tests that depend on PostgreSQL skip cleanly when `TEST_DATABASE_URL` is
-unset, so `go test ./...` always compiles and runs (pure-Go tests still
-execute; DB-bound tests skip).
-
-## Local AI model setup
-
-The AI Agent Runtime calls an OpenAI-compatible chat-completions endpoint.
-For local development the recommended path is **Ollama + medgemma:4b**.
-
-### Install and start Ollama
-
-```bash
-# macOS (Homebrew)
-brew install ollama
-
-# Pull the model (one-time, ~3 GB download)
+brew install ollama          # macOS — skip if already installed
 ollama pull medgemma:4b
-
-# Start the Ollama server (if not already running as a service)
-ollama serve          # listens on port 11434 by default
+ollama serve                 # keep this running in a terminal tab
 ```
 
-Verify the model is available:
+### 3. Bring up the stack and seed it
 
 ```bash
-ollama list           # should show medgemma:4b in the list
+make compose-up
 ```
 
-### How the compose stack reaches Ollama
+This single target:
+1. Runs `docker compose up -d --build --wait` — builds the Go binary inside the
+   container, starts Postgres 16 and the server, waits until both are healthy.
+2. Runs `make seed` — inserts one synthetic tenant, physician, patient, and care
+   relationship (idempotent, safe to re-run).
 
-`docker-compose.yml` sets:
-
-```yaml
-environment:
-  AGENT_MODEL_BASE_URL: http://host.docker.internal:11434/v1
-  AGENT_MODEL_NAME: medgemma:4b
-extra_hosts:
-  - "host.docker.internal:host-gateway"
-```
-
-`host.docker.internal` resolves automatically on Docker Desktop (macOS/Windows).
-Under **Colima** (the default container runtime for this project), `extra_hosts`
-maps the name to `host-gateway` so the container can reach the host's Ollama
-process. No additional configuration is needed.
-
-To use a different model, override `AGENT_MODEL_NAME`:
+Verify the server is healthy:
 
 ```bash
-AGENT_MODEL_NAME=llama3.2 docker compose up -d --build --wait
+curl http://localhost:8080/healthz
+# → ok
 ```
 
-### Alternative: vLLM with a MedGemma variant
-
-For GPU-accelerated inference or the larger MedGemma variants, a
-[vLLM](https://github.com/vllm-project/vllm) server with an
-OpenAI-compatible endpoint works as a drop-in replacement:
+### 4. Run the end-to-end test
 
 ```bash
-# Example vLLM startup (requires a capable GPU)
-vllm serve google/medgemma-27b-it --port 11434
-
-# Point the compose stack at it
-AGENT_MODEL_BASE_URL=http://host.docker.internal:11434/v1 \
-AGENT_MODEL_NAME=google/medgemma-27b-it \
-  docker compose up -d --build --wait
-```
-
-Any OpenAI-compatible `/v1/chat/completions` endpoint works — the agent
-client negotiates the API contract, not the model name.
-
-## End-to-end test
-
-`scripts/e2e.sh` drives the complete physician-in-loop recommendation cycle
-against a running local stack:
-
-1. Patient logs in and posts a clinical question via the JSON API.
-2. The agent drafts a recommendation and transitions it to `PENDING_REVIEW`.
-3. Physician logs into the **web app** (`/web/login`) and approves the
-   recommendation via the HTML review form (`POST /web/recommendations/{id}/review`).
-4. Patient polls the JSON API until the recommendation state is `DELIVERED`
-   with non-empty `final_content`.
-
-### Prerequisites
-
-- Ollama is running on the host: `ollama serve`
-- `medgemma:4b` is downloaded: `ollama pull medgemma:4b`
-- `curl` and `docker` are in `$PATH`
-- `python3` is in `$PATH` (used for JSON parsing; `jq` is optional but recommended)
-
-### One-command run
-
-```bash
-cd backend
 ./scripts/e2e.sh
 ```
 
-The script calls `docker compose up -d --build --wait` and `make seed`
-automatically, so a fresh clone only needs the prerequisites above.
-
-If the stack is already up and seeded (e.g. you are iterating):
-
-```bash
-SKIP_UP=1 ./scripts/e2e.sh
-```
-
-### Expected output (abridged)
+Expected tail of output:
 
 ```
-[e2e] ========================================
-[e2e] HouseCall E2E Test
-[e2e]   API:  http://localhost:8080
-[e2e]   WEB:  http://localhost:8080
-[e2e] ========================================
-[e2e] Bringing up compose stack ...
-[e2e] Seed complete.
-[e2e] Step 1: patient login...
-[e2e] Step 2: patient creates conversation...
-[e2e] Step 3: patient posts message (triggers agent draft)...
-[e2e] Step 4a: physician API login ...
-[e2e] Step 5: polling physician queue for PENDING_REVIEW (timeout 120s)...
-[e2e]   ...waiting for agent draft (0s elapsed, will retry in 3s)
-[e2e] PENDING_REVIEW recommendation found: <uuid> (after 12s)
-[e2e] Step 6: physician approves recommendation <uuid> via web app...
-[e2e]   6a. Web app login...
-[e2e]   Web login OK, hc_session cookie captured.
-[e2e]   6b. Loading physician queue page...
-[e2e]   Recommendation visible in queue.
-[e2e]   6c. Submitting approve form...
-[e2e]   Approve form submitted, redirected back to queue (HTTP 200).
-[e2e] Step 7: patient polls for DELIVERED recommendation (timeout 30s)...
-[e2e] Recommendation <uuid> is DELIVERED. final_content: [non-empty, content redacted]
 [e2e] ========================================
 [e2e] E2E PASSED
 [e2e] Full loop verified:
@@ -250,98 +86,354 @@ SKIP_UP=1 ./scripts/e2e.sh
 [e2e] ========================================
 ```
 
+---
+
+## Configuration
+
+### Environment variables
+
+The server binary reads these from the process environment (or the `.env` file
+when running via `docker compose`).
+
+| Variable | Required | Default (dev) | Description |
+|---|---|---|---|
+| `DATABASE_URL` | **Yes** | — | PostgreSQL DSN (`postgres://user:pass@host:port/db?sslmode=disable`) |
+| `JWT_SECRET` | **Yes** | — | HMAC-HS256 signing secret; must be ≥ 16 characters |
+| `AGENT_MODEL_BASE_URL` | No | `http://host.docker.internal:11434/v1` | OpenAI-compatible chat completions base URL |
+| `AGENT_MODEL_NAME` | No | `medgemma:4b` | Model identifier passed in the `model` field |
+| `AGENT_MODEL_API_KEY` | No | _(empty)_ | Bearer token for hosted endpoints; leave empty for Ollama |
+
+The Makefile supplies dev defaults:
+
+```
+DATABASE_URL      = postgres://housecall:housecall@localhost:5432/housecall?sslmode=disable
+TEST_DATABASE_URL = postgres://housecall:housecall@localhost:5432/housecall_test?sslmode=disable
+JWT_SECRET        = dev-secret-change-me-in-production
+```
+
+> **Never use `sslmode=disable` outside localhost. Never commit a real `JWT_SECRET`.**
+> Generate a strong one: `openssl rand -hex 32`.
+
+### Compose-managed values
+
+`docker-compose.yml` sets these automatically for the `server` container:
+
+```yaml
+DATABASE_URL:         postgres://housecall:housecall@postgres:5432/housecall?sslmode=disable
+JWT_SECRET:           ${JWT_SECRET:-dev-jwt-secret-change-me-in-production}
+AGENT_MODEL_BASE_URL: http://host.docker.internal:11434/v1
+AGENT_MODEL_NAME:     ${AGENT_MODEL_NAME:-medgemma:4b}
+AGENT_MODEL_API_KEY:  ${AGENT_MODEL_API_KEY:-}
+SERVER_PORT:          ${SERVER_PORT:-8080}   # host-side port binding
+```
+
+Override `JWT_SECRET` for any non-localhost environment by setting it in your
+shell before running compose:
+
+```bash
+export JWT_SECRET="$(openssl rand -hex 32)"
+make compose-up
+```
+
+### Colima and `host.docker.internal`
+
+`host.docker.internal` resolves automatically on Docker Desktop (macOS/Windows).
+Under **Colima** the daemon does not inject this hostname; `docker-compose.yml`
+includes an `extra_hosts` entry that maps it to `host-gateway` so the container
+can reach the host's Ollama process. No manual configuration is required.
+
+### Local AI model setup
+
+The Agent Runtime requires an OpenAI-compatible `/v1/chat/completions` endpoint.
+
+**Recommended: Ollama + medgemma:4b**
+
+```bash
+brew install ollama
+ollama pull medgemma:4b      # one-time download, ~3 GB
+ollama serve                 # listens on port 11434 by default
+ollama list                  # verify medgemma:4b appears
+```
+
+To use a different model, set `AGENT_MODEL_NAME` before bringing up the stack:
+
+```bash
+AGENT_MODEL_NAME=llama3.2 make compose-up
+```
+
+**Alternative: vLLM (GPU)**
+
+```bash
+vllm serve google/medgemma-27b-it --port 11434
+
+AGENT_MODEL_BASE_URL=http://host.docker.internal:11434/v1 \
+AGENT_MODEL_NAME=google/medgemma-27b-it \
+  docker compose up -d --build --wait
+```
+
+Any endpoint that implements `POST /v1/chat/completions` (OpenAI-compatible) is
+a valid drop-in.
+
+---
+
+## Local development without Docker
+
+Use this path when you want fast rebuild-test cycles or prefer a host-native
+Postgres.
+
+### Start Postgres
+
+Either run the compose Postgres service alone:
+
+```bash
+cd backend
+make db-up      # docker compose up -d --wait postgres
+```
+
+Or create a host-native database:
+
+```bash
+sudo -u postgres psql -c "CREATE USER housecall WITH PASSWORD 'housecall' SUPERUSER;"
+sudo -u postgres psql -c "CREATE DATABASE housecall OWNER housecall;"
+sudo -u postgres psql -c "CREATE DATABASE housecall_test OWNER housecall;"
+```
+
+### Apply migrations and start the server
+
+```bash
+make migrate    # applies pending SQL files from migrations/
+make seed       # inserts synthetic seed data (idempotent)
+make run        # build + start the server on :8080
+```
+
+Override the DSN for a non-default Postgres:
+
+```bash
+make migrate DATABASE_URL=postgres://user:pass@host:port/db?sslmode=disable
+make run     DATABASE_URL=postgres://user:pass@host:port/db?sslmode=disable JWT_SECRET=my-secret
+```
+
+### Stop Postgres
+
+```bash
+make db-down    # docker compose down (data persists in housecall-pgdata volume)
+```
+
+---
+
+## Running tests
+
+```bash
+make test
+```
+
+This runs `go test ./...` with `TEST_DATABASE_URL` set. Tests that require
+PostgreSQL skip cleanly when `TEST_DATABASE_URL` is unset, so the suite always
+compiles and pure-Go tests still execute.
+
+Override the test DSN:
+
+```bash
+make test TEST_DATABASE_URL=postgres://user:pass@host:port/housecall_test?sslmode=disable
+```
+
+Run a specific package or test:
+
+```bash
+cd backend
+TEST_DATABASE_URL=postgres://housecall:housecall@localhost:5432/housecall_test?sslmode=disable \
+  go test ./internal/store/... -run TestTenantIsolation -v
+```
+
+The `internal/store` suite includes a tenant-isolation battery:
+1. Creates two parallel tenants with patients, physicians, care relationships,
+   conversations, messages, and recommendations.
+2. Asserts every read function returns `ErrNotFound` (or an empty list) when
+   called with the wrong tenant id.
+3. Asserts the schema's composite foreign keys reject cross-tenant parent rows
+   at write time.
+
+---
+
+## End-to-end test
+
+`scripts/e2e.sh` drives the complete physician-in-loop recommendation cycle
+against a running local stack.
+
+### What it verifies
+
+1. Patient logs in and posts a clinical question via the JSON API.
+2. The agent drafts a recommendation and transitions it to `PENDING_REVIEW`.
+3. Physician logs into the web app (`/web/login`) and approves the
+   recommendation via the HTML review form
+   (`POST /web/recommendations/{id}/review` with `action=approve`).
+4. Patient polls the JSON API until the recommendation is `DELIVERED` with
+   non-empty `final_content`.
+
+### Prerequisites
+
+- Ollama is running: `ollama serve`
+- Model is downloaded: `ollama pull medgemma:4b`
+- `curl` and `docker` are in `$PATH`
+- `python3` or `jq` is in `$PATH` (for JSON parsing)
+
+### Running
+
+From the `backend/` directory:
+
+```bash
+./scripts/e2e.sh
+```
+
+The script calls `docker compose up -d --build --wait` and `make seed`
+automatically. A fresh clone only needs the prerequisites above.
+
+If the stack is already up and seeded (e.g. iterating on a fix):
+
+```bash
+SKIP_UP=1 ./scripts/e2e.sh
+```
+
 ### Environment overrides
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `API_BASE` | `http://localhost:8080` | JSON API base URL |
 | `WEB_BASE` | `http://localhost:8080` | Web app base URL |
-| `SKIP_UP` | `0` | Set `1` to skip `compose up` + seed |
-| `AGENT_POLL_TIMEOUT` | `120` | Seconds to wait for PENDING_REVIEW |
+| `SKIP_UP` | `0` | Set `1` to skip `compose up` and seed |
+| `AGENT_POLL_TIMEOUT` | `120` | Seconds to wait for `PENDING_REVIEW` |
+| `EXEC_MODE` | _(auto)_ | Force `host` (curl) or `exec` (docker exec wget) |
 
-### Colima / non-default port
+### Colima / exec mode
 
-The script auto-detects whether the server is reachable from the macOS host.
-Under Colima with the macOS Virtualization.Framework, `localhost:8080` may not
-be accessible from the host even though the container port is published. In
-that case the script automatically falls back to running all HTTP calls via
-`docker compose exec housecall-server wget ...` (exec mode). No manual
-configuration is required.
+The script auto-detects whether `localhost:8080` is reachable from the macOS
+host. Under Colima with the macOS Virtualization.Framework, host-to-container
+port forwarding may not work even though the port is published. When the
+auto-detection probe fails, the script falls back to running all HTTP calls via
+`docker compose exec housecall-server wget ...` inside the container — the
+server binary is exercised identically either way.
 
-To force exec mode explicitly (or if auto-detection is slow):
+To force exec mode explicitly:
 
 ```bash
 EXEC_MODE=exec ./scripts/e2e.sh
 ```
 
-If the server is exposed on a different port:
+For a non-default port:
 
 ```bash
 API_BASE=http://localhost:9090 WEB_BASE=http://localhost:9090 ./scripts/e2e.sh
 ```
 
-### Approve path: web app vs JSON API
+---
 
-The script drives the **web app** approve path
-(`POST /web/recommendations/{id}/review` with a form-encoded `action=approve`
-body and the `hc_session` cookie). This exercises the full server-rendered
-physician UI path, not just the JSON API, which satisfies the task spec's
-requirement to "approve in the web app". The JSON API review endpoint
-(`POST /api/recommendations/{id}/review`) shares the same `review.Execute`
-logic and is covered by the API integration tests.
-
-### Model not yet downloaded
-
-If `ollama list` does not show `medgemma:4b` when the patient message is
-posted, the agent will fail to produce a recommendation and the script will
-time out at step 5 with a clear diagnostic:
+## Project layout
 
 ```
-[e2e] FAIL: Timed out after 120s waiting for PENDING_REVIEW recommendation. Is the model running?
+backend/
+├── cmd/
+│   ├── server/        main(): -cmd serve|migrate; listens on :8080
+│   └── seed/          inserts synthetic dev data (tenant + physician + patient)
+├── internal/
+│   ├── agent/         AI Agent Runtime — Drafter, LLM client (OpenAI-compat)
+│   ├── api/           JSON REST API router (chi); auth, conversations, messages,
+│   │                  recommendations endpoints
+│   ├── audit/         Audit event writer; logs to the audit_events table
+│   ├── domain/        Shared domain types (Recommendation states, etc.)
+│   ├── jwtutil/       JWT sign/verify helpers (HMAC-HS256)
+│   ├── migrate/       Lightweight SQL migration runner (schema_migrations table)
+│   ├── review/        Physician review business logic shared by API + web
+│   ├── store/         pgx store; every PHI query takes a TenantID
+│   └── web/           Server-rendered physician web app (chi + html/template)
+│       └── templates/ HTML templates for login, queue, and review pages
+├── migrations/        SQL migration files (NNNN_<description>.sql)
+├── docker/
+│   └── initdb/        01-create-test-db.sql — creates housecall_test on first run
+├── scripts/
+│   └── e2e.sh         End-to-end test driver
+├── Dockerfile
+├── Makefile
+├── docker-compose.yml
+├── .env.example
+└── go.mod
 ```
 
-Pull the model and re-run:
-
-```bash
-ollama pull medgemma:4b
-./scripts/e2e.sh
-```
-
-## Data model
-
-See [`../openspec/changes/add-cloud-platform-mvp/design.md`](../openspec/changes/add-cloud-platform-mvp/design.md) §2 for the
-table list and rationale. Highlights:
+### Schema highlights
 
 - Every PHI-bearing table carries a non-null `tenant_id`.
-- Cross-table foreign keys are **composite** on `(tenant_id, parent_id)`
-  so the schema itself rejects rows whose parent belongs to a different
-  tenant. The store layer also includes `tenant_id` in every `WHERE`
-  clause; the composite FK is defence-in-depth.
+- Cross-table foreign keys are composite on `(tenant_id, parent_id)` so the
+  schema rejects rows whose parent belongs to a different tenant. The store
+  layer also filters by `tenant_id` in every `WHERE` clause — defence in depth.
 - `recommendations.payload_type` is constrained to
-  `{guidance, prescription, lab_order, referral}`. Phase 4 only writes
-  `guidance`; the prescribing and lab-order payload types are produced by
-  `add-pa-chronic-disease-launch`.
+  `{guidance, prescription, lab_order, referral}`. The MVP writes `guidance`;
+  other types are added by later change proposals.
 
-## Migrations
+### Migrations
 
-`internal/migrate` is a small SQL runner: files in `migrations/` named
-`NNNN_<description>.sql` are applied in lexicographic order, tracked in
-`schema_migrations`. There is no down-migration path on purpose — schema
-rollback at MVP scale is handled by restoring a snapshot.
+SQL files in `migrations/` named `NNNN_<description>.sql` are applied in
+lexicographic order and tracked in `schema_migrations`. There is no down-migration
+path — schema rollback at MVP scale is handled by restoring a volume snapshot.
 
-To add a migration: drop a new `NNNN_<description>.sql` into
-`migrations/` with the next number and run `make migrate`.
+To add a migration: create the next-numbered file and run `make migrate`.
 
-## Tests
+---
 
-`internal/store` ships a tenant-isolation suite that:
+## Seed credentials (dev-only, synthetic, non-PHI)
 
-1. Creates two parallel tenants with patients, physicians, care
-   relationships, conversations, messages, and recommendations.
-2. Asserts every read function returns `ErrNotFound` (or an empty list)
-   when called with the wrong tenant id.
-3. Asserts the schema's composite FKs reject a cross-tenant parent at
-   write time.
+`make seed` (or `make compose-up`) inserts deterministic rows that the e2e
+script relies on. Re-running is safe (all inserts use `ON CONFLICT DO NOTHING`).
 
-Run the suite with `make test`. The Phase 2 work will extend it with
-authenticated REST round-trips and the audit-event invariant.
+| Role | Email | Password |
+|---|---|---|
+| Physician | `physician@dev.housecall.local` | `PhysicianDev1!` |
+| Patient | `patient@dev.housecall.local` | `PatientDev1!` |
+
+Tenant id: `00000000-0000-0000-0000-000000000001`
+
+---
+
+## Troubleshooting
+
+### e2e times out at step 5 ("waiting for PENDING_REVIEW")
+
+The agent could not reach the model. Steps:
+
+1. `ollama serve` — ensure Ollama is running on the host.
+2. `ollama list` — confirm `medgemma:4b` (or your chosen model) appears.
+3. `ollama pull medgemma:4b` — download it if missing.
+4. `docker compose logs server | tail -50` — check for connection errors.
+
+Under Colima: the `extra_hosts` entry in `docker-compose.yml` should make
+`host.docker.internal` resolve inside the container. If not:
+
+```bash
+docker exec housecall-server wget -qO- http://host.docker.internal:11434/api/tags
+```
+
+If that fails, Colima's `host-gateway` may not be set up. Try restarting Colima:
+`colima stop && colima start`.
+
+### Port 5432 already in use
+
+A local Postgres is running. Either stop it (`brew services stop postgresql@16`)
+or change the compose port mapping in `docker-compose.yml`.
+
+### `JWT_SECRET must be set and at least 16 characters`
+
+The server enforces this at startup. Set `JWT_SECRET` in your shell or `.env`
+file before running `make run` or `docker compose up`.
+
+### `localhost:8080` not reachable under Colima
+
+Use exec mode for the e2e test (`EXEC_MODE=exec ./scripts/e2e.sh`) and verify
+Colima's network mode. Colima with `--network-address` or `vmType: vz` mode
+(macOS Virtualization.Framework) may not forward published ports to the host.
+Switching to `vmType: qemu` resolves this in most cases.
+
+### `go: toolchain go1.25.0 is not available`
+
+Install Go 1.25+ from <https://go.dev/dl/> or via `mise`:
+
+```bash
+mise use go@1.25
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -58,8 +58,9 @@ make compose-up
 This single target:
 1. Runs `docker compose up -d --build --wait` — builds the Go binary inside the
    container, starts Postgres 16 and the server, waits until both are healthy.
-2. Runs `make seed` — inserts one synthetic tenant, physician, patient, and care
-   relationship (idempotent, safe to re-run).
+2. Seeds the database (`go run ./cmd/seed`, the same code `make seed` runs) —
+   inserts one synthetic tenant, physician, patient, and care relationship
+   (idempotent, safe to re-run).
 
 Verify the server is healthy:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,11 +5,15 @@
 > web app, cloud backend, and AI agent fit together, how PHI flows between them,
 > and what has to be true before Phase 1 code can start.
 
-**Status:** Draft for review. Nothing here is built yet — the current codebase is
-a single-device iOS app (encrypted Core Data, on-device only). This document
-describes the target state and the migration path to it.
+**Status:** The Cloud Platform MVP described here is built and on `main` as of
+2026-06-03 (`add-cloud-platform-mvp` Phases 1–7). The Go Core API, AI agent
+runtime, physician web app (`internal/web`), iOS cloud sync, Docker Compose
+stack, and a live e2e (Ollama + medgemma:4b) are all shipped. Sections still
+describing future AWS deployment (§8) and production compliance gates (§9,
+§12) remain as-spec — they apply to the production environment, not the local
+MVP.
 
-*Last updated: 2026-05-14*
+*Last updated: 2026-06-03*
 
 ---
 
@@ -39,7 +43,7 @@ These shape every decision below:
 ```
 ┌─────────────────┐         ┌─────────────────┐
 │  Patient iOS    │         │ Physician Web   │
-│  App (SwiftUI)  │         │ App (TBD stack) │
+│  App (SwiftUI)  │         │ App (Go/HTML)   │
 └────────┬────────┘         └────────┬────────┘
          │ HTTPS/TLS 1.2+            │ HTTPS/TLS 1.2+
          │ (REST + WebSocket)        │ (REST + WebSocket)
@@ -82,15 +86,15 @@ These shape every decision below:
 
 ### Components
 
-| Component | Responsibility | Phase 1 scope |
+| Component | Responsibility | MVP status |
 |---|---|---|
-| **Patient iOS app** | Patient-facing surface: chat, dashboard, HealthKit capture, notifications | Reuse existing auth + chat UI; add cloud sync |
-| **Physician web app** | Clinical oversight: patient panel, recommendation review queue, protocol view | New build — minimal queue + approve/reject/modify |
-| **API Gateway** | TLS termination, authN/Z, rate limiting, request routing | Managed (AWS API Gateway) |
-| **Core API Service** | CRUD for patients, conversations, messages, recommendations, protocols; enforces physician-in-loop state machine | New build |
-| **AI Agent Runtime** | Per-patient agent: reactive chat responses, recommendation generation, escalation triage | New build — reactive only in Phase 1 |
-| **Integration Workers** | Async jobs pulling/pushing external data (HealthKit deltas, lab results) | New build — HealthKit only in Phase 1 |
-| **Data Layer** | PostgreSQL system of record, S3 for media, append-only audit store | New build |
+| **Patient iOS app** | Patient-facing surface: chat, dashboard, HealthKit capture, notifications | Cloud sync added (`SyncClient`, `CloudSyncCoordinator`, `RecommendationCard` — `HouseCall/Core/Services/Sync/`) |
+| **Physician web app** | Clinical oversight: patient panel, recommendation review queue | Built — Go server-rendered HTML templates (`internal/web`); login, patient panel, recommendation queue (approve / reject / modify) |
+| **API Gateway** | TLS termination, authN/Z, rate limiting, request routing | MVP: Go `net/http` router in `internal/api`; production target is AWS API Gateway |
+| **Core API Service** | CRUD for patients, conversations, messages, recommendations, protocols; enforces physician-in-loop state machine | Built — `internal/api`, `internal/store`, `internal/domain`, `internal/review`; multi-tenant Postgres; physician state-licensing enforced on every approval |
+| **AI Agent Runtime** | Per-patient agent: reactive chat responses, recommendation generation | Built — `internal/agent`; OpenAI-compatible client pointed at `AGENT_MODEL_BASE_URL` (Ollama/medgemma:4b for local dev); reactive only (Phase 1) |
+| **Integration Workers** | Async jobs pulling/pushing external data (HealthKit deltas, lab results) | Deferred — not in MVP; HealthKit ingestion is Phase 1 production work |
+| **Data Layer** | PostgreSQL system of record, S3 for media, append-only audit store | Postgres built (`backend/migrations/`, Docker Compose); S3 and audit store are production targets |
 
 ### Backend stack
 
@@ -194,13 +198,21 @@ Only `APPROVED` and `MODIFIED` can transition to `DELIVERED`. The transition to
 is enforced in the Core API, covered by tests, and audited on every transition.
 
 ### iOS migration path
-1. Keep the existing local Core Data model.
-2. Add a sync layer: local rows get a `serverId` + `syncState`
-   (`pending` / `synced` / `conflict`).
-3. New data flows to the server first; the local store mirrors it.
-4. Offline: writes queue locally, replay on reconnect. Reads serve from cache.
-5. The existing encryption stays for local-at-rest; transport encryption is
-   additional, not a replacement.
+
+Steps 1–5 are implemented in the Cloud Platform MVP:
+
+1. The existing local Core Data model is unchanged.
+2. Sync layer added: `Conversation` and `Message` entities now carry
+   `serverId` (String, optional) and `syncState` (String: `pending` /
+   `synced` / `conflict`). See `HouseCall/HouseCall.xcdatamodeld`.
+3. `SyncClient.swift` (`HouseCall/Core/Services/Sync/`) handles REST calls
+   to the Core API; `CloudSyncCoordinator.swift` orchestrates sync lifecycle
+   and conflict resolution (server wins in Phase 1). New data flows to the
+   server first; the local store mirrors it.
+4. `RecommendationCard.swift` (`HouseCall/Features/Conversation/Views/`)
+   surfaces physician-approved recommendations in the patient UI.
+5. The existing AES-256-GCM local encryption is unchanged; transport
+   encryption (TLS) is additional.
 
 ---
 
@@ -299,10 +311,15 @@ See §11 Decision Log for the hosting alternatives considered.
 
 ## 7. Sync Protocol (iOS ↔ Cloud)
 
-- **Transport**: REST for CRUD, WebSocket for live updates (streaming AI
-  responses, recommendation-delivered push, escalation alerts).
-- **Write path**: client writes locally (queued) → POSTs to server → server
-  assigns `serverId` → client reconciles.
+This protocol is implemented in the Cloud Platform MVP (`SyncClient.swift`,
+`CloudSyncCoordinator.swift`).
+
+- **Transport**: REST for CRUD (`SyncClient` wraps the Core API endpoints);
+  WebSocket (`internal/api/ws.go`) for live updates (streaming AI responses,
+  recommendation delivery). Escalation push is deferred to production
+  (APNs via SNS — §8).
+- **Write path**: client writes locally (queued, `syncState = pending`) → POSTs
+  to server → server assigns `serverId` → client sets `syncState = synced`.
 - **Read path**: client pulls deltas since last sync cursor; server is
   authoritative on conflict.
 - **Conflict policy (Phase 1)**: server wins; conflicting local edits are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,8 +391,9 @@ say and do.
 The backend stack (§2 — Go), §5 (identity — AWS Cognito per ADR-004), and §6
 (model selection — MedGemma) decisions are now closed; Cognito is a
 HIPAA-eligible AWS service and MedGemma runs inside the AWS BAA boundary. Until
-item 1 is done, the iOS app cannot talk to a real backend
-and Phase 1 is blocked. Extending the iOS app in isolation (e.g., HealthKit
+item 1 is done, the iOS app cannot talk to a real **production** backend
+(the local-only MVP backend is built and runnable — see the status note at the
+top of this document) and production Phase 1 is blocked. Extending the iOS app in isolation (e.g., HealthKit
 capture into local Core Data) is possible in parallel but is throwaway-risk work
 until the sync layer exists.
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -162,6 +162,16 @@ AI evaluates patient
 chat with their AI agent, the agent drafts a recommendation, a physician reviews
 it, and the approved result reaches the patient. Everything else is deferred.
 
+**Engineering MVP landed (2026-06-03):** The `add-cloud-platform-mvp` OpenSpec
+change delivered a local-development proof of the core loop. The backend
+(`backend/`), physician web app (`internal/web`), and iOS cloud sync
+(`SyncClient`, `CloudSyncCoordinator`, `RecommendationCard`) are built and
+e2e-tested against Ollama + medgemma:4b. The boxes below track what remains
+for _production_ Phase 1 (AWS infrastructure, real patients, HIPAA gates). See
+[`backend/README.md`](../backend/README.md) for how to run the MVP locally and
+[`docs/ARCHITECTURE.md`](./ARCHITECTURE.md) for the design. Spec:
+[`openspec/changes/add-cloud-platform-mvp/`](../openspec/changes/add-cloud-platform-mvp/).
+
 **In scope:**
 - [ ] HIPAA-compliant AWS infrastructure (RDS, S3, API Gateway, self-hosted Zitadel — per ARCHITECTURE.md §8)
 - [ ] Core API service: patients, conversations, messages, recommendations, protocols
@@ -254,4 +264,4 @@ it, and the approved result reaches the patient. Everything else is deferred.
 
 ---
 
-*Last updated: 2026-05-14*
+*Last updated: 2026-06-03*

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -191,8 +191,8 @@ full loop.
 - [x] Replace the `backend/README.md` placeholder with real run instructions
 
 ### Task 8.2: Cross-references
-- [ ] Note the MVP in `docs/PROJECT.md` (Phase 1 progress)
-- [ ] Confirm `docs/ARCHITECTURE.md` §2/§4/§7 still match what was built;
+- [x] Note the MVP in `docs/PROJECT.md` (Phase 1 progress)
+- [x] Confirm `docs/ARCHITECTURE.md` §2/§4/§7 still match what was built;
       update if they drifted
 
 **Validation**: a new developer can go from clone to a working loop using only

--- a/openspec/changes/add-cloud-platform-mvp/tasks.md
+++ b/openspec/changes/add-cloud-platform-mvp/tasks.md
@@ -188,7 +188,7 @@ full loop.
 ## Phase 8: Documentation
 
 ### Task 8.1: Backend README
-- [ ] Replace the `backend/README.md` placeholder with real run instructions
+- [x] Replace the `backend/README.md` placeholder with real run instructions
 
 ### Task 8.2: Cross-references
 - [ ] Note the MVP in `docs/PROJECT.md` (Phase 1 progress)


### PR DESCRIPTION
## Phase 8 — Documentation (final phase)

Brings the cross-cutting docs in line with the now-built cloud MVP.

### Tasks (tester PASS + reviewer APPROVE)
- [x] **8.1 Backend README** — `backend/README.md` rewritten into a complete clone→working-loop guide: quick start (`make compose-up` → `./scripts/e2e.sh`), full env/config table, no-Docker dev path, tests, the e2e + Colima exec-mode notes, project layout, troubleshooting. Every command verified against the Makefile/compose/scripts/`main.go`.
- [x] **8.2 Cross-references** — noted the MVP landing in `docs/PROJECT.md` (without breaking its progress framing); updated `docs/ARCHITECTURE.md` §2/§4/§7 (+ status header and the §10 production-gate wording) to match what shipped: `internal/web` physician app, `internal/agent` runtime, the iOS sync layer (`SyncClient`/`CloudSyncCoordinator`/`RecommendationCard` + `serverId`/`syncState`), and the implemented WebSocket sync (`internal/api/ws.go`).

### Accuracy (reviewer-verified)
- Docs-only; `go build` clean; every referenced target/flag/env var/e2e knob confirmed real against source.
- No over-claim: clearly scoped as a **local-development MVP**, not production/HIPAA-compliant. Deferred items stay deferred — Cognito (HMAC JWT today via `internal/jwtutil`, JWKS swap is the seam), APNs/SNS escalation push, S3 audit store, integration workers.
- WebSocket library not misnamed (`coder/websocket`); auth framing consistent with ADR-004; no secrets/PHI.

### Beads closed
- HouseCall-7j0 (8.1) #20 · HouseCall-c3d (8.2) #19

### This completes `add-cloud-platform-mvp`
With this merged, all 8 phases of the change are done (backend Phases 1–4, physician web app 5, iOS cloud sync 6, local dev + live e2e 7, docs 8). Consider `openspec archive add-cloud-platform-mvp` after merge to move the change into `openspec/changes/archive/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)