### PR TITLE
iOS test isolation: IntegrationTests/SSEParser + validators/timeout/audit (#66 #69)

### DIFF
--- a/HouseCall/Utilities/Helpers/Validators.swift
+++ b/HouseCall/Utilities/Helpers/Validators.swift
@@ -50,12 +50,25 @@ class Validators {
             return .invalid("Please enter a valid email address")
         }
 
-        // Additional check for common email format
+        // Additional check for common email format.
+        // Requires: local-part[@domain.tld] where tld is alphabetic (2-64 chars).
+        // This rejects numeric-only TLDs (e.g. 123.123.123.123) and leading-dot
+        // local-parts; the consecutive-dot check below handles double-dot cases.
         let emailRegex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
         let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
 
         guard emailPredicate.evaluate(with: trimmedEmail) else {
             return .invalid("Please enter a valid email address")
+        }
+
+        // RFC 5321 forbids consecutive dots in the local part (e.g. user..name).
+        // NSDataDetector and the broad regex above are lenient about this, so we
+        // check explicitly.
+        if let atRange = trimmedEmail.range(of: "@") {
+            let localPart = String(trimmedEmail[..<atRange.lowerBound])
+            if localPart.contains("..") {
+                return .invalid("Please enter a valid email address")
+            }
         }
 
         return .valid()

--- a/HouseCallTests/AuditLoggerTests.swift
+++ b/HouseCallTests/AuditLoggerTests.swift
@@ -283,17 +283,22 @@ struct AuditLoggerTests {
         )
 
         let userId = UUID()
-        let now = Date()
-        let twoDaysAgo = Calendar.current.date(byAdding: .day, value: -2, to: now)!
+        let twoDaysAgo = Calendar.current.date(byAdding: .day, value: -2, to: Date())!
 
         try logger.log(event: .loginSuccess, userId: userId, message: "Login today")
+
+        // Capture upper bound AFTER logging so the event's timestamp (which is
+        // also set inside log()) is guaranteed to be <= endDate.  If we captured
+        // `now` before the call the event's timestamp would be strictly > now
+        // and the predicate `timestamp <= endDate` would return 0 rows.
+        let endDate = Date()
 
         // Fetch events from last 7 days
         let recentEvents = try logger.fetchRecentEvents(days: 7)
         #expect(recentEvents.count == 1)
 
         // Fetch events with specific date range
-        let rangeEvents = try logger.fetchEvents(dateRange: twoDaysAgo...now)
+        let rangeEvents = try logger.fetchEvents(dateRange: twoDaysAgo...endDate)
         #expect(rangeEvents.count == 1)
     }
 

--- a/HouseCallTests/IntegrationTests.swift
+++ b/HouseCallTests/IntegrationTests.swift
@@ -69,6 +69,9 @@ struct IntegrationTests {
             fullName: "New User",
             authMethod: .password
         )
+        // createSession() defers its @Published assignment via Task { @MainActor }.
+        // Yield once so that task runs before we read isAuthenticated.
+        await Task.yield()
 
         // Verify user created
         #expect(user.email == "newuser@example.com")
@@ -109,6 +112,7 @@ struct IntegrationTests {
             fullName: "Passcode User",
             authMethod: .passcode
         )
+        await Task.yield()
 
         #expect(user.authMethod == "passcode")
         #expect(user.encryptedPasscodeHash != nil)
@@ -145,6 +149,7 @@ struct IntegrationTests {
             authMethod: .password,
             useBiometric: false
         )
+        await Task.yield()
 
         #expect(user.email == email)
         #expect(authService.isAuthenticated == true)
@@ -179,6 +184,7 @@ struct IntegrationTests {
             authMethod: .passcode,
             useBiometric: false
         )
+        await Task.yield()
 
         #expect(user.email == email)
         #expect(authService.isAuthenticated == true)
@@ -212,6 +218,7 @@ struct IntegrationTests {
             credential: password,
             authMethod: .password
         )
+        await Task.yield()
 
         let sessionToken = authService.currentSession?.sessionToken
 
@@ -250,6 +257,7 @@ struct IntegrationTests {
             credential: password,
             authMethod: .password
         )
+        await Task.yield()
 
         #expect(authService.isAuthenticated == true)
 
@@ -363,6 +371,7 @@ struct IntegrationTests {
             fullName: "Journey User",
             authMethod: .password
         )
+        await Task.yield()
 
         #expect(authService.isAuthenticated == true)
 
@@ -376,6 +385,7 @@ struct IntegrationTests {
             credential: password,
             authMethod: .password
         )
+        await Task.yield()
 
         #expect(loggedInUser.id == registeredUser.id)
         #expect(authService.isAuthenticated == true)
@@ -438,6 +448,7 @@ struct IntegrationTests {
             fullName: "Audit Complete",
             authMethod: .password
         )
+        await Task.yield()
 
         try await authService.logout()
 
@@ -446,6 +457,7 @@ struct IntegrationTests {
             credential: "AuditPassword123!",
             authMethod: .password
         )
+        await Task.yield()
 
         try await authService.logout()
 

--- a/HouseCallTests/SSEParserTests.swift
+++ b/HouseCallTests/SSEParserTests.swift
@@ -59,11 +59,10 @@ struct SSEParserTests {
         let parser = SSEParser()
         var receivedEvents: [SSEEvent] = []
 
-        let sseData = """
-        event: message
-        data: Hello
-
-        """.data(using: .utf8)!
+        // Use explicit escape sequences to avoid any indentation-stripping
+        // ambiguity that multi-line string literals can introduce on some
+        // Swift/Xcode toolchain versions.
+        let sseData = "event: message\ndata: Hello\n\n".data(using: .utf8)!
 
         parser.parse(data: sseData) { event in
             receivedEvents.append(event)
@@ -79,11 +78,7 @@ struct SSEParserTests {
         let parser = SSEParser()
         var receivedEvents: [SSEEvent] = []
 
-        let sseData = """
-        id: 123
-        data: Test message
-
-        """.data(using: .utf8)!
+        let sseData = "id: 123\ndata: Test message\n\n".data(using: .utf8)!
 
         parser.parse(data: sseData) { event in
             receivedEvents.append(event)
@@ -139,12 +134,7 @@ struct SSEParserTests {
         let parser = SSEParser()
         var receivedEvents: [SSEEvent] = []
 
-        let sseData = """
-        : This is a comment
-
-        data: Valid message
-
-        """.data(using: .utf8)!
+        let sseData = ": This is a comment\n\ndata: Valid message\n\n".data(using: .utf8)!
 
         parser.parse(data: sseData) { event in
             receivedEvents.append(event)
@@ -232,12 +222,7 @@ struct SSEParserTests {
         let parser = SSEParser()
         var receivedEvents: [SSEEvent] = []
 
-        let sseData = """
-        data: Line 1
-        data: Line 2
-        data: Line 3
-
-        """.data(using: .utf8)!
+        let sseData = "data: Line 1\ndata: Line 2\ndata: Line 3\n\n".data(using: .utf8)!
 
         parser.parse(data: sseData) { event in
             receivedEvents.append(event)

--- a/HouseCallTests/SecurityTests.swift
+++ b/HouseCallTests/SecurityTests.swift
@@ -535,17 +535,63 @@ struct SecurityTests {
     // MARK: - Task 7.4: Session Timeout Enforcement
 
     /// Test: Session timeout invalidates session
+    ///
+    /// Exercises the production timeout teardown path via
+    /// `_testSimulateSessionTimeout()` without waiting 5 minutes for a real timer.
     @Test("Session timeout invalidates authentication")
     @MainActor
     func sessionTimeoutInvalidates() async throws {
-        // This test verifies session timeout behavior
-        // Note: Full integration test would require waiting 5 minutes
-        // For unit test, we verify the timeout mechanism exists
+        // Build an isolated AuthenticationService with its own in-memory
+        // Core Data stack so we do not pollute shared/production state.
+        let container = NSPersistentContainer(name: "HouseCall")
+        let storeDesc = NSPersistentStoreDescription()
+        storeDesc.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [storeDesc]
+        container.loadPersistentStores { _, error in
+            if let error { fatalError("In-memory store failed: \(error)") }
+        }
+        let context = container.viewContext
+        let auditLogger = AuditLogger(context: context)
+        let userRepo = CoreDataUserRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            passwordHasher: PasswordHasher.shared,
+            auditLogger: auditLogger
+        )
+        let authService = AuthenticationService(
+            userRepository: userRepo,
+            keychainManager: KeychainManager.shared,
+            biometricAuthManager: BiometricAuthManager.shared,
+            auditLogger: auditLogger
+        )
 
-        let authService = AuthenticationService.shared
+        // Register a user and establish a session.
+        _ = try await authService.register(
+            email: "timeout-test@example.com",
+            password: "TimeoutPass123!",
+            passcode: nil,
+            fullName: "Timeout User",
+            authMethod: .password
+        )
 
-        // Verify session timeout constant is set to 5 minutes (300 seconds)
-        // Note: This is a compile-time check, actual timeout is in AuthenticationService
+        // Let the deferred Task { @MainActor } assignment run so isAuthenticated
+        // reflects the newly created session before we invoke the timeout path.
+        await Task.yield()
+
+        #expect(authService.isAuthenticated == true,
+                "Session must be active before simulating timeout")
+
+        // Drive the same teardown path that fires when the 5-min inactivity
+        // timer expires, without waiting for a real timer.
+        await authService._testSimulateSessionTimeout()
+
+        // After timeout teardown: session must be nil and auth flag must be false.
+        #expect(authService.isAuthenticated == false,
+                "isAuthenticated must be false after session timeout")
+        #expect(authService.currentSession == nil,
+                "currentSession must be nil after session timeout")
+        #expect(authService.validateSession() == nil,
+                "validateSession() must return nil after timeout")
     }
 
     /// Test: Background transition triggers session check

--- a/HouseCallTests/ValidatorsTests.swift
+++ b/HouseCallTests/ValidatorsTests.swift
@@ -21,7 +21,10 @@ struct ValidatorsTests {
             "test+tag@example.co.uk",
             "user123@test-domain.com",
             "first.last@subdomain.example.com",
-            "email@123.123.123.123",
+            // "email@123.123.123.123" removed: the validator's secondary TLD
+            // regex requires [A-Za-z]{2,64}, so bare numeric octets as the
+            // domain suffix are intentionally rejected. This is correct
+            // behavior for a healthcare app (numeric TLDs are non-standard).
             "a@b.co"
         ]
 
@@ -155,7 +158,9 @@ struct ValidatorsTests {
     func testValidPasscode() {
         let validPasscodes = [
             "123789",
-            "987654",
+            // "987654" removed: 9-8-7-6-5-4 is a descending sequence and is
+            // correctly rejected by validatePasscode(_:). It also appears in
+            // testSequentialDescendingPasscode as an expected-invalid case.
             "135792",
             "246801"
         ]
@@ -360,9 +365,13 @@ struct ValidatorsTests {
 
     @Test("Unicode characters in password")
     func testUnicodePassword() {
-        let password = "Pässw0rd!你好"
+        // "Pässw0rd!你好" is only 11 characters (< 12 minimum). Add one extra
+        // character so the fixture meets every validation rule: 12+ chars,
+        // uppercase, lowercase, digit, and special character.
+        let password = "Pässw0rd!你好Z"
         let result = Validators.validatePassword(password)
-        // Should pass if it meets all requirements
+        // Should pass: 12 chars, uppercase (P, Z), lowercase (ä, s, s, w, r, d),
+        // digit (0), special (!)
         #expect(result.isValid == true)
     }
 


### PR DESCRIPTION
Closes #66 (HouseCall-4oc, isolation portion) and #69 (HouseCall-iz3). Final iOS test-suite cleanup from the #59 triage backlog. Mostly test fixes + one RFC-correct validator tightening.

## Fixes
**#66 — test isolation**
- IntegrationTests (8): `AuthenticationService.createSession()` defers its `@Published` writes via `Task { @MainActor }`; tests now `await Task.yield()` after register/login so the session state is visible before asserting. Real post-conditions retained.
- SSEParserTests (4): replaced multi-line string literals with inline `\n` strings (a toolchain literal quirk produced empty input); same logical bytes, parser already isolated per test.

**#69 — validators / timeout / audit**
- ValidatorsTests: corrected bad fixtures — `"987654"` (descending sequence, correctly invalid), numeric-TLD email (correctly invalid), unicode password padded to the 12-char minimum.
- **Production (Validators.swift):** reject consecutive dots in the email local-part (RFC 5321 — never valid; only tightens, single-dot addresses still pass).
- `SecurityTests.sessionTimeoutInvalidates` was an empty vacuous body — now drives the real timeout path and asserts `isAuthenticated == false` / session cleared.
- `AuditLoggerTests.testFetchEventsByDateRange`: fixed the test's date boundary (capture `endDate` after logging); the inclusive query was already correct.

## Validation
- `BUILD SUCCEEDED`; full suite **440 pass / 2 fail** non-parallel — and the 2 are exactly the tests fixed in PR #73 (this branch is off `main`, pre-#73). With #73 + this merged, the suite is fully green non-parallel.
- Reviewer APPROVE: validator change is a safe tightening, no test faked/weakened, await is the correct idiom.

## Deferred (tracked)
The parallel-runner SEGV (the other half of #66) is intentionally not fixed here — it needs `@MainActor`-safe singleton init, a larger change with app-layer risk. Canonical run stays `-parallel-testing-enabled NO`. Split into **HouseCall-d8q**. No production concurrency bug (test-host launch artifact only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)