### PR TITLE
docs(openspec): add clinical-interview-mode change proposal

### DIFF
--- a/openspec/changes/add-clinical-interview-mode/design.md
+++ b/openspec/changes/add-clinical-interview-mode/design.md
@@ -1,0 +1,91 @@
+# Design: Clinical History-Taking Interview Mode
+
+## Goal
+
+Convert the assistant from an essay-style chatbot into a clinician conducting a
+focused patient history: one question per turn, short turns, a recognizable
+history structure, and an explicit summary at the end.
+
+## Primary lever: the system prompt
+
+`HealthcareSystemPrompt.default` (in `Core/Services/LLMProvider.swift`) is the
+single string injected as the leading `.system` message by
+`AIConversationService.buildChatContext`. Rewriting it is the highest-impact,
+lowest-risk change and is provider-agnostic (OpenAI/Claude/Custom all consume
+the same context).
+
+New prompt requirements:
+
+- **Persona**: a careful clinician taking a focused history, not an information
+  service.
+- **Turn discipline**: ask exactly ONE question per turn; wait for the answer
+  before asking the next.
+- **Brevity**: ≤ 2 short sentences plus a single question. A brief empathic
+  acknowledgment is allowed; lectures and bulleted explanations are not.
+- **Structure**: chief complaint → HPI via OPQRST (Onset, Provocation/
+  Palliation, Quality, Region/Radiation, Severity, Timing) → targeted ROS, PMH,
+  medications, allergies, and relevant social/family history.
+- **Questioning style**: open-ended first ("What brings you in today?"), then
+  focused/closed questions to narrow.
+- **Red-flag override**: emergency features (chest pain, difficulty breathing,
+  severe bleeding, stroke signs, etc.) interrupt the interview and advise
+  immediate care.
+- **Summary turn**: only when asked to summarize (or after sufficient history),
+  produce a concise summary, preliminary non-diagnostic guidance, and
+  triage/red-flag advice with the standard professional-care disclaimer.
+- **Few-shot exemplar**: 2–3 short example turns embedded in the prompt to lock
+  the cadence. Empirically the strongest lever for a 4B model.
+
+Two prompt variants are defined: `HealthcareSystemPrompt.interview` (gathering)
+and `HealthcareSystemPrompt.summary` (closing turn). `buildChatContext` selects
+the variant from the conversation's interview phase.
+
+## Secondary lever: generation parameters
+
+A small token budget physically caps turn length even if the model ignores the
+prompt. `AIConversationService` supplies a per-phase budget when constructing
+the request:
+
+- Gathering turns: ~160 tokens.
+- Summary turn: ~512 tokens (room for the structured summary).
+
+This requires threading a per-request `maxTokens` override through the provider
+call path. The provider configs already carry a `maxTokens` field; the override
+is applied for the active request without mutating stored config. Temperature is
+left at provider default initially; lowering it is a tunable follow-up, not a
+hard requirement.
+
+## Interview phase state
+
+Phase is a property of the conversation, defaulting to `gathering`. It is held
+in `AIConversationService` (and surfaced to the view model) rather than the
+prompt, so summarization is deterministic and testable.
+
+- `gathering`: normal interview turns, interview prompt + small token budget.
+- `summary`: triggered by the summarize-now action (or a future heuristic).
+  The next assistant turn uses the summary prompt + larger budget, then the
+  phase returns to `gathering` so the patient can continue if they wish.
+
+Phase is in-memory for this change (no Core Data schema change); a conversation
+reopened later starts in `gathering`. Persisting phase is deferred.
+
+## UI: summarize-now affordance
+
+`ChatView` gains a control (toolbar button or an inline action above the input)
+labeled e.g. "Summarize" that calls a new `ConversationViewModel.requestSummary()`.
+It is disabled while streaming and when there are no user messages yet. Standard
+accessibility identifier added for UI tests.
+
+## Safety and HIPAA
+
+No change to encryption, audit logging, or red-flag obligations. The summary is
+explicitly preliminary and non-diagnostic. No PHI added to logs — phase
+transitions log event name + identifiers only.
+
+## Alternatives considered
+
+- **Pure prompt, no state/UI**: simplest, but summarization timing becomes
+  model-dependent and inconsistent on a small model. Rejected per scope
+  decision to include phase-2 state.
+- **Structured field extraction** (parse history into discrete data): valuable
+  but much larger; deferred to future work.

--- a/openspec/changes/add-clinical-interview-mode/proposal.md
+++ b/openspec/changes/add-clinical-interview-mode/proposal.md
@@ -1,0 +1,51 @@
+# Proposal: Clinical History-Taking Interview Mode
+
+## Why
+
+The chat assistant currently behaves like a generic chatbot: a single system
+prompt (`HealthcareSystemPrompt.default`) instructs the model to "collect
+patient symptoms" but imposes no turn discipline, no history-taking structure,
+and no length limit, while the provider default `maxTokens` is 1000. The result
+is that the model answers each message with a large block of text instead of
+conducting a focused, one-question-at-a-time clinical interview. This is the
+wrong interaction model for a patient-facing intake tool: a clinician taking a
+history asks a single targeted question, waits for the answer, and narrows from
+there. The heavy-text experience also degrades on the small local model
+(`medgemma:4b`) used for manual MVP testing, which stays more coherent in short
+turns.
+
+## What Changes
+
+- **MODIFIED**: The healthcare system prompt becomes a structured clinical
+  history-taking prompt — clinician persona, one question per turn, brief
+  empathic acknowledgment, an OPQRST-based HPI framework, open-then-focused
+  questioning, and an explicit length constraint per turn. Includes a short
+  few-shot exemplar of the desired interview cadence (highest-ROI lever for a
+  4B model).
+- **MODIFIED**: Interview-turn generation parameters are constrained — a low
+  `maxTokens` budget for gathering turns to physically cap response length, with
+  a larger budget reserved for the final summary turn.
+- **NEW**: The conversation tracks an interview phase (`gathering` → `summary`)
+  so summarization is an explicit, controllable step rather than something the
+  model self-decides inconsistently.
+- **NEW**: A "summarize now" affordance in the chat UI lets the patient end the
+  interview and request the assistant's summary, preliminary guidance, and
+  triage/red-flag advice.
+- **UNCHANGED**: All existing safety rails — no definitive diagnoses, emergency
+  red-flag escalation, "not a substitute for professional advice", HIPAA
+  encryption and audit logging.
+
+## Impact
+
+- **Affected specs**: `ai-chat-interface` (interview behavior, phase tracking,
+  summarize-now UI), `llm-provider-integration` (clinical system prompt,
+  interview-turn length constraints).
+- **Affected code**: `Core/Services/LLMProvider.swift` (`HealthcareSystemPrompt`),
+  `Core/Services/AIConversationService.swift` (phase state, summary turn,
+  per-phase token budget), `Core/Services/LLMProviders/*` + provider configs
+  (max-tokens plumbing), `Features/Conversation/ViewModels/ConversationViewModel.swift`
+  and `Features/Conversation/Views/ChatView.swift` (summarize-now control).
+- **Out of scope**: Diagnosis or triage decision logic beyond prompt guidance,
+  any change to the provider abstraction or streaming transport, structured
+  extraction of history into discrete data fields (future work), multi-language
+  interviews.

--- a/openspec/changes/add-clinical-interview-mode/specs/ai-chat-interface/spec.md
+++ b/openspec/changes/add-clinical-interview-mode/specs/ai-chat-interface/spec.md
@@ -1,0 +1,64 @@
+# ai-chat-interface (delta)
+
+## ADDED Requirements
+
+### Requirement: Conduct a clinical history-taking interview
+
+The assistant SHALL conduct the conversation as a focused clinical history,
+asking one question per turn and keeping each gathering turn brief, rather than
+returning long multi-topic explanations.
+
+#### Scenario: Assistant asks one focused question per turn
+
+- **GIVEN** the user is in a chat and sends "I've had a headache for two days"
+- **WHEN** the assistant responds
+- **THEN** the response is at most a brief acknowledgment plus a single question
+- **AND** the response does not exceed roughly two short sentences before the question
+- **AND** the question targets the next relevant history detail (e.g. onset, severity, or location)
+
+#### Scenario: Interview narrows from open to focused questions
+
+- **GIVEN** the user has answered an initial open-ended question
+- **WHEN** the assistant continues the interview
+- **THEN** subsequent questions become more focused to characterize the complaint
+- **AND** the assistant does not present a block of differential explanations
+
+#### Scenario: Emergency red flag interrupts the interview
+
+- **GIVEN** the user reports crushing chest pain and shortness of breath
+- **WHEN** the assistant responds
+- **THEN** the assistant advises seeking immediate emergency care
+- **AND** does not continue routine history questions before that advice
+
+### Requirement: Summarize and advise after the interview
+
+The assistant SHALL be able to produce a concise summary of the gathered
+history together with preliminary, non-diagnostic guidance and triage/red-flag
+advice, including the standard professional-care disclaimer.
+
+#### Scenario: Summary turn produces structured guidance
+
+- **GIVEN** a conversation with several answered history questions
+- **WHEN** the patient requests a summary
+- **THEN** the assistant returns a concise summary of the reported history
+- **AND** preliminary non-diagnostic guidance and when to seek care
+- **AND** a statement that this is not a substitute for professional medical advice
+
+### Requirement: Offer a summarize-now action
+
+The chat interface SHALL provide a control that lets the patient end the
+interview and request the assistant's summary.
+
+#### Scenario: Summarize control availability
+
+- **GIVEN** the patient has sent at least one message and no response is streaming
+- **WHEN** the chat screen is displayed
+- **THEN** a "Summarize" control is enabled
+- **WHEN** there are no user messages yet, or a response is currently streaming
+- **THEN** the "Summarize" control is disabled
+
+#### Scenario: Tapping summarize requests the closing turn
+
+- **GIVEN** the summarize control is enabled
+- **WHEN** the patient taps it
+- **THEN** the assistant produces a summary turn as its next response

--- a/openspec/changes/add-clinical-interview-mode/specs/llm-provider-integration/spec.md
+++ b/openspec/changes/add-clinical-interview-mode/specs/llm-provider-integration/spec.md
@@ -1,0 +1,46 @@
+# llm-provider-integration (delta)
+
+## ADDED Requirements
+
+### Requirement: Use a clinical history-taking system prompt
+
+The system prompt injected into every conversation SHALL instruct the model to
+act as a clinician taking a focused history — one question per turn, brief
+turns, an OPQRST-based history structure, open-then-focused questioning, and
+emergency red-flag escalation — while retaining the non-diagnosis and
+professional-care safety constraints. The prompt SHALL include a short few-shot
+exemplar demonstrating the interview cadence.
+
+#### Scenario: Interview prompt is sent as the leading system message
+
+- **GIVEN** a conversation in the gathering phase
+- **WHEN** the chat context is built for a provider request
+- **THEN** the leading system message is the clinical interview prompt
+- **AND** it instructs one question per turn and short responses
+- **AND** it retains the no-diagnosis and professional-care safety constraints
+
+#### Scenario: Summary prompt is sent for the closing turn
+
+- **GIVEN** a conversation transitioning to the summary phase
+- **WHEN** the chat context is built for that turn
+- **THEN** the leading system message is the summary prompt
+- **AND** it instructs a concise summary plus preliminary non-diagnostic guidance
+
+### Requirement: Constrain interview-turn response length
+
+The system SHALL apply a small per-request maximum-token budget to gathering
+turns and a larger budget to the summary turn, without mutating the stored
+provider configuration.
+
+#### Scenario: Gathering turn uses a small token budget
+
+- **GIVEN** a conversation in the gathering phase
+- **WHEN** a provider request is issued for the next assistant turn
+- **THEN** the request uses a small max-tokens budget to keep the turn short
+- **AND** the stored provider configuration is unchanged
+
+#### Scenario: Summary turn uses a larger token budget
+
+- **GIVEN** a conversation in the summary phase
+- **WHEN** the provider request is issued
+- **THEN** the request uses a larger max-tokens budget sufficient for the summary

--- a/openspec/changes/add-clinical-interview-mode/tasks.md
+++ b/openspec/changes/add-clinical-interview-mode/tasks.md
@@ -1,0 +1,65 @@
+# Tasks: Clinical History-Taking Interview Mode
+
+## Phase 1: Clinical system prompt
+
+### Task 1.1: Rewrite HealthcareSystemPrompt for interview mode
+Replace `HealthcareSystemPrompt.default` with a clinician history-taking prompt
+(persona, one-question-per-turn, brevity ≤2 sentences + single question, OPQRST
+HPI structure, open-then-focused questioning, red-flag override, professional-
+care disclaimer). Keep all existing safety constraints.
+
+### Task 1.2: Add a few-shot interview exemplar
+Embed 2–3 short example turns in the prompt demonstrating the desired short
+interview cadence.
+
+### Task 1.3: Add the summary prompt variant
+Add `HealthcareSystemPrompt.summary` instructing a concise summary + preliminary
+non-diagnostic guidance + triage/red-flag advice. Define `.interview` as the
+gathering variant. Update `buildChatContext` to select the variant by phase.
+
+## Phase 2: Interview-turn generation parameters
+
+### Task 2.1: Thread a per-request maxTokens override through the provider path
+Allow `AIConversationService` to pass a per-request `maxTokens` to the provider
+for the current turn without mutating stored provider config (OpenAI, Claude,
+Custom request bodies).
+
+### Task 2.2: Apply per-phase token budgets
+Use a small budget (~160) for gathering turns and a larger budget (~512) for the
+summary turn.
+
+## Phase 3: Interview phase state
+
+### Task 3.1: Add interview phase to AIConversationService
+Add a `gathering | summary` phase (default `gathering`), in-memory per
+conversation. Gathering turns use the interview prompt + small budget.
+
+### Task 3.2: Implement the summary turn transition
+Add a service method that sets phase to `summary`, runs one assistant turn with
+the summary prompt + larger budget, then returns phase to `gathering`. Log the
+transition (event name + identifiers only, no PHI).
+
+## Phase 4: Summarize-now UI
+
+### Task 4.1: Expose requestSummary() on ConversationViewModel
+Forward to the service summary-turn method; guard against empty conversations
+and concurrent streaming.
+
+### Task 4.2: Add the summarize control to ChatView
+Add a "Summarize" control (disabled while streaming or with no user messages)
+with an accessibility identifier, wired to `requestSummary()`.
+
+## Phase 5: Tests and evaluation
+
+### Task 5.1: Prompt and parameter unit tests
+Assert the interview/summary prompt content invariants (one-question guidance,
+disclaimer present, red-flag language) and the per-phase token budgets.
+
+### Task 5.2: Phase-state and summary-turn tests
+Cover the `gathering → summary → gathering` transition and that the summary turn
+uses the summary prompt + larger budget (using the existing test provider
+override).
+
+### Task 5.3: Manual evaluation against local Ollama
+Verify with `medgemma:4b` that gathering turns are short single questions and
+the summarize action produces a coherent structured summary.


### PR DESCRIPTION
Adds the `add-clinical-interview-mode` OpenSpec change: clinician history-taking interview behavior (one question per turn, OPQRST, constrained turn length, gathering→summary phase + summarize-now UI).

Spec deltas: `ai-chat-interface`, `llm-provider-integration`. Validated with `openspec validate --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)