### PR TITLE
iOS correctness: auth error, keychain-read data-loss, invalid URL, onChange (#65 #67 #68)

### DIFF
--- a/HouseCall/Core/Persistence/CoreDataUserRepository.swift
+++ b/HouseCall/Core/Persistence/CoreDataUserRepository.swift
@@ -176,13 +176,15 @@ class CoreDataUserRepository: UserRepositoryProtocol {
                 throw UserRepositoryError.invalidCredentials
             }
 
+            // All wrong-credential outcomes (decryption failure or hash mismatch)
+            // are surfaced as invalidCredentials — opaque to the caller.
             do {
                 let hashedPassword = try encryptionManager.decrypt(
                     encryptedData: encryptedHash,
                     for: user.id!
                 )
 
-                if try !passwordHasher.verify(password: credential, hash: hashedPassword) {
+                guard try passwordHasher.verify(password: credential, hash: hashedPassword) else {
                     try? auditLogger.logLoginFailure(
                         email: email,
                         reason: "Invalid password",
@@ -190,8 +192,18 @@ class CoreDataUserRepository: UserRepositoryProtocol {
                     )
                     throw UserRepositoryError.invalidCredentials
                 }
+            } catch let repoError as UserRepositoryError {
+                // Re-throw repository errors (e.g. invalidCredentials) as-is.
+                throw repoError
             } catch {
-                throw UserRepositoryError.decryptionFailed
+                // A genuine decryption/system failure is still an opaque
+                // invalidCredentials to the caller — no credential-stage info leaks.
+                try? auditLogger.logLoginFailure(
+                    email: email,
+                    reason: "Credential verification failed",
+                    authMethod: authMethod.rawValue
+                )
+                throw UserRepositoryError.invalidCredentials
             }
 
         case .passcode:
@@ -199,13 +211,14 @@ class CoreDataUserRepository: UserRepositoryProtocol {
                 throw UserRepositoryError.invalidCredentials
             }
 
+            // Same opaque policy for passcode verification.
             do {
                 let hashedPasscode = try encryptionManager.decrypt(
                     encryptedData: encryptedHash,
                     for: user.id!
                 )
 
-                if try !passwordHasher.verify(password: credential, hash: hashedPasscode) {
+                guard try passwordHasher.verify(password: credential, hash: hashedPasscode) else {
                     try? auditLogger.logLoginFailure(
                         email: email,
                         reason: "Invalid passcode",
@@ -213,8 +226,15 @@ class CoreDataUserRepository: UserRepositoryProtocol {
                     )
                     throw UserRepositoryError.invalidCredentials
                 }
+            } catch let repoError as UserRepositoryError {
+                throw repoError
             } catch {
-                throw UserRepositoryError.decryptionFailed
+                try? auditLogger.logLoginFailure(
+                    email: email,
+                    reason: "Credential verification failed",
+                    authMethod: authMethod.rawValue
+                )
+                throw UserRepositoryError.invalidCredentials
             }
 
         case .biometric:

--- a/HouseCall/Core/Security/EncryptionManager.swift
+++ b/HouseCall/Core/Security/EncryptionManager.swift
@@ -84,8 +84,13 @@ class EncryptionManager {
             return masterKey
         }
 
-        // Try to retrieve existing key from keychain
-        if let keyData = try? keychainManager.retrieveMasterKey() {
+        // Try to retrieve existing key from keychain.
+        // `retrieveMasterKey()` returns nil ONLY for errSecItemNotFound (genuine
+        // first-run) and throws for any other OSStatus.  Using `try` (not `try?`)
+        // ensures a transient keychain read error propagates to the caller instead
+        // of being silently swallowed — which would cause key regeneration and
+        // permanent loss of all previously-encrypted PHI.
+        if let keyData = try keychainManager.retrieveMasterKey() {
             let key = SymmetricKey(data: keyData)
             masterKey = key
             return key
@@ -227,5 +232,12 @@ class EncryptionManager {
     func _testInjectMasterKey(_ key: SymmetricKey) {
         masterKey = key
         derivedKeyCache.removeAll()
+    }
+
+    /// Creates a fresh `EncryptionManager` backed by the supplied
+    /// `KeychainManager`.  Intended exclusively for unit tests that need to
+    /// inject a mock or stub keychain; **do not call in production code**.
+    static func _testMakeInstance(keychainManager: KeychainManager) -> EncryptionManager {
+        EncryptionManager(keychainManager: keychainManager)
     }
 }

--- a/HouseCall/Core/Services/LLMProviderConfigManager.swift
+++ b/HouseCall/Core/Services/LLMProviderConfigManager.swift
@@ -208,8 +208,15 @@ class LLMProviderConfigManager: ObservableObject {
             guard let customConfig = loadCustomProviderConfig() else {
                 return false
             }
-            // Custom provider needs a valid URL at minimum
-            guard URL(string: customConfig.baseURL) != nil else {
+            // Custom provider needs a syntactically valid URL with an http/https
+            // scheme and a non-empty host.  `URL(string:)` alone is too permissive
+            // — it percent-encodes strings like "not a valid url" and returns
+            // non-nil even though they are not usable endpoints.
+            guard let components = URLComponents(string: customConfig.baseURL),
+                  let scheme = components.scheme,
+                  (scheme == "http" || scheme == "https"),
+                  let host = components.host,
+                  !host.isEmpty else {
                 return false
             }
             // If auth is required, check for API key

--- a/HouseCall/Features/Authentication/Views/LoginView.swift
+++ b/HouseCall/Features/Authentication/Views/LoginView.swift
@@ -139,7 +139,7 @@ struct LoginView: View {
         .sheet(isPresented: $showingSignUp) {
             SignUpView()
         }
-        .onChange(of: authService.isAuthenticated) { isAuth in
+        .onChange(of: authService.isAuthenticated) { _, isAuth in
             if isAuth {
                 print("🟢 LoginView detected authentication, closing sheet")
                 showingSignUp = false

--- a/HouseCall/Features/Authentication/Views/SignUpView.swift
+++ b/HouseCall/Features/Authentication/Views/SignUpView.swift
@@ -40,7 +40,7 @@ struct SignUpView: View {
                                 .textContentType(.name)
                                 .autocapitalization(.words)
                                 .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .onChange(of: viewModel.fullName) { _ in
+                                .onChange(of: viewModel.fullName) {
                                     Task { @MainActor in
                                         viewModel.validateFullName()
                                     }
@@ -63,7 +63,7 @@ struct SignUpView: View {
                                 .autocapitalization(.none)
                                 .keyboardType(.emailAddress)
                                 .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .onChange(of: viewModel.email) { _ in
+                                .onChange(of: viewModel.email) {
                                     Task { @MainActor in
                                         viewModel.validateEmail()
                                     }
@@ -84,7 +84,7 @@ struct SignUpView: View {
                             SecureField("Minimum 12 characters", text: $viewModel.password)
                                 .textContentType(.newPassword)
                                 .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .onChange(of: viewModel.password) { _ in
+                                .onChange(of: viewModel.password) {
                                     Task { @MainActor in
                                         viewModel.validatePassword()
                                     }
@@ -120,7 +120,7 @@ struct SignUpView: View {
                             SecureField("Re-enter password", text: $viewModel.confirmPassword)
                                 .textContentType(.newPassword)
                                 .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .onChange(of: viewModel.confirmPassword) { _ in
+                                .onChange(of: viewModel.confirmPassword) {
                                     Task { @MainActor in
                                         viewModel.validateConfirmPassword()
                                     }

--- a/HouseCall/Features/Conversation/Views/ChatView.swift
+++ b/HouseCall/Features/Conversation/Views/ChatView.swift
@@ -54,13 +54,13 @@ struct ChatView: View {
                     .padding(.top, 8)
                     .padding(.bottom, 16)
                 }
-                .onChange(of: viewModel.messages.count) { _ in
+                .onChange(of: viewModel.messages.count) {
                     scrollToBottom(proxy: proxy)
                 }
-                .onChange(of: viewModel.streamingText) { _ in
+                .onChange(of: viewModel.streamingText) {
                     scrollToBottom(proxy: proxy)
                 }
-                .onChange(of: viewModel.recommendationCards.count) { _ in
+                .onChange(of: viewModel.recommendationCards.count) {
                     scrollToBottom(proxy: proxy)
                 }
             }

--- a/HouseCall/Features/Conversation/Views/MessageBubbleView.swift
+++ b/HouseCall/Features/Conversation/Views/MessageBubbleView.swift
@@ -100,7 +100,7 @@ struct MessageBubbleView: View {
         .onAppear {
             decryptMessage()
         }
-        .onChange(of: message.encryptedContent) { _ in
+        .onChange(of: message.encryptedContent) {
             // Update when streaming adds new content
             decryptMessage()
         }

--- a/HouseCallTests/EncryptionManagerTests.swift
+++ b/HouseCallTests/EncryptionManagerTests.swift
@@ -250,4 +250,47 @@ struct EncryptionManagerTests {
         // Should complete in less than 50ms
         #expect(elapsed < 0.05)
     }
+
+    // MARK: - Keychain Read-Error Safety Tests (qax)
+
+    @Test("Keychain read error does not cause master key regeneration")
+    @MainActor
+    func testKeychainReadErrorDoesNotRegenerateKey() throws {
+        // A transient keychain read error must propagate — not silently trigger
+        // key regeneration — which would make all previously-encrypted PHI
+        // permanently unreadable (silent data loss).
+        let errorKeychain = ThrowingOnReadKeychainManager()
+        let manager = EncryptionManager._testMakeInstance(keychainManager: errorKeychain)
+
+        // getMasterKey() must throw rather than silently generate a new key.
+        #expect(throws: (any Error).self) {
+            try manager.getMasterKey()
+        }
+
+        // Confirm no write was attempted (key regeneration would call saveMasterKey).
+        #expect(errorKeychain.saveCallCount == 0,
+                "Key must not be regenerated after a read error")
+    }
+}
+
+// MARK: - Test Helper: KeychainManager that throws on retrieve
+
+/// A `KeychainManager` subclass used exclusively in tests to simulate a
+/// transient keychain read failure.  `retrieveMasterKey()` throws
+/// `KeychainError.unexpectedStatus(-1)` (simulating a real non-not-found
+/// OSStatus) and a counter tracks whether `saveMasterKey` was ever called.
+@MainActor
+final class ThrowingOnReadKeychainManager: KeychainManager {
+    private(set) var saveCallCount: Int = 0
+
+    override func retrieveMasterKey() throws -> Data? {
+        // Simulate a non-not-found keychain error (e.g. data protection class
+        // mismatch or background access restriction).
+        throw KeychainError.unexpectedStatus(-1)
+    }
+
+    override func saveMasterKey(_ key: SymmetricKey) throws {
+        saveCallCount += 1
+        // Do not actually write to the keychain during tests.
+    }
 }


### PR DESCRIPTION
Closes #65, #67, #68 (HouseCall-0mz/8e6/qax) + HouseCall-w9r. Four iOS correctness/security fixes from the #59 triage backlog. Each had a failing test asserting the correct behavior — fixed the production code, did not weaken tests.

## Fixes
- **#65 (P1, security)** `CoreDataUserRepository.authenticateUser` — a wrong password leaked `UserRepositoryError.decryptionFailed`. Now passes through `.invalidCredentials` and maps all other errors to it too (opaque, no enumeration). Wrong password → `.invalidCredentials`; correct password still authenticates.
- **#68 (P2, data-loss)** `EncryptionManager.getMasterKey()` keychain **read** was `try?` — a transient read failure silently regenerated the master key, orphaning all prior PHI. Now `try`; `KeychainManager.retrieve` returns nil only for `errSecItemNotFound` and throws otherwise, so a read error propagates and never regenerates. New test `testKeychainReadErrorDoesNotRegenerateKey`. (Mirror of the #59 write-path fix; write stays strict.)
- **#67 (P2)** `LLMProviderConfigManager.isProviderConfigured(.custom)` — `URL(string:)` accepted `"not a valid url"`. Now requires scheme∈{http,https} + non-empty host via `URLComponents`. Valid local/https URLs still accepted.
- **w9r (P3)** Migrated deprecated `onChange(of:perform:)` (iOS 17) in SignUpView/ChatView/MessageBubbleView/LoginView — build is warning-free.

## Validation
- `BUILD SUCCEEDED`, deprecation warnings gone.
- Full `HouseCallTests`: **416 pass** (up from 407 — fixes 2 prior failures), no new failures; remainder are the known #66/#69 buckets.
- Reviewer APPROVE: auth mapping safe & opaque, key-regen genuinely prevented, write still strict, URL validation correct, no test weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)