### PR TITLE
chore(beads): record d8q -> issue #77 mapping

### DIFF
--- a/.beads/github-map.tsv
+++ b/.beads/github-map.tsv
@@ -39,3 +39,4 @@ HouseCall-4oc	66
 HouseCall-8e6	67
 HouseCall-qax	68
 HouseCall-iz3	69
+HouseCall-d8q	77


### PR DESCRIPTION
Follow-on to #76. Records the `HouseCall-d8q -> #77` mapping created when the mirror ran from main, so a future `beads-sync-github.sh` stays idempotent (won't create a duplicate issue for d8q).

🤖 Generated with [Claude Code](https://claude.com/claude-code)