### PR TITLE
feat(llm): local Ollama support — custom provider via build config + ATS

### DIFF
--- a/HouseCall/Config/Base.xcconfig
+++ b/HouseCall/Config/Base.xcconfig
@@ -11,12 +11,23 @@
 // The '?' in #include? makes the include optional: the build succeeds even when
 // Secrets.xcconfig is absent (fresh clone, CI environment without the file).
 
+// xcconfig does not allow // in values (it starts a comment).
+// SLASH = / lets you embed slashes when defining URL-valued settings, e.g.:
+//   LLM_CUSTOM_BASE_URL = http:$(SLASH)$(SLASH)localhost:11434
+SLASH = /
+
 // Default LLM provider used for every patient conversation.
 LLM_DEFAULT_PROVIDER = openai
 
 // API key for the default provider.
 // Keep this EMPTY here. Set the real value in the gitignored Secrets.xcconfig.
 LLM_DEFAULT_API_KEY =
+
+// Custom / self-hosted provider settings (used when LLM_DEFAULT_PROVIDER = custom).
+// Keep EMPTY here. Set real values in the gitignored Secrets.xcconfig.
+LLM_CUSTOM_BASE_URL =
+LLM_CUSTOM_ENDPOINT =
+LLM_CUSTOM_MODEL =
 
 // Optional include of the gitignored secrets file.
 // Values in Secrets.xcconfig override the defaults above.

--- a/HouseCall/Config/Secrets.example.xcconfig
+++ b/HouseCall/Config/Secrets.example.xcconfig
@@ -13,3 +13,28 @@ LLM_DEFAULT_PROVIDER = openai
 // API key for the provider above (e.g. sk-... for OpenAI).
 // Leave empty to fall back to any key stored in the device Keychain.
 LLM_DEFAULT_API_KEY =
+
+// ── Custom / local Ollama provider ───────────────────────────────────────────
+// To point the app at a local Ollama instance for manual MVP testing:
+//   1. Set LLM_DEFAULT_PROVIDER = custom
+//   2. Fill in LLM_CUSTOM_BASE_URL, LLM_CUSTOM_ENDPOINT, LLM_CUSTOM_MODEL below.
+//
+// IMPORTANT — xcconfig URL syntax:
+//   xcconfig treats '//' as a comment.  Use the $(SLASH) helper (defined in
+//   Base.xcconfig as SLASH = /) to embed slashes in URL values, e.g.:
+//     LLM_CUSTOM_BASE_URL = http:$(SLASH)$(SLASH)localhost:11434
+//
+// Example for Ollama + MedGemma running on localhost:
+//   LLM_DEFAULT_PROVIDER = custom
+//   LLM_CUSTOM_BASE_URL = http:$(SLASH)$(SLASH)localhost:11434
+//   LLM_CUSTOM_ENDPOINT = v1/chat/completions
+//   LLM_CUSTOM_MODEL = medgemma:4b
+//
+// NOTE: Ollama runs over plain HTTP. NSAllowsLocalNetworking is enabled in
+// Info.plist to permit loopback / .local HTTP — for local/dev testing only.
+// Production PHI traffic MUST use TLS.
+//
+// Ollama requires no API key; leave LLM_DEFAULT_API_KEY empty.
+LLM_CUSTOM_BASE_URL =
+LLM_CUSTOM_ENDPOINT =
+LLM_CUSTOM_MODEL =

--- a/HouseCall/Core/Services/LLMProviderConfigManager.swift
+++ b/HouseCall/Core/Services/LLMProviderConfigManager.swift
@@ -72,6 +72,39 @@ class LLMProviderConfigManager: ObservableObject {
         return key
     }
 
+    /// Custom provider config derived from LLM_CUSTOM_BASE_URL / LLM_CUSTOM_ENDPOINT /
+    /// LLM_CUSTOM_MODEL build settings (substituted via Info.plist at build time).
+    ///
+    /// Returns nil when LLMCustomBaseURL is absent or empty (unsubstituted `$(…)` values
+    /// are treated as absent so a missing Secrets.xcconfig never produces a broken config).
+    ///
+    /// Ollama needs no API key, so `requiresAuth` is always false here.
+    private func buildConfigCustomConfig() -> CustomProviderConfig? {
+        guard let baseURL = Bundle.main.object(forInfoDictionaryKey: "LLMCustomBaseURL") as? String,
+              !baseURL.isEmpty,
+              // Guard against unresolved xcconfig placeholders such as "$(LLM_CUSTOM_BASE_URL)"
+              !baseURL.hasPrefix("$(") else {
+            return nil
+        }
+
+        let rawEndpoint = Bundle.main.object(forInfoDictionaryKey: "LLMCustomEndpoint") as? String ?? ""
+        let endpoint = (rawEndpoint.isEmpty || rawEndpoint.hasPrefix("$("))
+            ? "v1/chat/completions"
+            : rawEndpoint
+
+        let rawModel = Bundle.main.object(forInfoDictionaryKey: "LLMCustomModel") as? String ?? ""
+        let model = (rawModel.isEmpty || rawModel.hasPrefix("$("))
+            ? "llama3"
+            : rawModel
+
+        return CustomProviderConfig(
+            baseURL: baseURL,
+            endpoint: endpoint,
+            model: model,
+            requiresAuth: false
+        )
+    }
+
     // MARK: - Provider Selection
 
     /// Set the active provider (preserved for backward compat; does not override build config)
@@ -175,14 +208,23 @@ class LLMProviderConfigManager: ObservableObject {
         }
     }
 
-    /// Load custom provider configuration
+    /// Load custom provider configuration.
+    ///
+    /// Priority:
+    ///  1. UserDefaults (any config previously saved via saveCustomProviderConfig(_:)).
+    ///  2. Build-config values from LLM_CUSTOM_BASE_URL / LLM_CUSTOM_ENDPOINT /
+    ///     LLM_CUSTOM_MODEL (substituted via Info.plist at build time).
+    ///
+    /// This lets Secrets.xcconfig act as the working default for local Ollama
+    /// testing with no Settings UI required.
     func loadCustomProviderConfig() -> CustomProviderConfig? {
         let key = "\(configKeyPrefix)_custom"
         if let data = userDefaults.data(forKey: key),
            let config = try? JSONDecoder().decode(CustomProviderConfig.self, from: data) {
             return config
         }
-        return nil
+        // Fall back to build-config (Secrets.xcconfig → Info.plist substitution).
+        return buildConfigCustomConfig()
     }
 
     // MARK: - Provider Configuration Access

--- a/HouseCall/Info.plist
+++ b/HouseCall/Info.plist
@@ -7,5 +7,24 @@
 	<string>$(LLM_DEFAULT_PROVIDER)</string>
 	<key>LLMDefaultAPIKey</key>
 	<string>$(LLM_DEFAULT_API_KEY)</string>
+	<!-- Custom / self-hosted provider settings (used when LLMDefaultProvider = custom). -->
+	<key>LLMCustomBaseURL</key>
+	<string>$(LLM_CUSTOM_BASE_URL)</string>
+	<key>LLMCustomEndpoint</key>
+	<string>$(LLM_CUSTOM_ENDPOINT)</string>
+	<key>LLMCustomModel</key>
+	<string>$(LLM_CUSTOM_MODEL)</string>
+	<!--
+	    NSAllowsLocalNetworking permits plain-HTTP connections to loopback
+	    (127.0.0.1 / localhost) and .local mDNS hosts only.
+	    This is the minimal ATS exception needed for local Ollama (HTTP) during
+	    local/dev testing.  It does NOT enable arbitrary HTTP.
+	    Production PHI traffic must always use TLS.
+	-->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Local Ollama (custom provider) for manual MVP testing

Lets the app point at a local Ollama with **no settings UI and no API key** (the provider-config UI was removed in update-patient-chat-ux Phase 2, which only wired build-config defaults for keyed OpenAI/Claude — not the custom provider).

### Changes
- **xcconfig** (`Base.xcconfig`): new empty-default keys `LLM_CUSTOM_BASE_URL`, `LLM_CUSTOM_ENDPOINT`, `LLM_CUSTOM_MODEL`, plus a `SLASH = /` helper (xcconfig treats `//` as a comment, so URLs must be written `http:$(SLASH)$(SLASH)host`).
- **Secrets.example.xcconfig**: documents the ready-to-use Ollama + MedGemma example.
- **Info.plist**: `LLMCustomBaseURL/Endpoint/Model` substitution keys + `NSAppTransportSecurity → NSAllowsLocalNetworking = true` (minimal ATS — loopback/.local HTTP only; **no** `NSAllowsArbitraryLoads`).
- **LLMProviderConfigManager**: `buildConfigCustomConfig()` reads those Info.plist keys (nil when baseURL empty/unresolved → no garbage endpoint); `loadCustomProviderConfig()` falls back to it (UserDefaults-first). `requiresAuth=false`. So with `LLM_DEFAULT_PROVIDER=custom`, `isProviderConfigured(.custom)` is true with zero UI/key.

### Usage (in gitignored `Secrets.xcconfig`)
```
LLM_DEFAULT_PROVIDER = custom
LLM_CUSTOM_BASE_URL  = http:$(SLASH)$(SLASH)localhost:11434
LLM_CUSTOM_ENDPOINT  = v1/chat/completions
LLM_CUSTOM_MODEL     = medgemma:4b
```

### Validation
- Build green. `xcodebuild -showBuildSettings` resolves `LLM_CUSTOM_BASE_URL = http://localhost:11434` (escaping verified). `LLMProviderConfigManagerTests` 20/20, `CustomProviderTests` 37/37. Full suite: only known-flaky failures.
- No secret committed; openai/claude paths unchanged.

### HIPAA / follow-up
- Plain-HTTP local LLM is **dev/testing only**; production PHI must use TLS (noted in Info.plist + example).
- Follow-up **HouseCall-cjn (#116)**: scope `NSAllowsLocalNetworking` to Debug-only so the loopback exception never ships in a production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)