### PR TITLE
fix(tests): strict-concurrency hotfix for CI (Xcode 16.x)

### DIFF
--- a/HouseCallTests/EncryptionManagerTests.swift
+++ b/HouseCallTests/EncryptionManagerTests.swift
@@ -281,7 +281,12 @@ struct EncryptionManagerTests {
 /// OSStatus) and a counter tracks whether `saveMasterKey` was ever called.
 @MainActor
 final class ThrowingOnReadKeychainManager: KeychainManager {
-    private(set) var saveCallCount: Int = 0
+    // `saveMasterKey` overrides a nonisolated parent method, so it can't touch
+    // a @MainActor-isolated stored property. The counter is mutated only from
+    // that override and read only from the @MainActor test — single-threaded —
+    // so nonisolated(unsafe) is safe here and satisfies strict concurrency
+    // (Swift 6 / Xcode 16.x), which the local toolchain did not enforce.
+    nonisolated(unsafe) private(set) var saveCallCount: Int = 0
 
     override func retrieveMasterKey() throws -> Data? {
         // Simulate a non-not-found keychain error (e.g. data protection class


### PR DESCRIPTION
Hotfix — `main`'s CI iOS job went red after the #73/#74 merges. The new CI gate (#72) caught a real toolchain-portability issue the local environment missed.

## Cause
The GitHub runner uses **Xcode 16.4** (strict Swift 6 actor isolation); the local dev machine uses **Xcode 26.5** (permissive). The qax test mock `ThrowingOnReadKeychainManager.saveMasterKey` overrides a nonisolated parent method and mutated a `@MainActor`-isolated `saveCallCount` — rejected under strict concurrency, but compiled locally, so it slipped through into #73.

## Fix
Mark the test-only counter `nonisolated(unsafe)` (it's mutated only in the override and read only from the `@MainActor` test — single-threaded). Verified locally with `SWIFT_STRICT_CONCURRENCY=complete`: **TEST BUILD SUCCEEDED**, and no other strict-concurrency errors in the suite.

## Note
This is exactly the value the CI gate was added for — it caught a break that local builds (on a newer, more permissive Xcode) did not. Worth considering pinning the CI runner's Xcode to match local, tracked separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)