### PR TITLE
update-patient-chat-ux: Phase 3 — Fix streaming

### DIFF
--- a/HouseCall/Core/Services/LLMProviderConfigManager.swift
+++ b/HouseCall/Core/Services/LLMProviderConfigManager.swift
@@ -213,7 +213,7 @@ class LLMProviderConfigManager: ObservableObject {
 
     /// Create an instance of the active provider
     func createActiveProvider() -> LLMProvider? {
-        return createProvider(type: activeProvider)
+        return createProvider(type: getActiveProvider())
     }
 
     /// Create a provider instance by type.

--- a/HouseCall/Core/Services/LLMProviders/ClaudeProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/ClaudeProvider.swift
@@ -18,6 +18,9 @@ class ClaudeProvider: LLMProvider {
     private let auditLogger: AuditLogger
 
     private var currentTask: URLSessionDataTask?
+    /// Dedicated session created per streaming request (URLSession.shared does not
+    /// support per-request delegates).  Stored so `cancelStreaming()` can invalidate it.
+    private var streamingSession: URLSession?
     private let sseParser = SSEParser()
 
     /// Configuration for Claude requests
@@ -78,6 +81,8 @@ class ClaudeProvider: LLMProvider {
     func cancelStreaming() {
         currentTask?.cancel()
         currentTask = nil
+        streamingSession?.invalidateAndCancel()
+        streamingSession = nil
         sseParser.reset()
     }
 
@@ -146,51 +151,22 @@ class ClaudeProvider: LLMProvider {
         let requestBody = buildRequestBody(messages: messages)
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
-        // Reset SSE parser
-        sseParser.reset()
+        // Create a fresh SSEParser per request so that cancelStreaming's sseParser.reset()
+        // cannot race with background delegate callbacks on the URLSession queue.
+        let requestParser = SSEParser()
 
-        // Track accumulated response
-        var fullResponse = ""
-
-        // Create URL session with streaming delegate
-        let session = URLSession.shared
-        let task = session.dataTask(with: request) { [weak self] data, response, error in
-            guard let self = self else { return }
-
-            // Handle completion
-            if let error = error {
-                let nsError = error as NSError
-                if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
-                    onComplete(.failure(.cancelled))
-                } else if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut {
-                    onComplete(.failure(.timeout))
-                } else {
-                    onComplete(.failure(.networkError(error)))
-                }
-                return
-            }
-
-            // Check HTTP response
-            if let httpResponse = response as? HTTPURLResponse {
-                guard (200...299).contains(httpResponse.statusCode) else {
-                    let error = self.parseHTTPError(
-                        statusCode: httpResponse.statusCode,
-                        data: data
-                    )
-                    onComplete(.failure(error))
-                    return
-                }
-            }
-
-            // This completion handler is called once at the end
-            // For streaming, we need to use URLSessionDataDelegate
-            onComplete(.success(fullResponse))
-        }
-
-        // Store task for cancellation
+        let streamingDelegate = ClaudeStreamingDelegate(
+            sseParser: requestParser,
+            onChunk: onChunk,
+            onComplete: onComplete
+        )
+        // URLSession.shared does not support per-request delegates; a dedicated session
+        // is required so urlSession(_:dataTask:didReceive:) fires incrementally for
+        // each SSE chunk instead of once at the end of the response.
+        let session = URLSession(configuration: .default, delegate: streamingDelegate, delegateQueue: nil)
+        streamingSession = session
+        let task = session.dataTask(with: request)
         currentTask = task
-
-        // Start streaming request
         task.resume()
     }
 
@@ -277,6 +253,8 @@ class ClaudeStreamingDelegate: NSObject, URLSessionDataDelegate {
     private let onChunk: (String) -> Void
     private let onComplete: (Result<String, LLMError>) -> Void
     private var fullResponse = ""
+    /// Guards against double-firing onComplete (e.g. message_stop arrives then didCompleteWithError fires).
+    private var hasCompleted = false
 
     init(
         sseParser: SSEParser,
@@ -286,6 +264,40 @@ class ClaudeStreamingDelegate: NSObject, URLSessionDataDelegate {
         self.sseParser = sseParser
         self.onChunk = onChunk
         self.onComplete = onComplete
+    }
+
+    /// Fires onComplete exactly once.
+    private func fireComplete(_ result: Result<String, LLMError>) {
+        guard !hasCompleted else { return }
+        hasCompleted = true
+        onComplete(result)
+    }
+
+    /// Validate the HTTP status code before allowing data to flow through the parser.
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            completionHandler(.allow)
+            return
+        }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let statusCode = httpResponse.statusCode
+            let llmError: LLMError
+            switch statusCode {
+            case 401, 403: llmError = .authenticationFailed
+            case 429: llmError = .rateLimit(retryAfterSeconds: 60)
+            case 500...599: llmError = .providerError(statusCode: statusCode, message: "Server error")
+            default: llmError = .providerError(statusCode: statusCode, message: "HTTP \(statusCode)")
+            }
+            fireComplete(.failure(llmError))
+            completionHandler(.cancel)
+            return
+        }
+        completionHandler(.allow)
     }
 
     func urlSession(
@@ -299,7 +311,7 @@ class ClaudeStreamingDelegate: NSObject, URLSessionDataDelegate {
 
             // Check for completion marker
             if SSEParser.isClaudeComplete(event: event) {
-                self.onComplete(.success(self.fullResponse))
+                self.fireComplete(.success(self.fullResponse))
                 return
             }
 
@@ -316,15 +328,21 @@ class ClaudeStreamingDelegate: NSObject, URLSessionDataDelegate {
         task: URLSessionTask,
         didCompleteWithError error: Error?
     ) {
+        defer { session.finishTasksAndInvalidate() }
         if let error = error {
             let nsError = error as NSError
             if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
-                onComplete(.failure(.cancelled))
+                fireComplete(.failure(.cancelled))
             } else if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut {
-                onComplete(.failure(.timeout))
+                fireComplete(.failure(.timeout))
             } else {
-                onComplete(.failure(.networkError(error)))
+                fireComplete(.failure(.networkError(error)))
             }
+        } else {
+            // Normal task completion; the message_stop event should have already fired
+            // onComplete via didReceive(_:data:).  If the server closed the stream
+            // without it (non-standard), fire it here as a fallback.
+            fireComplete(.success(fullResponse))
         }
     }
 }

--- a/HouseCall/Core/Services/LLMProviders/OpenAIProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/OpenAIProvider.swift
@@ -18,6 +18,9 @@ class OpenAIProvider: LLMProvider {
     private let auditLogger: AuditLogger
 
     private var currentTask: URLSessionDataTask?
+    /// Dedicated session created per streaming request (URLSession.shared does not
+    /// support per-request delegates).  Stored so `cancelStreaming()` can invalidate it.
+    private var streamingSession: URLSession?
     private let sseParser = SSEParser()
 
     /// Configuration for OpenAI requests
@@ -75,6 +78,8 @@ class OpenAIProvider: LLMProvider {
     func cancelStreaming() {
         currentTask?.cancel()
         currentTask = nil
+        streamingSession?.invalidateAndCancel()
+        streamingSession = nil
         sseParser.reset()
     }
 
@@ -140,56 +145,23 @@ class OpenAIProvider: LLMProvider {
         let requestBody = buildRequestBody(messages: messages)
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
-        // Reset SSE parser
-        sseParser.reset()
+        // Create a fresh SSEParser per request so that cancelStreaming's sseParser.reset()
+        // cannot race with background delegate callbacks on the URLSession queue.
+        let requestParser = SSEParser()
 
-        // Track accumulated response
-        var fullResponse = ""
-
-        // Create URL session with streaming delegate
-        let session = URLSession.shared
-        let task = session.dataTask(with: request) { [weak self] data, response, error in
-            guard let self = self else { return }
-
-            // Handle completion
-            if let error = error {
-                let nsError = error as NSError
-                if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
-                    onComplete(.failure(.cancelled))
-                } else if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut {
-                    onComplete(.failure(.timeout))
-                } else {
-                    onComplete(.failure(.networkError(error)))
-                }
-                return
-            }
-
-            // Check HTTP response
-            if let httpResponse = response as? HTTPURLResponse {
-                guard (200...299).contains(httpResponse.statusCode) else {
-                    let error = self.parseHTTPError(
-                        statusCode: httpResponse.statusCode,
-                        data: data
-                    )
-                    onComplete(.failure(error))
-                    return
-                }
-            }
-
-            // This completion handler is called once at the end
-            // For streaming, we need to use URLSessionDataDelegate
-            onComplete(.success(fullResponse))
-        }
-
-        // Store task for cancellation
+        let streamingDelegate = StreamingURLSessionDelegate(
+            sseParser: requestParser,
+            onChunk: onChunk,
+            onComplete: onComplete
+        )
+        // URLSession.shared does not support per-request delegates; a dedicated session
+        // is required so urlSession(_:dataTask:didReceive:) fires incrementally for
+        // each SSE chunk instead of once at the end of the response.
+        let session = URLSession(configuration: .default, delegate: streamingDelegate, delegateQueue: nil)
+        streamingSession = session
+        let task = session.dataTask(with: request)
         currentTask = task
-
-        // Start streaming request
         task.resume()
-
-        // Note: For true streaming, we need URLSessionDataDelegate
-        // This basic implementation will work but won't stream in real-time
-        // See StreamingURLSessionDelegate below for full streaming support
     }
 
     private func buildRequestBody(messages: [ChatMessage]) -> [String: Any] {
@@ -266,6 +238,8 @@ class StreamingURLSessionDelegate: NSObject, URLSessionDataDelegate {
     private let onChunk: (String) -> Void
     private let onComplete: (Result<String, LLMError>) -> Void
     private var fullResponse = ""
+    /// Guards against double-firing onComplete (e.g. [DONE] arrives then didCompleteWithError fires).
+    private var hasCompleted = false
 
     init(
         sseParser: SSEParser,
@@ -275,6 +249,40 @@ class StreamingURLSessionDelegate: NSObject, URLSessionDataDelegate {
         self.sseParser = sseParser
         self.onChunk = onChunk
         self.onComplete = onComplete
+    }
+
+    /// Fires onComplete exactly once.
+    private func fireComplete(_ result: Result<String, LLMError>) {
+        guard !hasCompleted else { return }
+        hasCompleted = true
+        onComplete(result)
+    }
+
+    /// Validate the HTTP status code before allowing data to flow through the parser.
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            completionHandler(.allow)
+            return
+        }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let statusCode = httpResponse.statusCode
+            let llmError: LLMError
+            switch statusCode {
+            case 401, 403: llmError = .authenticationFailed
+            case 429: llmError = .rateLimit(retryAfterSeconds: 60)
+            case 500...599: llmError = .providerError(statusCode: statusCode, message: "Server error")
+            default: llmError = .providerError(statusCode: statusCode, message: "HTTP \(statusCode)")
+            }
+            fireComplete(.failure(llmError))
+            completionHandler(.cancel)
+            return
+        }
+        completionHandler(.allow)
     }
 
     func urlSession(
@@ -288,7 +296,7 @@ class StreamingURLSessionDelegate: NSObject, URLSessionDataDelegate {
 
             // Check for completion marker
             if event.isComplete {
-                self.onComplete(.success(self.fullResponse))
+                self.fireComplete(.success(self.fullResponse))
                 return
             }
 
@@ -305,15 +313,21 @@ class StreamingURLSessionDelegate: NSObject, URLSessionDataDelegate {
         task: URLSessionTask,
         didCompleteWithError error: Error?
     ) {
+        defer { session.finishTasksAndInvalidate() }
         if let error = error {
             let nsError = error as NSError
             if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
-                onComplete(.failure(.cancelled))
+                fireComplete(.failure(.cancelled))
             } else if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut {
-                onComplete(.failure(.timeout))
+                fireComplete(.failure(.timeout))
             } else {
-                onComplete(.failure(.networkError(error)))
+                fireComplete(.failure(.networkError(error)))
             }
+        } else {
+            // Normal task completion; the [DONE] marker should have already fired
+            // onComplete via didReceive(_:data:).  If the server closed the stream
+            // without [DONE] (non-standard), fire it here as a fallback.
+            fireComplete(.success(fullResponse))
         }
     }
 }

--- a/HouseCall/Features/Conversation/Views/ChatView.swift
+++ b/HouseCall/Features/Conversation/Views/ChatView.swift
@@ -26,18 +26,16 @@ struct ChatView: View {
                     LazyVStack(spacing: 8) {
                         // Messages
                         ForEach(viewModel.messages, id: \.id) { message in
+                            let isThisMessageStreaming = viewModel.isStreaming && message.id == viewModel.streamingMessageId
                             MessageBubbleView(
                                 message: message,
                                 messageRepository: viewModel.messageRepository,
-                                isStreaming: viewModel.isStreaming && message.id == viewModel.streamingMessageId
+                                isStreaming: isThisMessageStreaming,
+                                // Pass live text only for the in-progress assistant message
+                                // so tokens appear incrementally without a second bubble.
+                                streamingText: isThisMessageStreaming ? viewModel.streamingText : nil
                             )
                             .id(message.id)
-                        }
-
-                        // Streaming message (if not yet in messages array)
-                        if viewModel.isStreaming && !viewModel.streamingText.isEmpty {
-                            streamingBubbleView
-                                .id("streaming")
                         }
 
                         // Physician-approved recommendation cards delivered via
@@ -95,39 +93,6 @@ struct ChatView: View {
     }
 
     // MARK: - Subviews
-
-    private var streamingBubbleView: some View {
-        HStack(alignment: .bottom, spacing: 8) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(viewModel.streamingText)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(Color(.systemGray5))
-                    .foregroundColor(.primary)
-                    .cornerRadius(20)
-
-                // Typing indicator
-                HStack(spacing: 4) {
-                    ForEach(0..<3) { index in
-                        Circle()
-                            .fill(Color.gray)
-                            .frame(width: 6, height: 6)
-                            .animation(
-                                Animation
-                                    .easeInOut(duration: 0.6)
-                                    .repeatForever(autoreverses: true)
-                                    .delay(Double(index) * 0.2),
-                                value: index
-                            )
-                    }
-                }
-                .padding(.horizontal, 8)
-            }
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 4)
-    }
 
     private var inputArea: some View {
         HStack(spacing: 12) {
@@ -251,8 +216,9 @@ struct ChatView: View {
     private func scrollToBottom(proxy: ScrollViewProxy) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             withAnimation {
-                if viewModel.isStreaming {
-                    proxy.scrollTo("streaming", anchor: .bottom)
+                if viewModel.isStreaming, let streamingId = viewModel.streamingMessageId {
+                    // Scroll to the in-list streaming bubble (no separate "streaming" anchor needed)
+                    proxy.scrollTo(streamingId, anchor: .bottom)
                 } else if let lastMessage = viewModel.messages.last {
                     proxy.scrollTo(lastMessage.id, anchor: .bottom)
                 }

--- a/HouseCall/Features/Conversation/Views/MessageBubbleView.swift
+++ b/HouseCall/Features/Conversation/Views/MessageBubbleView.swift
@@ -14,9 +14,22 @@ struct MessageBubbleView: View {
     let message: Message
     let messageRepository: MessageRepositoryProtocol
     let isStreaming: Bool
+    /// Live text passed in from the ViewModel while this message is being streamed.
+    /// When non-nil and non-empty this is shown instead of the (not-yet-persisted)
+    /// decrypted encrypted content, so tokens appear in real time.
+    var streamingText: String? = nil
 
     @State private var decryptedContent: String = ""
     @State private var showTimestamp: Bool = false
+
+    /// Returns the text to display: live streamingText during streaming, otherwise
+    /// the persisted-and-decrypted content.
+    private var displayContent: String {
+        if let live = streamingText, !live.isEmpty {
+            return live
+        }
+        return decryptedContent
+    }
 
     var body: some View {
         // System messages are displayed differently (centered)
@@ -32,7 +45,7 @@ struct MessageBubbleView: View {
     private var systemMessageView: some View {
         HStack {
             Spacer()
-            Text(decryptedContent)
+            Text(displayContent)
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .padding(.horizontal, 12)
@@ -56,7 +69,7 @@ struct MessageBubbleView: View {
 
             VStack(alignment: isUserMessage ? .trailing : .leading, spacing: 4) {
                 // Message bubble
-                Text(decryptedContent)
+                Text(displayContent)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 10)
                     .background(bubbleColor)

--- a/openspec/changes/update-patient-chat-ux/tasks.md
+++ b/openspec/changes/update-patient-chat-ux/tasks.md
@@ -14,7 +14,7 @@
 
 ## 3. Fix streaming
 
-- [ ] 3.1 Trace the SSE → `streamingText`/`streamingMessageId` publish path in `AIConversationService` and confirm chunks are published on the main actor as they arrive.
+- [x] 3.1 Trace the SSE → `streamingText`/`streamingMessageId` publish path in `AIConversationService` and confirm chunks are published on the main actor as they arrive.
 - [ ] 3.2 Ensure `ChatView` updates the bubble incrementally (streaming bubble or in-place message update) so tokens appear in real time.
 - [ ] 3.3 Verify auto-scroll keeps the latest streamed text visible and the input stays disabled until the stream completes.
 

--- a/openspec/changes/update-patient-chat-ux/tasks.md
+++ b/openspec/changes/update-patient-chat-ux/tasks.md
@@ -15,7 +15,7 @@
 ## 3. Fix streaming
 
 - [x] 3.1 Trace the SSE → `streamingText`/`streamingMessageId` publish path in `AIConversationService` and confirm chunks are published on the main actor as they arrive.
-- [ ] 3.2 Ensure `ChatView` updates the bubble incrementally (streaming bubble or in-place message update) so tokens appear in real time.
+- [x] 3.2 Ensure `ChatView` updates the bubble incrementally (streaming bubble or in-place message update) so tokens appear in real time.
 - [ ] 3.3 Verify auto-scroll keeps the latest streamed text visible and the input stays disabled until the stream completes.
 
 ## 4. Markdown rendering

--- a/openspec/changes/update-patient-chat-ux/tasks.md
+++ b/openspec/changes/update-patient-chat-ux/tasks.md
@@ -16,7 +16,7 @@
 
 - [x] 3.1 Trace the SSE → `streamingText`/`streamingMessageId` publish path in `AIConversationService` and confirm chunks are published on the main actor as they arrive.
 - [x] 3.2 Ensure `ChatView` updates the bubble incrementally (streaming bubble or in-place message update) so tokens appear in real time.
-- [ ] 3.3 Verify auto-scroll keeps the latest streamed text visible and the input stays disabled until the stream completes.
+- [x] 3.3 Verify auto-scroll keeps the latest streamed text visible and the input stays disabled until the stream completes.
 
 ## 4. Markdown rendering
 


### PR DESCRIPTION
## Phase 3 — Fix streaming

Third phase of OpenSpec change `update-patient-chat-ux`. Fixes the original "chat does not stream the response" complaint — and a deeper latent bug it exposed.

### Root cause found
`OpenAIProvider.performRequest` and `ClaudeProvider.performRequest` used a non-streaming `URLSession.dataTask(completionHandler:)` that **never called `onChunk` and returned an empty string** — the `StreamingURLSessionDelegate`/`ClaudeStreamingDelegate` SSE classes were dead code. So assistant replies never streamed *and* persisted empty. The `AIConversationService` main-actor publish path was already correct.

### Tasks completed
- [x] 3.1 Traced the SSE → `streamingText`/`streamingMessageId` publish path; wired up real delegate-based `URLSession` streaming in OpenAI + Claude providers (per-packet `SSEParser`, incremental `onChunk`, HTTP-status error handling, session invalidation to break the delegate retain cycle). Service-side publish confirmed correct (main-actor per chunk).
- [x] 3.2 Removed the duplicate render (blank placeholder bubble + separate `streamingBubbleView`); the single in-list `MessageBubbleView` now shows `streamingText` live, falling back to decrypted persisted content on completion. `scrollToBottom` targets `streamingMessageId`.
- [x] 3.3 Verified (code inspection) auto-scroll pins to the latest streamed token and input/Send stay disabled (+ "AI is responding…") until completion. No code change needed beyond 3.1/3.2.

Also included: `fix(llm): route createActiveProvider through getActiveProvider()` (HouseCall-ump / #104) — the deferred Phase 2 follow-up, closing the build-config-wins latent trap.

### Beads closed
- HouseCall-o09 (#91) — 3.1
- HouseCall-tt5 (#90) — 3.2
- HouseCall-5iw (#89) — 3.3
- HouseCall-ump (#104) — createActiveProvider follow-up

### Validation
- Debug build green. Provider/SSE/service suites (`OpenAIProviderTests`, `ClaudeProviderTests`, `CustomProviderTests`, `SSEParserTests`, `AIConversationServiceTests`, `LLMProviderConfigManagerTests`) all pass. Remaining suite failures are pre-existing flaky (CloudSync/Integration/PasswordHasher) that also fail on `main` and pass in isolation.
- ⚠️ Runtime token-by-token streaming could not be exercised end-to-end here (no live API key); verified by provider unit tests (MockURLProtocol) + code inspection. Live UI-test coverage lands in Phase 5 (task 5.4).

### Deferred (non-blocking reviewer notes)
- 3.1: dead class-level `sseParser` property + ineffective `sseParser.reset()` in `cancelStreaming()`; `streamingSession` left as a stale (non-leaking) reference after invalidation; 429 `Retry-After` header hardcoded to 60s.
- 3.2: brief empty bubble before the first chunk arrives (pre-existing; typing indicator covers it); a couple of code-clarity comment suggestions in `handleStreamComplete`.

### Out of scope
Markdown rendering (Phase 4), test/UI-test updates (Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)