### PR TITLE
fix(llm): parse the SSE response body in CustomProvider (empty replies)

### DIFF
--- a/HouseCall/Core/Services/LLMProviders/CustomProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/CustomProvider.swift
@@ -198,6 +198,19 @@ class CustomProvider: LLMProvider {
                 }
             }
 
+            // Parse the (OpenAI-compatible) SSE body. The completion-handler
+            // dataTask delivers the whole response at once, so we feed it through
+            // the SSE parser here and accumulate the assistant content. Without
+            // this the reply was silently dropped and the bubble rendered empty.
+            if let data = data {
+                self.sseParser.parse(data: data) { event in
+                    if let content = SSEParser.extractOpenAIContent(from: event) {
+                        fullResponse += content
+                        onChunk(content)
+                    }
+                }
+            }
+
             onComplete(.success(fullResponse))
         }
 


### PR DESCRIPTION
## Problem
`CustomProvider.performRequest` received the provider's HTTP response in the `dataTask` completion handler but **never parsed it** — it ran the error/HTTP-status checks and then called `onComplete(.success(fullResponse))` with an always-empty `fullResponse`, and `onChunk` was never invoked. Every custom/self-hosted (e.g. local Ollama) chat reply therefore came back **empty**: the assistant bubble rendered blank with no error banner.

## Fix
Feed the response body through the existing `SSEParser` in the completion handler and accumulate the OpenAI-compatible delta content:

```swift
if let data = data {
    self.sseParser.parse(data: data) { event in
        if let content = SSEParser.extractOpenAIContent(from: event) {
            fullResponse += content
            onChunk(content)
        }
    }
}
onComplete(.success(fullResponse))
```

## Verification
Driven end-to-end through the real iOS GUI (XCUITest) against a local Ollama (`medgemma:4b`): sign up → New Chat → send "I have a headache, what should I do?" → **a real medgemma reply now renders** in the chat (previously blank).

## Scope / follow-up
- This parses the **full body at completion** — replies appear all at once, not token-by-token. The `StreamingURLSessionDelegate` for true incremental streaming exists but is not wired up.
- `OpenAIProvider` and `ClaudeProvider` have the **same unparsed-response stub** (replies would be empty there too). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)