### PR TITLE
chore(beads): map HouseCall-kza -> issue #81

### DIFF
--- a/.beads/github-map.tsv
+++ b/.beads/github-map.tsv
@@ -40,3 +40,4 @@ HouseCall-8e6	67
 HouseCall-qax	68
 HouseCall-iz3	69
 HouseCall-d8q	77
+HouseCall-kza	81


### PR DESCRIPTION
Records the `HouseCall-kza` → GitHub issue **#81** mapping in `.beads/github-map.tsv`.

#81 (the LLM-streaming tracker) was created manually, so without this row `scripts/beads-sync-github.sh` would open a **duplicate** issue for `kza` on the next mirror run. One-line, mirror-idempotency housekeeping (same pattern as the earlier map reconciliations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)