### PR TITLE
update-patient-chat-ux: Phase 4 — Markdown rendering

### DIFF
--- a/HouseCall/Core/Services/AIConversationService.swift
+++ b/HouseCall/Core/Services/AIConversationService.swift
@@ -450,8 +450,14 @@ class AIConversationService: ObservableObject {
         conversationId: UUID,
         providerType: LLMProviderType
     ) async {
+        // INVARIANT: keep isStreaming = false, streamingMessageId = nil, and
+        // messages[index] = updatedMessage free of any `await` between them so
+        // SwiftUI coalesces all three into a single render pass and avoids a
+        // blank-flash where the streaming overlay disappears before the final
+        // message text appears.
         isStreaming = false
         streamingMessageId = nil
+        streamingText = ""
 
         switch result {
         case .success(let fullText):
@@ -542,8 +548,6 @@ class AIConversationService: ObservableObject {
                 )
             }
         }
-
-        streamingText = ""
     }
 
     /// Builds chat context from conversation messages

--- a/HouseCall/Core/Services/LLMProviders/ClaudeProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/ClaudeProvider.swift
@@ -156,8 +156,7 @@ class ClaudeProvider: LLMProvider {
         let streamingDelegate = ClaudeStreamingDelegate(
             sseParser: requestParser,
             onChunk: onChunk,
-            onComplete: onComplete,
-            onSessionInvalidated: { [weak self] in self?.streamingSession = nil }
+            onComplete: onComplete
         )
         // URLSession.shared does not support per-request delegates; a dedicated session
         // is required so urlSession(_:dataTask:didReceive:) fires incrementally for
@@ -254,19 +253,15 @@ class ClaudeStreamingDelegate: NSObject, URLSessionDataDelegate {
     private var fullResponse = ""
     /// Guards against double-firing onComplete (e.g. message_stop arrives then didCompleteWithError fires).
     private var hasCompleted = false
-    /// Called when the URLSession becomes invalid so the owning provider can clear its reference.
-    private let onSessionInvalidated: (() -> Void)?
 
     init(
         sseParser: SSEParser,
         onChunk: @escaping (String) -> Void,
-        onComplete: @escaping (Result<String, LLMError>) -> Void,
-        onSessionInvalidated: (() -> Void)? = nil
+        onComplete: @escaping (Result<String, LLMError>) -> Void
     ) {
         self.sseParser = sseParser
         self.onChunk = onChunk
         self.onComplete = onComplete
-        self.onSessionInvalidated = onSessionInvalidated
     }
 
     /// Fires onComplete exactly once.
@@ -305,10 +300,6 @@ class ClaudeStreamingDelegate: NSObject, URLSessionDataDelegate {
             return
         }
         completionHandler(.allow)
-    }
-
-    func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
-        onSessionInvalidated?()
     }
 
     func urlSession(

--- a/HouseCall/Core/Services/LLMProviders/ClaudeProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/ClaudeProvider.swift
@@ -21,7 +21,6 @@ class ClaudeProvider: LLMProvider {
     /// Dedicated session created per streaming request (URLSession.shared does not
     /// support per-request delegates).  Stored so `cancelStreaming()` can invalidate it.
     private var streamingSession: URLSession?
-    private let sseParser = SSEParser()
 
     /// Configuration for Claude requests
     private var config: ClaudeConfig
@@ -83,7 +82,6 @@ class ClaudeProvider: LLMProvider {
         currentTask = nil
         streamingSession?.invalidateAndCancel()
         streamingSession = nil
-        sseParser.reset()
     }
 
     // MARK: - Private Methods
@@ -151,14 +149,15 @@ class ClaudeProvider: LLMProvider {
         let requestBody = buildRequestBody(messages: messages)
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
-        // Create a fresh SSEParser per request so that cancelStreaming's sseParser.reset()
-        // cannot race with background delegate callbacks on the URLSession queue.
+        // Create a fresh SSEParser per request to isolate parser state across
+        // concurrent or back-to-back requests.
         let requestParser = SSEParser()
 
         let streamingDelegate = ClaudeStreamingDelegate(
             sseParser: requestParser,
             onChunk: onChunk,
-            onComplete: onComplete
+            onComplete: onComplete,
+            onSessionInvalidated: { [weak self] in self?.streamingSession = nil }
         )
         // URLSession.shared does not support per-request delegates; a dedicated session
         // is required so urlSession(_:dataTask:didReceive:) fires incrementally for
@@ -255,15 +254,19 @@ class ClaudeStreamingDelegate: NSObject, URLSessionDataDelegate {
     private var fullResponse = ""
     /// Guards against double-firing onComplete (e.g. message_stop arrives then didCompleteWithError fires).
     private var hasCompleted = false
+    /// Called when the URLSession becomes invalid so the owning provider can clear its reference.
+    private let onSessionInvalidated: (() -> Void)?
 
     init(
         sseParser: SSEParser,
         onChunk: @escaping (String) -> Void,
-        onComplete: @escaping (Result<String, LLMError>) -> Void
+        onComplete: @escaping (Result<String, LLMError>) -> Void,
+        onSessionInvalidated: (() -> Void)? = nil
     ) {
         self.sseParser = sseParser
         self.onChunk = onChunk
         self.onComplete = onComplete
+        self.onSessionInvalidated = onSessionInvalidated
     }
 
     /// Fires onComplete exactly once.
@@ -289,7 +292,11 @@ class ClaudeStreamingDelegate: NSObject, URLSessionDataDelegate {
             let llmError: LLMError
             switch statusCode {
             case 401, 403: llmError = .authenticationFailed
-            case 429: llmError = .rateLimit(retryAfterSeconds: 60)
+            case 429:
+                // Extract Retry-After header (integer seconds per HTTP spec); fall back to 60.
+                let retryAfter = httpResponse.value(forHTTPHeaderField: "Retry-After")
+                    .flatMap { Int($0) }
+                llmError = .rateLimit(retryAfterSeconds: retryAfter ?? 60)
             case 500...599: llmError = .providerError(statusCode: statusCode, message: "Server error")
             default: llmError = .providerError(statusCode: statusCode, message: "HTTP \(statusCode)")
             }
@@ -298,6 +305,10 @@ class ClaudeStreamingDelegate: NSObject, URLSessionDataDelegate {
             return
         }
         completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
+        onSessionInvalidated?()
     }
 
     func urlSession(

--- a/HouseCall/Core/Services/LLMProviders/OpenAIProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/OpenAIProvider.swift
@@ -150,8 +150,7 @@ class OpenAIProvider: LLMProvider {
         let streamingDelegate = StreamingURLSessionDelegate(
             sseParser: requestParser,
             onChunk: onChunk,
-            onComplete: onComplete,
-            onSessionInvalidated: { [weak self] in self?.streamingSession = nil }
+            onComplete: onComplete
         )
         // URLSession.shared does not support per-request delegates; a dedicated session
         // is required so urlSession(_:dataTask:didReceive:) fires incrementally for
@@ -239,19 +238,15 @@ class StreamingURLSessionDelegate: NSObject, URLSessionDataDelegate {
     private var fullResponse = ""
     /// Guards against double-firing onComplete (e.g. [DONE] arrives then didCompleteWithError fires).
     private var hasCompleted = false
-    /// Called when the URLSession becomes invalid so the owning provider can clear its reference.
-    private let onSessionInvalidated: (() -> Void)?
 
     init(
         sseParser: SSEParser,
         onChunk: @escaping (String) -> Void,
-        onComplete: @escaping (Result<String, LLMError>) -> Void,
-        onSessionInvalidated: (() -> Void)? = nil
+        onComplete: @escaping (Result<String, LLMError>) -> Void
     ) {
         self.sseParser = sseParser
         self.onChunk = onChunk
         self.onComplete = onComplete
-        self.onSessionInvalidated = onSessionInvalidated
     }
 
     /// Fires onComplete exactly once.
@@ -290,10 +285,6 @@ class StreamingURLSessionDelegate: NSObject, URLSessionDataDelegate {
             return
         }
         completionHandler(.allow)
-    }
-
-    func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
-        onSessionInvalidated?()
     }
 
     func urlSession(

--- a/HouseCall/Core/Services/LLMProviders/OpenAIProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/OpenAIProvider.swift
@@ -21,7 +21,6 @@ class OpenAIProvider: LLMProvider {
     /// Dedicated session created per streaming request (URLSession.shared does not
     /// support per-request delegates).  Stored so `cancelStreaming()` can invalidate it.
     private var streamingSession: URLSession?
-    private let sseParser = SSEParser()
 
     /// Configuration for OpenAI requests
     private var config: OpenAIConfig
@@ -80,7 +79,6 @@ class OpenAIProvider: LLMProvider {
         currentTask = nil
         streamingSession?.invalidateAndCancel()
         streamingSession = nil
-        sseParser.reset()
     }
 
     // MARK: - Private Methods
@@ -145,14 +143,15 @@ class OpenAIProvider: LLMProvider {
         let requestBody = buildRequestBody(messages: messages)
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
-        // Create a fresh SSEParser per request so that cancelStreaming's sseParser.reset()
-        // cannot race with background delegate callbacks on the URLSession queue.
+        // Create a fresh SSEParser per request to isolate parser state across
+        // concurrent or back-to-back requests.
         let requestParser = SSEParser()
 
         let streamingDelegate = StreamingURLSessionDelegate(
             sseParser: requestParser,
             onChunk: onChunk,
-            onComplete: onComplete
+            onComplete: onComplete,
+            onSessionInvalidated: { [weak self] in self?.streamingSession = nil }
         )
         // URLSession.shared does not support per-request delegates; a dedicated session
         // is required so urlSession(_:dataTask:didReceive:) fires incrementally for
@@ -240,15 +239,19 @@ class StreamingURLSessionDelegate: NSObject, URLSessionDataDelegate {
     private var fullResponse = ""
     /// Guards against double-firing onComplete (e.g. [DONE] arrives then didCompleteWithError fires).
     private var hasCompleted = false
+    /// Called when the URLSession becomes invalid so the owning provider can clear its reference.
+    private let onSessionInvalidated: (() -> Void)?
 
     init(
         sseParser: SSEParser,
         onChunk: @escaping (String) -> Void,
-        onComplete: @escaping (Result<String, LLMError>) -> Void
+        onComplete: @escaping (Result<String, LLMError>) -> Void,
+        onSessionInvalidated: (() -> Void)? = nil
     ) {
         self.sseParser = sseParser
         self.onChunk = onChunk
         self.onComplete = onComplete
+        self.onSessionInvalidated = onSessionInvalidated
     }
 
     /// Fires onComplete exactly once.
@@ -274,7 +277,11 @@ class StreamingURLSessionDelegate: NSObject, URLSessionDataDelegate {
             let llmError: LLMError
             switch statusCode {
             case 401, 403: llmError = .authenticationFailed
-            case 429: llmError = .rateLimit(retryAfterSeconds: 60)
+            case 429:
+                // Extract Retry-After header (integer seconds per HTTP spec); fall back to 60.
+                let retryAfter = httpResponse.value(forHTTPHeaderField: "Retry-After")
+                    .flatMap { Int($0) }
+                llmError = .rateLimit(retryAfterSeconds: retryAfter ?? 60)
             case 500...599: llmError = .providerError(statusCode: statusCode, message: "Server error")
             default: llmError = .providerError(statusCode: statusCode, message: "HTTP \(statusCode)")
             }
@@ -283,6 +290,10 @@ class StreamingURLSessionDelegate: NSObject, URLSessionDataDelegate {
             return
         }
         completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
+        onSessionInvalidated?()
     }
 
     func urlSession(

--- a/HouseCall/Features/Conversation/Views/MarkdownText.swift
+++ b/HouseCall/Features/Conversation/Views/MarkdownText.swift
@@ -206,6 +206,14 @@ struct MarkdownText: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        // VoiceOver fix: without this, each block (heading, paragraph, list
+        // item, code block) is a separate accessibility element and VoiceOver
+        // reads them one by one, breaking the flow of the message.
+        // .ignore suppresses child elements; the single label below provides
+        // a clean plain-text reading of the full assistant message with all
+        // Markdown markers stripped (no "pound pound", "star star", backticks).
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Self.plainText(from: blocks))
     }
 
     // MARK: Block Rendering
@@ -286,6 +294,65 @@ struct MarkdownText: View {
         case 3:  return .headline
         default: return .subheadline
         }
+    }
+
+    // MARK: - Accessibility
+
+    /// Converts already-parsed Markdown blocks into a single plain-text
+    /// string for VoiceOver. All block-level markers (#, -, *, 1., fences)
+    /// and inline markers (**bold**, *italic*, `code`, [link](url)) are
+    /// stripped so the screen reader speaks clean prose — not markup symbols.
+    ///
+    /// PHI note: the returned string contains message content. That is
+    /// correct — VoiceOver is on-device display, equivalent to reading the
+    /// visible text. Nothing here is logged, printed, or sent to any service.
+    private static func plainText(from blocks: [MarkdownBlock]) -> String {
+        blocks
+            .compactMap { block -> String? in
+                switch block {
+                case .heading(_, let text):
+                    return stripInlineMarkdown(text)
+                case .paragraph(let text):
+                    return stripInlineMarkdown(text)
+                case .unorderedItem(_, let text):
+                    return stripInlineMarkdown(text)
+                case .orderedItem(_, _, let text):
+                    return stripInlineMarkdown(text)
+                case .codeBlock(_, let lines):
+                    // Code content is already literal text — no inline markers.
+                    let joined = lines.joined(separator: " ")
+                        .trimmingCharacters(in: .whitespaces)
+                    return joined.isEmpty ? nil : joined
+                }
+            }
+            .filter { !$0.isEmpty }
+            .joined(separator: ". ")
+    }
+
+    /// Strips common inline Markdown markers from `text`.
+    /// Order matters: remove `**`/`__` (bold) before `*`/`_` (italic) so that
+    /// bold markers do not leave stray single-character residue.
+    ///   **bold**    → bold
+    ///   *italic*    → italic
+    ///   `code`      → code
+    ///   [text](url) → text
+    private static func stripInlineMarkdown(_ text: String) -> String {
+        var s = text
+        // Bold markers first (two-char sequences).
+        s = s.replacingOccurrences(of: "**", with: "")
+        s = s.replacingOccurrences(of: "__", with: "")
+        // Italic markers (remaining single * / _ after bold pass).
+        s = s.replacingOccurrences(of: "*", with: "")
+        s = s.replacingOccurrences(of: "_", with: "")
+        // Inline code backticks.
+        s = s.replacingOccurrences(of: "`", with: "")
+        // Links: [link text](https://example.com) → link text.
+        if let regex = try? NSRegularExpression(pattern: #"\[([^\]]*)\]\([^)]*\)"#) {
+            let range = NSRange(s.startIndex..., in: s)
+            s = regex.stringByReplacingMatches(in: s, range: range,
+                                               withTemplate: "$1")
+        }
+        return s.trimmingCharacters(in: .whitespaces)
     }
 }
 

--- a/HouseCall/Features/Conversation/Views/MarkdownText.swift
+++ b/HouseCall/Features/Conversation/Views/MarkdownText.swift
@@ -1,0 +1,320 @@
+//
+//  MarkdownText.swift
+//  HouseCall
+//
+//  Lightweight in-house Markdown renderer for assistant chat bubbles.
+//  Handles ATX headings, paragraphs, unordered/ordered lists, fenced code
+//  blocks, and inline Markdown (bold, italic, inline code, links) via
+//  AttributedString. No third-party dependencies.
+//
+//  Use for ASSISTANT messages only — user messages stay plain Text.
+//
+
+import SwiftUI
+
+// MARK: - Block Model
+
+/// A parsed Markdown block element.
+private enum MarkdownBlock {
+    case heading(level: Int, text: String)
+    case paragraph(text: String)
+    case unorderedItem(indent: Int, text: String)
+    case orderedItem(number: Int, indent: Int, text: String)
+    case codeBlock(language: String?, lines: [String])
+}
+
+// MARK: - Parser
+
+/// Converts a raw Markdown string into an ordered list of block elements.
+///
+/// Safe with partial/unterminated Markdown that arrives during streaming:
+/// an unclosed fence or incomplete inline span is treated as best-effort
+/// plain text rather than crashing or producing garbage output.
+private struct MarkdownParser {
+
+    static func parse(_ content: String) -> [MarkdownBlock] {
+        var blocks: [MarkdownBlock] = []
+        let lines = content.components(separatedBy: "\n")
+        var i = 0
+        var pendingLines: [String] = []
+
+        // Accumulate pending paragraph lines into a block and reset.
+        func flushParagraph() {
+            guard !pendingLines.isEmpty else { return }
+            // Join with space: a single line-break in Markdown source is a soft
+            // wrap, not a paragraph break.
+            let text = pendingLines.joined(separator: " ")
+                .trimmingCharacters(in: .whitespaces)
+            if !text.isEmpty {
+                blocks.append(.paragraph(text: text))
+            }
+            pendingLines = []
+        }
+
+        while i < lines.count {
+            let line = lines[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // ── Fenced code block ──────────────────────────────────────────
+            if trimmed.hasPrefix("```") {
+                flushParagraph()
+                // Optional language identifier on the opening fence line.
+                let hint = String(trimmed.dropFirst(3))
+                    .trimmingCharacters(in: .whitespaces)
+                let language: String? = hint.isEmpty ? nil : hint
+                i += 1
+                var codeLines: [String] = []
+                while i < lines.count {
+                    let codeTrimmed = lines[i].trimmingCharacters(in: .whitespaces)
+                    // A closing fence is a line of only backticks (≥ 3) with
+                    // no language identifier.
+                    if codeTrimmed.hasPrefix("```") &&
+                       codeTrimmed.dropFirst(3)
+                           .trimmingCharacters(in: .whitespaces).isEmpty {
+                        i += 1
+                        break
+                    }
+                    codeLines.append(lines[i])
+                    i += 1
+                }
+                // Append even if the fence was never closed (streaming safety).
+                blocks.append(.codeBlock(language: language, lines: codeLines))
+                continue
+            }
+
+            // ── ATX heading ───────────────────────────────────────────────
+            if let headingBlock = parseHeading(trimmed) {
+                flushParagraph()
+                blocks.append(headingBlock)
+                i += 1
+                continue
+            }
+
+            // ── Unordered list item ───────────────────────────────────────
+            if let ulBlock = parseUnorderedItem(line) {
+                flushParagraph()
+                blocks.append(ulBlock)
+                i += 1
+                continue
+            }
+
+            // ── Ordered list item ─────────────────────────────────────────
+            if let olBlock = parseOrderedItem(line) {
+                flushParagraph()
+                blocks.append(olBlock)
+                i += 1
+                continue
+            }
+
+            // ── Blank line: paragraph break ───────────────────────────────
+            if trimmed.isEmpty {
+                flushParagraph()
+                i += 1
+                continue
+            }
+
+            // ── Paragraph continuation line ───────────────────────────────
+            pendingLines.append(trimmed)
+            i += 1
+        }
+
+        flushParagraph()
+        return blocks
+    }
+
+    // MARK: Heading
+
+    private static func parseHeading(_ trimmedLine: String) -> MarkdownBlock? {
+        var level = 0
+        for ch in trimmedLine {
+            guard ch == "#" else { break }
+            level += 1
+        }
+        guard level >= 1, level <= 6 else { return nil }
+        let afterHashes = trimmedLine.dropFirst(level)
+        // There must be a space after the hashes (or the heading text is empty).
+        guard afterHashes.isEmpty || afterHashes.first == " " else { return nil }
+        let text = afterHashes.trimmingCharacters(in: .whitespaces)
+        return .heading(level: level, text: text)
+    }
+
+    // MARK: Unordered list item
+
+    private static func parseUnorderedItem(_ line: String) -> MarkdownBlock? {
+        var idx = line.startIndex
+        var spaces = 0
+        while idx < line.endIndex, line[idx] == " " {
+            spaces += 1
+            idx = line.index(after: idx)
+        }
+        let rest = line[idx...]
+        guard !rest.isEmpty else { return nil }
+        let marker: String
+        if rest.hasPrefix("- ")      { marker = "- " }
+        else if rest.hasPrefix("* ") { marker = "* " }
+        else if rest.hasPrefix("+ ") { marker = "+ " }
+        else { return nil }
+        let text = String(rest.dropFirst(marker.count))
+        return .unorderedItem(indent: spaces / 2, text: text)
+    }
+
+    // MARK: Ordered list item
+
+    private static func parseOrderedItem(_ line: String) -> MarkdownBlock? {
+        var idx = line.startIndex
+        var spaces = 0
+        while idx < line.endIndex, line[idx] == " " {
+            spaces += 1
+            idx = line.index(after: idx)
+        }
+        let rest = line[idx...]
+        // Consume leading digits.
+        var digits = ""
+        var dIdx = rest.startIndex
+        while dIdx < rest.endIndex, rest[dIdx].isNumber {
+            digits.append(rest[dIdx])
+            dIdx = rest.index(after: dIdx)
+        }
+        guard !digits.isEmpty, dIdx < rest.endIndex else { return nil }
+        guard rest[dIdx...].hasPrefix(". ") else { return nil }
+        let number = Int(digits) ?? 1
+        let text = String(rest[dIdx...].dropFirst(2))
+        return .orderedItem(number: number, indent: spaces / 2, text: text)
+    }
+}
+
+// MARK: - MarkdownText View
+
+/// Renders a raw Markdown `String` as formatted SwiftUI content.
+///
+/// Block-level elements (headings, lists, code blocks, paragraphs) are
+/// composed as a vertical stack. Inline elements (bold, italic, inline code,
+/// links) within each block are rendered via `AttributedString(markdown:)`,
+/// which falls back to plain text if parsing throws.
+///
+/// Designed for use with ASSISTANT messages only. Partial/unterminated
+/// Markdown (as arrives during SSE streaming) degrades gracefully — never
+/// crashes, never exposes raw Markdown symbols beyond what the LLM wrote.
+struct MarkdownText: View {
+    let content: String
+
+    var body: some View {
+        let blocks = MarkdownParser.parse(content)
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                blockView(for: block)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Block Rendering
+
+    @ViewBuilder
+    private func blockView(for block: MarkdownBlock) -> some View {
+        switch block {
+
+        case .heading(let level, let text):
+            inlineText(text)
+                .font(headingFont(for: level))
+                .fontWeight(.bold)
+                .padding(.top, level <= 2 ? 4 : 2)
+                .padding(.bottom, 2)
+
+        case .paragraph(let text):
+            inlineText(text)
+                .font(.body)
+
+        case .unorderedItem(let indent, let text):
+            HStack(alignment: .top, spacing: 6) {
+                Text("•")
+                    .font(.body)
+                inlineText(text)
+                    .font(.body)
+                Spacer(minLength: 0)
+            }
+            .padding(.leading, CGFloat(max(indent, 0)) * 16)
+
+        case .orderedItem(let number, let indent, let text):
+            HStack(alignment: .top, spacing: 6) {
+                Text("\(number).")
+                    .font(.body)
+                    .monospacedDigit()
+                inlineText(text)
+                    .font(.body)
+                Spacer(minLength: 0)
+            }
+            .padding(.leading, CGFloat(max(indent, 0)) * 16)
+
+        case .codeBlock(_, let lines):
+            // Code blocks are rendered monospaced in a subtle background.
+            // No Markdown parsing inside — content is treated as literal text.
+            Text(lines.joined(separator: "\n"))
+                .font(.system(.caption, design: .monospaced))
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.systemGray4))
+                .cornerRadius(6)
+        }
+    }
+
+    // MARK: Inline Rendering
+
+    /// Renders `text` with inline Markdown via `AttributedString`.
+    /// If `AttributedString(markdown:)` throws (e.g. malformed or partial
+    /// input during streaming), falls back to plain `Text` — never crashes.
+    @ViewBuilder
+    private func inlineText(_ text: String) -> some View {
+        if let attributed = try? AttributedString(
+            markdown: text,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .inlineOnlyPreservingWhitespace
+            )
+        ) {
+            Text(attributed)
+        } else {
+            Text(text)
+        }
+    }
+
+    // MARK: Fonts
+
+    private func headingFont(for level: Int) -> Font {
+        switch level {
+        case 1:  return .title2
+        case 2:  return .title3
+        case 3:  return .headline
+        default: return .subheadline
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Markdown rendering") {
+    ScrollView {
+        MarkdownText(content: """
+        ## Symptom Summary
+
+        Based on your description, here are the key points:
+
+        - **Fever** above 38°C for more than two days
+        - *Fatigue* and general malaise
+        - Mild sore throat
+
+        ### What to Watch For
+
+        1. Temperature rising above **39.5°C**
+        2. Difficulty breathing
+        3. Rash or skin changes
+
+        ```
+        Normal temp range: 36.1 – 37.2°C
+        Fever threshold:   ≥ 38.0°C
+        ```
+
+        Please consult a healthcare provider if symptoms worsen.
+        """)
+        .padding()
+    }
+}

--- a/HouseCall/Features/Conversation/Views/MessageBubbleView.swift
+++ b/HouseCall/Features/Conversation/Views/MessageBubbleView.swift
@@ -21,6 +21,8 @@ struct MessageBubbleView: View {
 
     @State private var decryptedContent: String = ""
     @State private var showTimestamp: Bool = false
+    /// Drives the repeating opacity animation for the 3-dot typing indicator.
+    @State private var showDots: Bool = false
 
     /// Returns the text to display: live streamingText during streaming, otherwise
     /// the persisted-and-decrypted content.
@@ -68,14 +70,22 @@ struct MessageBubbleView: View {
             }
 
             VStack(alignment: isUserMessage ? .trailing : .leading, spacing: 4) {
-                // Message bubble
-                Text(displayContent)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(bubbleColor)
-                    .foregroundColor(textColor)
-                    .cornerRadius(20)
-                    .textSelection(.enabled)
+                // Message bubble — when the assistant bubble is streaming but no
+                // token has arrived yet, show the typing indicator inside the
+                // bubble so there is never an empty/zero-height gray box.
+                Group {
+                    if isStreaming && !isUserMessage && displayContent.isEmpty {
+                        inlineDotIndicator
+                    } else {
+                        Text(displayContent)
+                            .textSelection(.enabled)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(bubbleColor)
+                .foregroundColor(textColor)
+                .cornerRadius(20)
 
                 // Timestamp (shown on tap or long press)
                 if showTimestamp {
@@ -85,14 +95,21 @@ struct MessageBubbleView: View {
                         .padding(.horizontal, 8)
                 }
 
-                // Streaming indicator
-                if isStreaming && !isUserMessage {
+                // Below-bubble streaming dots — shown once tokens are arriving
+                // so the user knows the response is still in progress.
+                if isStreaming && !isUserMessage && !displayContent.isEmpty {
                     HStack(spacing: 4) {
                         ForEach(0..<3) { index in
                             Circle()
                                 .fill(Color.gray)
                                 .frame(width: 6, height: 6)
-                                .opacity(typingAnimation(index: index))
+                                .opacity(showDots ? 1.0 : 0.3)
+                                .animation(
+                                    .easeInOut(duration: 0.6)
+                                        .repeatForever(autoreverses: true)
+                                        .delay(Double(index) * 0.2),
+                                    value: showDots
+                                )
                         }
                     }
                     .padding(.horizontal, 8)
@@ -112,11 +129,41 @@ struct MessageBubbleView: View {
         .padding(.vertical, 4)
         .onAppear {
             decryptMessage()
+            // Start dot animation if this bubble is already streaming on appear.
+            if isStreaming && !isUserMessage {
+                showDots = true
+            }
         }
         .onChange(of: message.encryptedContent) {
             // Update when streaming adds new content
             decryptMessage()
         }
+        .onChange(of: isStreaming) {
+            // Start animation when the bubble transitions into streaming state.
+            if isStreaming && !isUserMessage {
+                showDots = true
+            }
+        }
+    }
+
+    /// Three animated dots rendered inside the assistant bubble before the
+    /// first SSE token arrives.
+    private var inlineDotIndicator: some View {
+        HStack(spacing: 6) {
+            ForEach(0..<3) { index in
+                Circle()
+                    .fill(Color.gray.opacity(0.7))
+                    .frame(width: 8, height: 8)
+                    .opacity(showDots ? 1.0 : 0.3)
+                    .animation(
+                        .easeInOut(duration: 0.6)
+                            .repeatForever(autoreverses: true)
+                            .delay(Double(index) * 0.2),
+                        value: showDots
+                    )
+            }
+        }
+        .onAppear { showDots = true }
     }
 
     // MARK: - Computed Properties
@@ -152,17 +199,6 @@ struct MessageBubbleView: View {
             decryptedContent = try messageRepository.decryptMessageContent(message)
         } catch {
             decryptedContent = "[Unable to decrypt message]"
-        }
-    }
-
-    private func typingAnimation(index: Int) -> Double {
-        let animation = Animation
-            .easeInOut(duration: 0.6)
-            .repeatForever(autoreverses: true)
-            .delay(Double(index) * 0.2)
-
-        return withAnimation(animation) {
-            0.3
         }
     }
 }

--- a/HouseCall/Features/Conversation/Views/MessageBubbleView.swift
+++ b/HouseCall/Features/Conversation/Views/MessageBubbleView.swift
@@ -76,8 +76,15 @@ struct MessageBubbleView: View {
                 Group {
                     if isStreaming && !isUserMessage && displayContent.isEmpty {
                         inlineDotIndicator
-                    } else {
+                    } else if isUserMessage {
+                        // User messages render as plain text — never interpret
+                        // patient input as markup.
                         Text(displayContent)
+                            .textSelection(.enabled)
+                    } else {
+                        // Assistant messages render as Markdown (headings, lists,
+                        // code blocks, bold/italic/links via AttributedString).
+                        MarkdownText(content: displayContent)
                             .textSelection(.enabled)
                     }
                 }

--- a/openspec/changes/update-patient-chat-ux/tasks.md
+++ b/openspec/changes/update-patient-chat-ux/tasks.md
@@ -20,7 +20,7 @@
 
 ## 4. Markdown rendering
 
-- [ ] 4.1 Render assistant message content as Markdown in `MessageBubbleView` (headings, bold/italic, lists, inline code/code blocks, links).
+- [x] 4.1 Render assistant message content as Markdown in `MessageBubbleView` (headings, bold/italic, lists, inline code/code blocks, links).
 - [ ] 4.2 Keep user messages as plaintext; ensure Markdown rendering does not break VoiceOver labels or PHI handling.
 
 ## 5. Tests

--- a/openspec/changes/update-patient-chat-ux/tasks.md
+++ b/openspec/changes/update-patient-chat-ux/tasks.md
@@ -21,7 +21,7 @@
 ## 4. Markdown rendering
 
 - [x] 4.1 Render assistant message content as Markdown in `MessageBubbleView` (headings, bold/italic, lists, inline code/code blocks, links).
-- [ ] 4.2 Keep user messages as plaintext; ensure Markdown rendering does not break VoiceOver labels or PHI handling.
+- [x] 4.2 Keep user messages as plaintext; ensure Markdown rendering does not break VoiceOver labels or PHI handling.
 
 ## 5. Tests
 


### PR DESCRIPTION
## Phase 4 — Markdown rendering

Fourth phase of OpenSpec change `update-patient-chat-ux`. Assistant messages now render as Markdown; user input stays plain. Also rolls in the deferred Phase 3 reviewer cleanups (per your request).

### Tasks completed
- [x] 4.1 Custom first-party `MarkdownText` renderer (NO third-party dependency) in `MessageBubbleView` — ATX headings, ordered/unordered lists, fenced code blocks, inline bold/italic/inline-code/links via `AttributedString(markdown:.inlineOnlyPreservingWhitespace)` with plain-text fallback. User + system messages stay plain `Text`.
- [x] 4.2 VoiceOver: assistant bubble reads as ONE combined accessibility element with markdown syntax stripped (clean prose, no `#`/`**`/backticks spoken). User messages confirmed plaintext. No PHI logged.

### Rolled-in Phase 3 deferred cleanups
- **HouseCall-md1 (#107)** — streaming provider polish: removed dead `sseParser` property + no-op reset; 429 now honors the `Retry-After` header (fallback 60); `handleStreamComplete` coalescing-invariant comment + `streamingText` relocation. **The session-invalidation callback I first added introduced a race (an old session could nil a newly-started one) — caught in review and removed; cancellation is handled synchronously in `cancelStreaming()`.**
- **HouseCall-adm (#106)** — streaming UX: inline animated typing-dot indicator INSIDE the assistant bubble during the pre-first-chunk window (no more empty gray box); fixed a previously-broken (static) typing animation.

### Beads closed
- HouseCall-bnq (#88) — 4.1
- HouseCall-coe (#87) — 4.2
- HouseCall-md1 (#107) — provider polish
- HouseCall-adm (#106) — streaming UX

### Decision
Markdown impl = **custom lightweight renderer, no SPM dependency** (your call) — keeps the HIPAA app all-first-party.

### Validation
- Debug build green every task. Full `HouseCallTests` ~433 pass; only failures are the documented pre-existing flaky tests (CloudSync/Integration/AIChatIntegration/PasswordHasher) that also fail on `main` and pass in isolation.
- Markdown/VoiceOver rendering verified by code review; unit tests for the renderer land in Phase 5 (task 5.3).

### Deferred (non-blocking reviewer notes)
- `MarkdownText`: no memoization of the parse (re-parses per render — fine for chat lengths); `ForEach(Array(enumerated()))` throwaway alloc; heading levels 4-6 visually identical (cosmetic); `NSRegularExpression` rebuilt per `stripInlineMarkdown` call (consider `static let`); `". "` block-join can yield ".." in VoiceOver (cosmetic); partial streamed link `[text](url` not stripped in the a11y label (streaming edge, no crash).
- `adm`: `showDots` never reset to false (non-issue — each stream is a new Message entity).

### Out of scope
Tests + UI-test updates (Phase 5 — incl. MarkdownText unit tests 5.3 and the stale `ProviderSettingsButton` UI test 5.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)