### PR TITLE
fix(chat): use active provider for new + stale conversations

### DIFF
--- a/HouseCall/Core/Services/AIConversationService.swift
+++ b/HouseCall/Core/Services/AIConversationService.swift
@@ -261,7 +261,14 @@ class AIConversationService: ObservableObject {
         }
 
         // --- Legacy LLM streaming path (no coordinator injected) ---
-        let providerType = LLMProviderType(rawValue: conversation.llmProvider ?? "openai") ?? .openai
+        // Resolve from the conversation's stored provider, but fall back to the
+        // active (build-config) provider when the stored one isn't configured.
+        // This rescues conversations created under an older default provider
+        // (e.g. "openai") once the app is pointed at a hardcoded provider.
+        var providerType = LLMProviderType(rawValue: conversation.llmProvider ?? "openai") ?? .openai
+        if !providerConfigManager.isProviderConfigured(providerType) {
+            providerType = providerConfigManager.getActiveProvider()
+        }
         // In DEBUG builds use the test-injected provider when present;
         // otherwise (and always in Release) resolve via the config manager.
         let provider: LLMProvider

--- a/HouseCall/HouseCallApp.swift
+++ b/HouseCall/HouseCallApp.swift
@@ -205,7 +205,7 @@ private struct AutoLaunchChatView: View {
             } else {
                 conversation = try conversationRepository.createConversation(
                     userId: userId,
-                    provider: .openai,
+                    provider: LLMProviderConfigManager.shared.getActiveProvider(),
                     title: nil
                 )
             }


### PR DESCRIPTION
## Problem
The app showed "AI service not configured" on send when pointed at the hardcoded local Ollama provider.

Two causes:
- `AutoLaunchChatView` created conversations hardcoded to `.openai`.
- The streaming send path resolved the provider solely from the conversation's stored `llmProvider`, so older `openai` conversations failed even after switching the default.

Both threw `LLMError.notConfigured` because no OpenAI key exists.

## Fix
- `AutoLaunchChatView` creates conversations with `LLMProviderConfigManager.getActiveProvider()` (build-config default → custom/Ollama).
- Send path falls back to the active provider when the conversation's stored provider isn't configured — rescues old conversations with no data wipe.

## Test
- Builds clean (Debug, iOS Simulator).
- Manually verified: chat streams against local Ollama `medgemma:4b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)