### PR TITLE
update-patient-chat-ux: Phase 1 — Navigation & entry

### DIFF
--- a/HouseCall/Features/Conversation/Views/ChatView.swift
+++ b/HouseCall/Features/Conversation/Views/ChatView.swift
@@ -17,6 +17,7 @@ struct ChatView: View {
     @State private var showError: Bool = false
     @State private var showProviderMenu: Bool = false
     @State private var showSettings: Bool = false
+    @State private var showProfile: Bool = false
     @FocusState private var isInputFocused: Bool
 
     var body: some View {
@@ -108,9 +109,21 @@ struct ChatView: View {
                     providerBadge
                 }
             }
+
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
+                    showProfile = true
+                }) {
+                    Image(systemName: "person.circle")
+                        .accessibilityLabel("Profile")
+                }
+            }
         }
         .sheet(isPresented: $showSettings) {
             LLMProviderSettingsView()
+        }
+        .sheet(isPresented: $showProfile) {
+            ProfileView()
         }
         .onAppear {
             viewModel.loadMessages()

--- a/HouseCall/Features/Profile/Views/ProfileView.swift
+++ b/HouseCall/Features/Profile/Views/ProfileView.swift
@@ -1,0 +1,104 @@
+//
+//  ProfileView.swift
+//  HouseCall
+//
+//  User profile sheet — shows account info, AI provider settings link,
+//  app about section, and a logout button.
+//  Presented as a sheet from the chat toolbar's Profile button.
+//
+
+import SwiftUI
+
+struct ProfileView: View {
+    @EnvironmentObject var authService: AuthenticationService
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                // MARK: - User Info Section
+                Section {
+                    if let user = authService.getCurrentUser() {
+                        HStack(spacing: 16) {
+                            Image(systemName: "person.circle.fill")
+                                .font(.system(size: 60))
+                                .foregroundColor(.blue)
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                if let fullName = try? authService.getCurrentUserFullName() {
+                                    Text(fullName)
+                                        .font(.title3)
+                                        .fontWeight(.semibold)
+                                }
+
+                                Text(user.email ?? "")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 8)
+                    }
+                }
+
+                // MARK: - Settings Section
+                Section(header: Text("Settings")) {
+                    NavigationLink(destination: LLMProviderSettingsView()) {
+                        Label("AI Provider Settings", systemImage: "cpu")
+                    }
+                }
+
+                // MARK: - About Section
+                Section(header: Text("About")) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("🏥 HouseCall")
+                            .font(.headline)
+                            .fontWeight(.bold)
+
+                        Text("AI Healthcare Assistant")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+
+                        Text("HIPAA-Compliant • Encrypted • Secure")
+                            .font(.caption)
+                            .foregroundColor(.green)
+                            .padding(.top, 4)
+                    }
+                    .padding(.vertical, 8)
+                }
+
+                // MARK: - Logout Section
+                Section {
+                    Button(action: {
+                        Task {
+                            try? await authService.logout()
+                        }
+                    }) {
+                        HStack {
+                            Spacer()
+                            Text("Logout")
+                                .fontWeight(.semibold)
+                                .foregroundColor(.red)
+                            Spacer()
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Profile")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ProfileView()
+        .environmentObject(AuthenticationService.shared)
+}

--- a/HouseCall/HouseCallApp.swift
+++ b/HouseCall/HouseCallApp.swift
@@ -89,12 +89,12 @@ struct MainAppView: View {
     var body: some View {
         // Tab bar removed; chat is the single root authenticated view.
         // Profile is accessible via the toolbar button in ChatView (ProfileView sheet).
-        conversationsTab
+        chatRootView
     }
 
-    // MARK: - Tabs
+    // MARK: - Chat Root
 
-    private var conversationsTab: some View {
+    private var chatRootView: some View {
         Group {
             if let user = authService.getCurrentUser(), let userId = user.id {
                 AutoLaunchChatView(

--- a/HouseCall/HouseCallApp.swift
+++ b/HouseCall/HouseCallApp.swift
@@ -87,19 +87,9 @@ struct MainAppView: View {
     @Environment(\.managedObjectContext) private var viewContext
 
     var body: some View {
-        TabView {
-            // Conversations Tab
-            conversationsTab
-                .tabItem {
-                    Label("Chat", systemImage: "bubble.left.and.bubble.right")
-                }
-
-            // Profile Tab
-            profileTab
-                .tabItem {
-                    Label("Profile", systemImage: "person.circle")
-                }
-        }
+        // Tab bar removed; chat is the single root authenticated view.
+        // Profile content (profileTab) is retained below for task 1.3 (toolbar button).
+        conversationsTab
     }
 
     // MARK: - Tabs

--- a/HouseCall/HouseCallApp.swift
+++ b/HouseCall/HouseCallApp.swift
@@ -97,7 +97,7 @@ struct MainAppView: View {
     private var conversationsTab: some View {
         Group {
             if let user = authService.getCurrentUser(), let userId = user.id {
-                ConversationListView(
+                AutoLaunchChatView(
                     userId: userId,
                     conversationRepository: CoreDataConversationRepository(context: viewContext),
                     messageRepository: CoreDataMessageRepository(context: viewContext)
@@ -180,6 +180,113 @@ struct MainAppView: View {
                 }
             }
             .navigationTitle("Profile")
+        }
+    }
+}
+
+// MARK: - Auto-Launch Chat View
+
+/// Resolves the patient's most-recent conversation (or creates one if none
+/// exists) and presents `ChatView` directly — no list, no "New Chat" step.
+private struct AutoLaunchChatView: View {
+
+    let userId: UUID
+    let conversationRepository: ConversationRepositoryProtocol
+    let messageRepository: MessageRepositoryProtocol
+
+    private enum LaunchState {
+        case loading
+        case ready
+        case failed(String)
+    }
+
+    @State private var launchState: LaunchState = .loading
+    /// Incremented on each retry to re-trigger the `.task(id:)` modifier.
+    @State private var loadAttempt: Int = 0
+    /// Retained across re-renders once resolved.
+    @State private var chatViewModel: ConversationViewModel?
+
+    var body: some View {
+        NavigationStack {
+            contentView
+        }
+        .task(id: loadAttempt) {
+            await resolveConversation()
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        switch launchState {
+        case .loading:
+            ProgressView("Opening conversation…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .ready:
+            if let vm = chatViewModel {
+                ChatView(viewModel: vm)
+            }
+
+        case .failed(let message):
+            VStack(spacing: 20) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.system(size: 48))
+                    .foregroundColor(.secondary)
+
+                Text(message)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 32)
+
+                Button("Try Again") {
+                    launchState = .loading
+                    loadAttempt += 1
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Conversation Resolution
+
+    /// Fetches the most-recently-updated conversation for this user, or creates
+    /// a new one with the default provider if none exist.
+    /// No PHI is written to logs — only identifiers and event names.
+    private func resolveConversation() async {
+        do {
+            // fetchConversations returns results sorted by updatedAt descending,
+            // so .first is the most-recently-updated conversation.
+            let conversations = try conversationRepository.fetchConversations(userId: userId)
+            let conversation: Conversation
+            if let existing = conversations.first {
+                conversation = existing
+            } else {
+                conversation = try conversationRepository.createConversation(
+                    userId: userId,
+                    provider: .openai,
+                    title: nil
+                )
+            }
+            guard let conversationId = conversation.id else {
+                launchState = .failed("Unable to open your conversation. Please try again.")
+                return
+            }
+            chatViewModel = ConversationViewModel(
+                userId: userId,
+                conversationId: conversationId,
+                conversationRepository: conversationRepository,
+                messageRepository: messageRepository
+            )
+            launchState = .ready
+        } catch {
+            // Log the event without PHI.
+            try? AuditLogger.shared.log(
+                event: .aiInteractionFailed,
+                userId: userId,
+                details: AuditEventDetails(errorMessage: "auto-launch conversation resolve failed")
+            )
+            launchState = .failed("Unable to open your conversation. Please try again.")
         }
     }
 }

--- a/HouseCall/HouseCallApp.swift
+++ b/HouseCall/HouseCallApp.swift
@@ -88,7 +88,7 @@ struct MainAppView: View {
 
     var body: some View {
         // Tab bar removed; chat is the single root authenticated view.
-        // Profile content (profileTab) is retained below for task 1.3 (toolbar button).
+        // Profile is accessible via the toolbar button in ChatView (ProfileView sheet).
         conversationsTab
     }
 
@@ -109,79 +109,6 @@ struct MainAppView: View {
         }
     }
 
-    private var profileTab: some View {
-        NavigationStack {
-            List {
-                // User Info Section
-                Section {
-                    if let user = authService.getCurrentUser() {
-                        HStack(spacing: 16) {
-                            Image(systemName: "person.circle.fill")
-                                .font(.system(size: 60))
-                                .foregroundColor(.blue)
-
-                            VStack(alignment: .leading, spacing: 4) {
-                                if let fullName = try? authService.getCurrentUserFullName() {
-                                    Text(fullName)
-                                        .font(.title3)
-                                        .fontWeight(.semibold)
-                                }
-
-                                Text(user.email ?? "")
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                        .padding(.vertical, 8)
-                    }
-                }
-
-                // Settings Section
-                Section(header: Text("Settings")) {
-                    NavigationLink(destination: LLMProviderSettingsView()) {
-                        Label("AI Provider Settings", systemImage: "cpu")
-                    }
-                }
-
-                // App Info Section
-                Section(header: Text("About")) {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("🏥 HouseCall")
-                            .font(.headline)
-                            .fontWeight(.bold)
-
-                        Text("AI Healthcare Assistant")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-
-                        Text("HIPAA-Compliant • Encrypted • Secure")
-                            .font(.caption)
-                            .foregroundColor(.green)
-                            .padding(.top, 4)
-                    }
-                    .padding(.vertical, 8)
-                }
-
-                // Logout Section
-                Section {
-                    Button(action: {
-                        Task {
-                            try? await authService.logout()
-                        }
-                    }) {
-                        HStack {
-                            Spacer()
-                            Text("Logout")
-                                .fontWeight(.semibold)
-                                .foregroundColor(.red)
-                            Spacer()
-                        }
-                    }
-                }
-            }
-            .navigationTitle("Profile")
-        }
-    }
 }
 
 // MARK: - Auto-Launch Chat View

--- a/openspec/changes/update-patient-chat-ux/design.md
+++ b/openspec/changes/update-patient-chat-ux/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The chat surface was built (`add-ai-chat-interface`) as a power-user, multi-
+provider tool: conversation list, in-chat provider switching, and a settings
+screen for keys/model/temperature. The product is a consumer healthcare app
+where the patient must never see LLM plumbing. This change collapses the UX to a
+single zero-config streaming conversation and fixes two defects (no visible
+streaming, no Markdown).
+
+## Goals / Non-Goals
+
+- Goals: single-chat entry after login; remove all patient-facing provider
+  config; profile reachable from a toolbar button; visible token streaming;
+  Markdown for assistant messages.
+- Non-Goals: changing the cloud/physician-in-loop recommendation-card path;
+  multi-conversation management; in-app provider switching; deleting the
+  underlying repositories or `LLMProviderConfigManager` internals.
+
+## Decisions
+
+- **Provider is a hardcoded build-config default.** A single provider + key are
+  read from build configuration and used for all conversations. Keep
+  `LLMProviderConfigManager` as the internal seam but drive it from the default
+  rather than user input. Keychain key storage remains for the chosen default;
+  no user entry path.
+  - Alternatives: keep settings UI but hide the link (rejected — leaves dead
+    code reachable via deep links and tests); fully delete config layer
+    (rejected — larger blast radius, cloud path may still need it).
+- **Single-chat root, not a list.** Authenticated root resolves to the most-
+  recent conversation or creates one. `ConversationListView` is retired from the
+  authenticated entry point but left in the codebase until a follow-up removes
+  it, to keep this change focused.
+- **Profile as a toolbar sheet, not a tab.** Removes `TabView`; a top-right
+  toolbar button presents profile (about + logout).
+- **Markdown via SwiftUI `Text(AttributedString(markdown:))` / `Text(.init(...))`
+  for assistant bubbles**, falling back to plain text on parse failure. User
+  bubbles stay plaintext to avoid rendering patient input as markup.
+
+## Risks / Trade-offs
+
+- Streaming bug root cause unconfirmed — could be publish threading, Combine
+  sink, or in-place vs streaming-bubble swap. Task 3.1 traces before fixing.
+  → Mitigation: add a regression test asserting incremental `streamingText`.
+- Markdown rendering of untrusted assistant output → keep it display-only; no
+  HTML, no remote image loading; links rendered but not auto-opened.
+
+## Migration Plan
+
+Existing Core Data conversations are untouched; login opens the most-recent one.
+No schema change. Provider field on stored conversations is ignored at runtime
+in favor of the default.
+
+## Open Questions
+
+- Which build-config mechanism for the default key (xcconfig vs Info.plist vs
+  compile-time) — resolve in task 2.4 against existing project conventions.

--- a/openspec/changes/update-patient-chat-ux/proposal.md
+++ b/openspec/changes/update-patient-chat-ux/proposal.md
@@ -1,0 +1,41 @@
+# Change: Simplify patient chat to a single zero-config streaming conversation
+
+## Why
+
+The chat surface still exposes LLM plumbing to the patient — provider pickers,
+an "AI Provider Settings" screen, a conversation list, and a "New Chat" button —
+none of which belong in a consumer healthcare app. The patient should land in a
+working conversation immediately after login. Two defects compound this: the
+assistant response does not visibly stream, and assistant text renders as flat
+plaintext with no Markdown formatting.
+
+## What Changes
+
+- **BREAKING**: Remove the bottom `TabView`. After login the patient is taken
+  straight into a chat (no conversation list, no "New Chat" step).
+- **BREAKING**: Remove the in-chat LLM provider picker/badge and the
+  "AI Provider Settings" screen from Profile. The patient never sees or selects
+  a provider.
+- Provider + API key become a **hardcoded app default** (build config), used by
+  every conversation. No user-facing provider configuration remains.
+- Replace the tab bar with a single **Profile button in the top-right** of the
+  chat toolbar (logout + about live there).
+- **Fix streaming**: assistant responses must visibly render token-by-token in
+  the bubble as SSE chunks arrive (currently they do not update incrementally).
+- Add **Markdown rendering** for assistant messages (headings, bold, lists,
+  code, links).
+
+## Impact
+
+- Affected specs: `ai-chat-interface` (MODIFIED/REMOVED/ADDED),
+  `llm-provider-integration` (ADDED hardcoded default).
+- Affected code:
+  - `HouseCall/HouseCallApp.swift` — `MainAppView` tab bar → single chat + profile toolbar button.
+  - `HouseCall/Features/Conversation/Views/ChatView.swift` — remove provider menu/badge; add Markdown rendering; profile toolbar item.
+  - `HouseCall/Features/Conversation/Views/MessageBubbleView.swift` — Markdown.
+  - `HouseCall/Features/Conversation/ViewModels/ConversationViewModel.swift` — drop `switchProvider`; verify streaming publish path.
+  - `HouseCall/Core/Services/AIConversationService.swift` — incremental `streamingText` publish fix.
+  - `HouseCall/Features/Settings/**` — `LLMProviderSettingsView` no longer reachable from Profile.
+  - Auto-launch helper (open most-recent or create conversation on login).
+- Supersedes the provider-selection and conversation-list UX from
+  `add-ai-chat-interface`.

--- a/openspec/changes/update-patient-chat-ux/specs/ai-chat-interface/spec.md
+++ b/openspec/changes/update-patient-chat-ux/specs/ai-chat-interface/spec.md
@@ -1,0 +1,124 @@
+# Specification: AI Chat Interface
+
+## ADDED Requirements
+
+### Requirement: Launch directly into a chat after login
+
+After authentication, the patient SHALL be taken straight into a chat
+conversation without an intermediate conversation list or a "New Chat" step.
+
+#### Scenario: Returning patient lands in most-recent conversation
+
+- **GIVEN** the patient has at least one existing conversation
+- **WHEN** the patient finishes logging in
+- **THEN** the chat screen opens directly on the most-recently-updated conversation
+- **AND** no conversation list or "New Chat" button is shown
+
+#### Scenario: First-time patient gets a conversation created
+
+- **GIVEN** the patient has no existing conversations
+- **WHEN** the patient finishes logging in
+- **THEN** a new conversation is created automatically using the default provider
+- **AND** the chat screen opens on that empty conversation ready for input
+
+### Requirement: Access profile from the chat toolbar
+
+The patient SHALL reach profile actions (about, logout) from a profile control
+in the top-right of the chat toolbar. There SHALL be no bottom tab bar.
+
+#### Scenario: Patient opens profile from chat
+
+- **GIVEN** the patient is on the chat screen
+- **WHEN** the patient taps the profile control in the top-right of the toolbar
+- **THEN** the profile surface is presented with account info and a logout action
+- **AND** no AI/LLM provider configuration is shown anywhere in the profile
+
+### Requirement: Render assistant messages as Markdown
+
+Assistant message content SHALL be rendered as Markdown so headings, bold,
+italic, lists, inline code, code blocks, and links display formatted.
+
+#### Scenario: Assistant returns formatted guidance
+
+- **GIVEN** the assistant returns a response containing a heading, a bulleted list, and bold text
+- **WHEN** the message is displayed in the chat
+- **THEN** the heading, list, and bold text render as formatted Markdown
+- **AND** user messages continue to render as plain text
+- **AND** VoiceOver reads the formatted content without exposing markup symbols
+
+## MODIFIED Requirements
+
+### Requirement: Stream AI responses in real-time
+
+AI responses SHALL stream token-by-token to the user interface, with the
+visible message bubble updating incrementally as each Server-Sent Events chunk
+arrives, providing immediate feedback and reducing perceived latency.
+
+#### Scenario: Long AI response streams smoothly
+
+- **GIVEN** the user asks "What could cause chronic fatigue?"
+- **WHEN** the AI generates a 500-token response
+- **THEN** tokens appear incrementally in the message bubble as chunks arrive
+- **AND** the scroll view auto-scrolls to keep the latest text visible
+- **AND** the UI remains responsive (60fps) during streaming
+- **AND** the user can read earlier parts of the response while it completes
+
+#### Scenario: Streamed text updates before completion
+
+- **GIVEN** the assistant has begun streaming a response
+- **WHEN** the first SSE chunks have arrived but the stream is not complete
+- **THEN** the partial text is already visible in the bubble
+- **AND** the bubble continues to update as further chunks arrive
+- **AND** the input remains disabled until the stream completes
+
+#### Scenario: Streaming is interrupted by network loss
+
+- **GIVEN** the AI is streaming a response (50% complete)
+- **WHEN** the network connection is lost
+- **THEN** the partial response remains visible in the chat
+- **AND** an error indicator shows "Connection lost"
+- **AND** a "Retry" button appears below the partial message
+- **AND** tapping Retry resends the user's last message
+
+### Requirement: Display real-time chat conversation
+
+Users SHALL be able to view a real-time chat conversation with the AI health
+assistant, displaying both user messages and AI responses in a familiar
+messaging interface, with assistant responses rendered as Markdown.
+
+#### Scenario: User sends message and receives streaming response
+
+- **GIVEN** the user is authenticated and on the chat screen
+- **WHEN** the user types "I have a headache and fever" and taps Send
+- **THEN** the message appears immediately in the chat as a user bubble
+- **AND** an AI response begins streaming token-by-token within 2 seconds
+- **AND** a typing indicator shows while the AI is generating the response
+- **AND** the completed AI response is fully visible and Markdown-formatted
+
+#### Scenario: User views conversation history
+
+- **GIVEN** the user has an existing conversation with 10 messages
+- **WHEN** the user opens the conversation
+- **THEN** all 10 messages are displayed in chronological order
+- **AND** user messages are right-aligned in blue bubbles
+- **AND** AI messages are left-aligned in gray bubbles
+- **AND** each message shows a timestamp
+
+## REMOVED Requirements
+
+### Requirement: Provide conversation list view
+
+**Reason**: The patient now launches directly into a single chat; a multi-
+conversation list and "New Chat" entry point are removed from the consumer UX.
+
+**Migration**: Replaced by "Launch directly into a chat after login". Existing
+conversations remain in Core Data; the most-recent one is opened on login.
+
+### Requirement: Support LLM provider selection
+
+**Reason**: Provider choice is no longer a patient-facing concern. The app uses
+a single hardcoded default provider.
+
+**Migration**: Replaced by the hardcoded default provider requirement in
+`llm-provider-integration`. The in-chat picker and the provider-switch system
+message are removed.

--- a/openspec/changes/update-patient-chat-ux/specs/llm-provider-integration/spec.md
+++ b/openspec/changes/update-patient-chat-ux/specs/llm-provider-integration/spec.md
@@ -1,0 +1,22 @@
+# Specification: LLM Provider Integration
+
+## ADDED Requirements
+
+### Requirement: Use a hardcoded default provider with no user configuration
+
+The app SHALL use a single default LLM provider and API key sourced from build
+configuration. No provider selection, API-key entry, or model/temperature
+configuration SHALL be exposed in the patient-facing UI.
+
+#### Scenario: Every conversation uses the default provider
+
+- **GIVEN** a patient starts or resumes any conversation
+- **WHEN** a message is sent
+- **THEN** the request uses the hardcoded default provider and key
+- **AND** the patient is never prompted to choose or configure a provider
+
+#### Scenario: No provider configuration surface exists
+
+- **WHEN** the patient navigates the app, including the profile surface
+- **THEN** there is no screen, link, or control for AI/LLM provider settings
+- **AND** the API key is not displayed anywhere in the UI

--- a/openspec/changes/update-patient-chat-ux/tasks.md
+++ b/openspec/changes/update-patient-chat-ux/tasks.md
@@ -1,0 +1,31 @@
+## 1. Navigation & entry
+
+- [ ] 1.1 Remove the `TabView` from `MainAppView` (`HouseCallApp.swift`); show a single chat as the root authenticated view.
+- [ ] 1.2 Add an auto-launch path: on login, open the patient's most-recent conversation, or create one if none exists, and present `ChatView` directly (no list, no "New Chat").
+- [ ] 1.3 Add a Profile button to the top-right of the chat toolbar that presents the profile (about + logout); remove the standalone Profile tab.
+- [ ] 1.4 Stop routing to `ConversationListView` from the authenticated entry point.
+
+## 2. Remove provider configuration from the patient UI
+
+- [ ] 2.1 Remove the provider picker menu and provider badge from `ChatView` toolbar.
+- [ ] 2.2 Remove the "AI Provider Settings" `NavigationLink` and `LLMProviderSettingsView` sheet from Profile / chat.
+- [ ] 2.3 Remove `switchProvider` from `ConversationViewModel` (and any provider-switch system messages no longer reachable).
+- [ ] 2.4 Introduce a hardcoded default provider + API key sourced from build config; wire `AIConversationService` to always use it.
+
+## 3. Fix streaming
+
+- [ ] 3.1 Trace the SSE → `streamingText`/`streamingMessageId` publish path in `AIConversationService` and confirm chunks are published on the main actor as they arrive.
+- [ ] 3.2 Ensure `ChatView` updates the bubble incrementally (streaming bubble or in-place message update) so tokens appear in real time.
+- [ ] 3.3 Verify auto-scroll keeps the latest streamed text visible and the input stays disabled until the stream completes.
+
+## 4. Markdown rendering
+
+- [ ] 4.1 Render assistant message content as Markdown in `MessageBubbleView` (headings, bold/italic, lists, inline code/code blocks, links).
+- [ ] 4.2 Keep user messages as plaintext; ensure Markdown rendering does not break VoiceOver labels or PHI handling.
+
+## 5. Tests
+
+- [ ] 5.1 Update/remove tests covering provider selection and conversation-list navigation.
+- [ ] 5.2 Add a streaming regression test asserting `streamingText` updates incrementally and the final message is persisted.
+- [ ] 5.3 Add a Markdown rendering test for assistant bubbles.
+- [ ] 5.4 Update `ChatInterfaceUITests` for single-chat entry + top-right profile button.

--- a/openspec/changes/update-patient-chat-ux/tasks.md
+++ b/openspec/changes/update-patient-chat-ux/tasks.md
@@ -3,7 +3,7 @@
 - [x] 1.1 Remove the `TabView` from `MainAppView` (`HouseCallApp.swift`); show a single chat as the root authenticated view.
 - [x] 1.2 Add an auto-launch path: on login, open the patient's most-recent conversation, or create one if none exists, and present `ChatView` directly (no list, no "New Chat").
 - [x] 1.3 Add a Profile button to the top-right of the chat toolbar that presents the profile (about + logout); remove the standalone Profile tab.
-- [ ] 1.4 Stop routing to `ConversationListView` from the authenticated entry point.
+- [x] 1.4 Stop routing to `ConversationListView` from the authenticated entry point.
 
 ## 2. Remove provider configuration from the patient UI
 

--- a/openspec/changes/update-patient-chat-ux/tasks.md
+++ b/openspec/changes/update-patient-chat-ux/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Remove the `TabView` from `MainAppView` (`HouseCallApp.swift`); show a single chat as the root authenticated view.
 - [x] 1.2 Add an auto-launch path: on login, open the patient's most-recent conversation, or create one if none exists, and present `ChatView` directly (no list, no "New Chat").
-- [ ] 1.3 Add a Profile button to the top-right of the chat toolbar that presents the profile (about + logout); remove the standalone Profile tab.
+- [x] 1.3 Add a Profile button to the top-right of the chat toolbar that presents the profile (about + logout); remove the standalone Profile tab.
 - [ ] 1.4 Stop routing to `ConversationListView` from the authenticated entry point.
 
 ## 2. Remove provider configuration from the patient UI

--- a/openspec/changes/update-patient-chat-ux/tasks.md
+++ b/openspec/changes/update-patient-chat-ux/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Navigation & entry
 
 - [x] 1.1 Remove the `TabView` from `MainAppView` (`HouseCallApp.swift`); show a single chat as the root authenticated view.
-- [ ] 1.2 Add an auto-launch path: on login, open the patient's most-recent conversation, or create one if none exists, and present `ChatView` directly (no list, no "New Chat").
+- [x] 1.2 Add an auto-launch path: on login, open the patient's most-recent conversation, or create one if none exists, and present `ChatView` directly (no list, no "New Chat").
 - [ ] 1.3 Add a Profile button to the top-right of the chat toolbar that presents the profile (about + logout); remove the standalone Profile tab.
 - [ ] 1.4 Stop routing to `ConversationListView` from the authenticated entry point.
 

--- a/openspec/changes/update-patient-chat-ux/tasks.md
+++ b/openspec/changes/update-patient-chat-ux/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Navigation & entry
 
-- [ ] 1.1 Remove the `TabView` from `MainAppView` (`HouseCallApp.swift`); show a single chat as the root authenticated view.
+- [x] 1.1 Remove the `TabView` from `MainAppView` (`HouseCallApp.swift`); show a single chat as the root authenticated view.
 - [ ] 1.2 Add an auto-launch path: on login, open the patient's most-recent conversation, or create one if none exists, and present `ChatView` directly (no list, no "New Chat").
 - [ ] 1.3 Add a Profile button to the top-right of the chat toolbar that presents the profile (about + logout); remove the standalone Profile tab.
 - [ ] 1.4 Stop routing to `ConversationListView` from the authenticated entry point.


### PR DESCRIPTION
## Phase 1 — Navigation & entry

First phase of OpenSpec change `update-patient-chat-ux`. Reshapes the authenticated entry so the patient lands directly in a chat with a top-right profile button — no bottom tab bar, no conversation list, no "New Chat" step.

### Tasks completed
- [x] 1.1 Remove the `TabView` from `MainAppView`; chat is the single authenticated root view.
- [x] 1.2 Auto-launch: on login, open the most-recent conversation or create one, present `ChatView` directly (`AutoLaunchChatView` with loading + error/retry states).
- [x] 1.3 Profile button (`person.circle`) in the chat toolbar top-right presenting a new standalone `ProfileView` sheet; removed the dead `profileTab`.
- [x] 1.4 Verified `ConversationListView` is no longer routed to at runtime; renamed `conversationsTab` → `chatRootView`.

### Beads closed
- HouseCall-9le (#99) — 1.1
- HouseCall-a1v (#98) — 1.2
- HouseCall-eun (#97) — 1.3
- HouseCall-b66 (#96) — 1.4

### Validation
- `xcodebuild` Debug build succeeds (iPhone 17 simulator) on every task.
- `HouseCallTests`: ~430 pass; the only failures are pre-existing flaky tests (CloudSync / Integration / AIChatIntegration) that also fail on `main` under parallel execution and pass in isolation — not introduced by this phase.

### Notes / deferred
- Provider picker + provider badge still present in `ChatView`, and the "AI Provider Settings" link still in `ProfileView` — removed in Phase 2 (tasks 2.x), by design.
- `showProviderMenu` dead `@State` in `ChatView` left for Phase 2 (2.1).
- Filed follow-up bug: pre-existing `print(error.localizedDescription)` PHI-adjacent leak in `ConversationListView.swift:~314` (out of scope here).

### Out of scope for Phase 1
Provider hardcoding (Phase 2), streaming fix (Phase 3), Markdown rendering (Phase 4), tests (Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)