### PR TITLE
CI: build+test gate for backend and iOS (#x25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+# Build + test gate. Runs on every PR into main and on pushes to main.
+# Backend: build, vet, and the Go test suite against a real Postgres.
+# iOS: compile the app AND both test targets (build-for-testing) — the check
+# that would have caught the duplicate-enum breakage fixed in PR #58. The iOS
+# unit-test *run* is intentionally not gated yet: the suite has known
+# pre-existing failures tracked in beads (#65–#69). Add it once #66 (parallel
+# runner / isolation) and #65 land.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref to save runner minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend (Go build + vet + test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: housecall
+          POSTGRES_PASSWORD: housecall
+          POSTGRES_DB: housecall
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U housecall"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://housecall:housecall@localhost:5432/housecall?sslmode=disable
+      TEST_DATABASE_URL: postgres://housecall:housecall@localhost:5432/housecall_test?sslmode=disable
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Create test database
+        run: PGPASSWORD=housecall psql -h localhost -U housecall -d housecall -c 'CREATE DATABASE housecall_test;'
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Migrate test database
+        run: DATABASE_URL="$TEST_DATABASE_URL" go run ./cmd/server -cmd migrate
+
+      - name: Test
+        run: make test
+
+  ios:
+    name: iOS (build app + test targets)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      # Uses the runner's preinstalled Xcode. If the project later requires a
+      # specific Xcode the runner doesn't default to, pin it here with
+      # `sudo xcode-select -s /Applications/Xcode_<ver>.app` (check the
+      # available versions on the GitHub macOS runner image).
+      - name: Show toolchain
+        run: xcodebuild -version
+
+      # build-for-testing compiles the app target AND HouseCallTests +
+      # HouseCallUITests — the check that catches a non-compiling app/tests.
+      # A generic simulator destination needs no specific device installed,
+      # and CODE_SIGNING_ALLOWED=NO skips device code signing.
+      - name: Build app + test targets
+        run: |
+          xcodebuild build-for-testing \
+            -scheme HouseCall \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -34,8 +34,12 @@ compose-up:
 	docker compose up -d --build --wait
 	DATABASE_URL=$(DATABASE_URL) go run ./cmd/seed
 
+# -p 1 serializes package test binaries. The DB-backed packages (store, api,
+# agent, review) share one TEST_DATABASE_URL, and some reset state with
+# TRUNCATE; running their binaries concurrently lets one package wipe another's
+# in-flight fixtures (FK violations). -p 1 keeps them from racing the shared DB.
 test:
-	TEST_DATABASE_URL=$(TEST_DATABASE_URL) go test ./...
+	TEST_DATABASE_URL=$(TEST_DATABASE_URL) go test -p 1 ./...
 
 tidy:
 	go mod tidy

--- a/backend/internal/agent/drafter.go
+++ b/backend/internal/agent/drafter.go
@@ -34,14 +34,28 @@ type PhysicianNotifier interface {
 // request is NOT propagated — drafting must complete even if the patient
 // disconnects. The goroutine uses a background context derived from the store.
 type Drafter struct {
-	client   ModelClient
-	store    *store.Store
-	notifier PhysicianNotifier
+	client     ModelClient
+	store      *store.Store
+	notifier   PhysicianNotifier
+	onComplete func() // optional; called (via defer) when the goroutine exits — tests use this for synchronisation
 }
 
 // NewDrafter constructs a Drafter. All three arguments are required.
 func NewDrafter(client ModelClient, s *store.Store, notifier PhysicianNotifier) *Drafter {
 	return &Drafter{client: client, store: s, notifier: notifier}
+}
+
+// WithOnComplete returns a shallow copy of d with the onComplete hook set.
+// The hook is called (via defer) when the goroutine spawned by DraftAsync
+// exits — regardless of whether it succeeded, failed, or panicked. Its
+// primary use is test synchronisation: tests inject a sync.WaitGroup.Done so
+// they can block until the goroutine has fully exited before making assertions
+// or returning (preventing races with shared-DB cleanup between tests).
+// Production callers use NewDrafter, which leaves the hook nil (no-op).
+func (d *Drafter) WithOnComplete(fn func()) *Drafter {
+	cp := *d
+	cp.onComplete = fn
+	return &cp
 }
 
 // DraftAsync spawns a goroutine that assembles the conversation context,
@@ -52,6 +66,13 @@ func NewDrafter(client ModelClient, s *store.Store, notifier PhysicianNotifier) 
 // HTTP handler returns.
 func (d *Drafter) DraftAsync(tenantID store.TenantID, conv store.Conversation, patient store.Patient) {
 	go func() {
+		// Signal completion to any test-injected hook. The defer is
+		// registered first so it fires last — after the recover() defer
+		// has had a chance to handle any panic.
+		if d.onComplete != nil {
+			defer d.onComplete()
+		}
+
 		// Recover from any panic inside draft() (nil-deref, driver bug, etc.)
 		// so a single drafting failure cannot crash the server process.
 		// middleware.Recoverer only protects HTTP handler goroutines; fire-and-

--- a/backend/internal/agent/drafter_test.go
+++ b/backend/internal/agent/drafter_test.go
@@ -90,6 +90,23 @@ func (p *panicClient) Complete(_ context.Context, _ []agent.Message) (string, er
 	panic("simulated model client panic")
 }
 
+// newDrafterWithWait constructs a Drafter whose background goroutine signals a
+// sync.WaitGroup when it exits (success, failure, or panic). Call wg.Wait()
+// (or register it in t.Cleanup) to ensure no goroutine outlives the test.
+// This is test-only; production callers use agent.NewDrafter directly.
+func newDrafterWithWait(t *testing.T, client agent.ModelClient, s *store.Store, notifier *stubNotifier) (*agent.Drafter, *sync.WaitGroup) {
+	t.Helper()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	d := agent.NewDrafter(client, s, notifier).WithOnComplete(wg.Done)
+	t.Cleanup(func() {
+		// Block until the goroutine has fully exited so no in-flight DB writes
+		// can race with test teardown or the store package's TRUNCATE.
+		wg.Wait()
+	})
+	return d, &wg
+}
+
 // stubNotifier records the last event sent to physicians.
 type stubNotifier struct {
 	mu     sync.Mutex
@@ -196,12 +213,12 @@ func TestDraft_HappyPath(t *testing.T) {
 	const wantText = "Take ibuprofen and rest. Consult a physician if symptoms worsen."
 
 	notifier := &stubNotifier{}
-	d := agent.NewDrafter(&stubClient{text: wantText}, s, notifier)
+	// newDrafterWithWait registers a t.Cleanup that blocks until the goroutine
+	// has exited, preventing races with shared-DB teardown across tests.
+	d, _ := newDrafterWithWait(t, &stubClient{text: wantText}, s, notifier)
 
-	// Call draft synchronously (via the exported DraftAsync → goroutine path
-	// we test via a small wait, or we test the internal logic via the public
-	// interface). Since DraftAsync is fire-and-forget, we wait for the
-	// notification to confirm the goroutine completed.
+	// DraftAsync is fire-and-forget; we detect completion via the
+	// queue.updated notification (which fires only after a successful commit).
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
 	// Poll until the notifier receives the event (max 5 s — the stub client
@@ -362,7 +379,7 @@ func TestDraft_TenantScoping(t *testing.T) {
 	// Run drafter for tenant A only.
 	const wantText = "Guidance for A only."
 	notifier := &stubNotifier{}
-	d := agent.NewDrafter(&stubClient{text: wantText}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{text: wantText}, s, notifier)
 	d.DraftAsync(fA.TenantID, fA.Conv, fA.Patient)
 
 	deadline := time.Now().Add(5 * time.Second)
@@ -511,7 +528,7 @@ func TestDraft_FailurePath_TransportError(t *testing.T) {
 	// a connection-refused error.
 	transportErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
 	notifier := &stubNotifier{}
-	d := agent.NewDrafter(&stubClient{err: transportErr}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{err: transportErr}, s, notifier)
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
 	assertFailurePath(t, pool, s, f, notifier, "model_unavailable")
@@ -527,7 +544,7 @@ func TestDraft_FailurePath_ModelError(t *testing.T) {
 
 	modelErr := &agent.ModelError{StatusCode: 503}
 	notifier := &stubNotifier{}
-	d := agent.NewDrafter(&stubClient{err: modelErr}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{err: modelErr}, s, notifier)
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
 	assertFailurePath(t, pool, s, f, notifier, "model_error")
@@ -544,7 +561,7 @@ func TestDraft_FailurePath_ParseError(t *testing.T) {
 
 	parseErr := &agent.ParseError{Detail: "response contained no choices"}
 	notifier := &stubNotifier{}
-	d := agent.NewDrafter(&stubClient{err: parseErr}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{err: parseErr}, s, notifier)
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
 	assertFailurePath(t, pool, s, f, notifier, "parse_error")
@@ -559,7 +576,7 @@ func TestDraft_FailurePath_Timeout(t *testing.T) {
 	f := setupDrafterFixture(t, s)
 
 	notifier := &stubNotifier{}
-	d := agent.NewDrafter(&stubClient{err: context.DeadlineExceeded}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{err: context.DeadlineExceeded}, s, notifier)
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
 	assertFailurePath(t, pool, s, f, notifier, "timeout")
@@ -593,11 +610,13 @@ func TestDraft_ErrorPath_StructuredForTask43(t *testing.T) {
 
 	modelErr := &agent.ModelError{StatusCode: 503}
 	notifier := &stubNotifier{}
-	d := agent.NewDrafter(&stubClient{err: modelErr}, s, notifier)
+	d, wg := newDrafterWithWait(t, &stubClient{err: modelErr}, s, notifier)
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
-	// Wait briefly — the goroutine returns quickly since the stub fails.
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the goroutine to finish before asserting; newDrafterWithWait
+	// also registers t.Cleanup(wg.Wait) but we need to wait before the assert
+	// below so that the goroutine's audit write (if any) does not race.
+	wg.Wait()
 
 	// No recommendation must be created on error.
 	recs, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
@@ -631,15 +650,15 @@ func TestDraft_PanicRecovery(t *testing.T) {
 	ctx := context.Background()
 
 	notifier := &stubNotifier{}
-	d := agent.NewDrafter(&panicClient{}, s, notifier)
+	d, wg := newDrafterWithWait(t, &panicClient{}, s, notifier)
 
 	// DraftAsync must return without panicking — if the goroutine's panic
 	// propagates the test binary itself will crash here.
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
-	// Give the goroutine time to run and recover; the panic client returns
-	// immediately so 200 ms is very generous.
-	time.Sleep(200 * time.Millisecond)
+	// Wait for the goroutine to exit (the onComplete hook fires after recover,
+	// so wg.Done() is called even on panic).
+	wg.Wait()
 
 	// No recommendation must be created when the client panicked.
 	recs, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)


### PR DESCRIPTION
Closes HouseCall-x25. Adds `.github/workflows/ci.yml` — the durable fix for the build-rot that required PRs #58 and #70 and caused the stale-checkout build failure.

## Jobs
- **Backend** (ubuntu + Postgres 16 service): `go build ./...`, `go vet ./...`, create `housecall_test`, apply migrations, `make test`. **Verified locally — all packages green.**
- **iOS** (macOS runner): `xcodebuild build-for-testing` compiles the app target **plus `HouseCallTests` + `HouseCallUITests`** on a generic simulator destination, no code signing. This is exactly the check that would have caught the duplicate-enum breakage fixed in #58. Verified locally with `build-for-testing`.

Runs on every PR into `main` and on push to `main`; concurrency-cancels superseded runs.

## Scoping note (honest)
The iOS **unit-test run** is intentionally NOT gated yet — the suite has ~16 known pre-existing failures tracked in #65–#69. Gating on it now would block every PR. Add the test run (with `-parallel-testing-enabled NO`) once **#66** (parallel runner/isolation) and **#65** land. Tracked.

## First-run caveat
A CI workflow is only fully validated when it runs on GitHub (runner Xcode/simulator specifics can't be reproduced locally). If the iOS job needs a specific Xcode the runner doesn't default to, pin it via `xcode-select` — there's a comment in the job. The backend job is high-confidence (standard Postgres service + the exact commands proven locally). Watch this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)