### PR TITLE
Security follow-ups: gate EncryptionManager test hooks + remove PHI-adjacent log

### DIFF
--- a/HouseCall/Core/Security/EncryptionManager.swift
+++ b/HouseCall/Core/Security/EncryptionManager.swift
@@ -82,7 +82,7 @@ class EncryptionManager {
     ///
     /// Behaviour:
     /// 1. Returns the in-memory cached key immediately (fastest path, also used
-    ///    when `_testInjectMasterKey` has been called in DEBUG builds).
+    ///    when `_testInjectMasterKey` has been called in `#if DEBUG` builds).
     /// 2. Retrieves an existing key from the Keychain.
     /// 3. Generates a fresh 256-bit key and persists it in the Keychain.
     ///    If the Keychain write fails the error is propagated — silently
@@ -248,6 +248,7 @@ class EncryptionManager {
 
     // MARK: - Test Support
 
+#if DEBUG
     /// Seeds a fixed master key directly into the in-memory cache without
     /// touching the Keychain.
     ///
@@ -274,4 +275,5 @@ class EncryptionManager {
     static func _testMakeInstance(keychainManager: KeychainManager) -> EncryptionManager {
         EncryptionManager(keychainManager: keychainManager)
     }
+#endif
 }

--- a/HouseCall/Features/Conversation/Views/ConversationListView.swift
+++ b/HouseCall/Features/Conversation/Views/ConversationListView.swift
@@ -311,7 +311,6 @@ class ConversationListViewModel: ObservableObject {
     private func handleError(_ error: Error, message: String) {
         errorMessage = message
         showError = true
-        print("ConversationListViewModel error: \(error.localizedDescription)")
     }
 }
 


### PR DESCRIPTION
## Security/hygiene follow-ups

Two standalone bug beads surfaced during the `update-patient-chat-ux` review cycle.

### HouseCall-2ui (#111) — gate EncryptionManager test hooks behind `#if DEBUG`
`EncryptionManager._testInjectMasterKey(_:)` and `_testMakeInstance(keychainManager:)` are test-only hooks that inject/replace the master encryption key, but shipped **un-gated in Release builds** — a HIPAA attack surface. Both are now wrapped in `#if DEBUG … #endif`.
- Confirmed every caller is in the test target (`EncryptionManagerTests`, `TestMasterKeyBootstrap`, `AIConversationServiceTests`) — all Debug — so `@testable import` still resolves them. No production caller.
- No other un-gated key-injection/Keychain-bypass hook remains on `EncryptionManager`.

### HouseCall-3v4 (#102) — remove PHI-adjacent `print()`
`ConversationListView.swift` logged `print("...: \(error.localizedDescription)")`, leaking Core Data error strings to stdout. Removed. Error handling is unchanged (`handleError` still surfaces a generic message to the user); no replacement stdout/log of the error description.

### Validation
- App build + `build-for-testing` succeed. `EncryptionManagerTests` (16) + `AIConversationServiceTests` pass — DEBUG gating did not break test-target compilation. Full suite: only pre-existing flaky tests fail (also fail on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)