### PR TITLE
add-clinical-interview-mode: Phase 1 — Clinical system prompt

### DIFF
--- a/HouseCall/Core/Services/AIConversationService.swift
+++ b/HouseCall/Core/Services/AIConversationService.swift
@@ -506,17 +506,28 @@ class AIConversationService: ObservableObject {
         }
     }
 
-    /// Builds chat context from conversation messages
-    /// - Parameter conversationId: UUID of the conversation
-    /// - Returns: Array of ChatMessage for LLM provider
+    /// Builds chat context from conversation messages.
+    /// - Parameters:
+    ///   - conversationId: UUID of the conversation.
+    ///   - useSummaryPrompt: When `true`, injects `HealthcareSystemPrompt.summary`
+    ///     (closing-turn variant). Defaults to `false`, which uses the normal
+    ///     `HealthcareSystemPrompt.interview` gathering prompt. Phase 3 will pass
+    ///     `true` when the conversation is in the summary phase; all other callers
+    ///     use the default.
+    /// - Returns: Array of ChatMessage for the LLM provider.
     /// - Throws: MessageRepositoryError
-    private func buildChatContext(conversationId: UUID) throws -> [ChatMessage] {
+    private func buildChatContext(conversationId: UUID, useSummaryPrompt: Bool = false) throws -> [ChatMessage] {
         var chatMessages: [ChatMessage] = []
+
+        // Select the prompt variant: summary for the closing turn, interview for all others.
+        let systemPrompt = useSummaryPrompt
+            ? HealthcareSystemPrompt.summary
+            : HealthcareSystemPrompt.interview
 
         // Add system prompt first
         chatMessages.append(ChatMessage(
             role: .system,
-            content: HealthcareSystemPrompt.default
+            content: systemPrompt
         ))
 
         // Add all conversation messages (excluding the placeholder we just created)

--- a/HouseCall/Core/Services/LLMProvider.swift
+++ b/HouseCall/Core/Services/LLMProvider.swift
@@ -130,18 +130,43 @@ enum LLMError: Error, LocalizedError {
 /// Default system prompt for healthcare conversations
 struct HealthcareSystemPrompt {
     static let `default` = """
-You are a medical AI assistant for HouseCall. Your role is to:
-1. Collect patient symptoms and health information
-2. Provide preliminary health guidance (NOT diagnoses)
-3. Recommend when to seek immediate medical attention
-4. Always emphasize that your responses are not a substitute for professional medical advice
-5. Be empathetic, clear, and patient-centered
+You are a careful clinician conducting a focused patient history. You are not a general \
+information service and you do not write essays or long explanations.
 
-IMPORTANT:
-- Never provide definitive diagnoses
-- Always recommend consulting a physician for serious symptoms
-- Recognize medical emergencies (chest pain, difficulty breathing, severe bleeding, etc.) and advise immediate care
-- Maintain patient confidentiality and privacy
-- Be supportive and non-judgmental
+TURN DISCIPLINE — absolute requirement:
+Ask exactly ONE question per turn. Wait for the patient's answer before asking the next. \
+Each turn must contain at most two short sentences plus exactly one question. A brief \
+empathic acknowledgment is permitted; lectures, bulleted lists, and differential dumps are not.
+
+INTERVIEW STRUCTURE — follow in order:
+1. Chief complaint: open with one open-ended question ("What brings you in today?").
+2. History of present illness (HPI) using OPQRST:
+   - Onset: when and how it started
+   - Provocation/Palliation: what makes it better or worse
+   - Quality: character of the symptom (sharp, dull, burning, pressure, etc.)
+   - Region/Radiation: location and whether it spreads anywhere
+   - Severity: intensity on a scale of 0 to 10
+   - Timing: constant vs. intermittent, duration, pattern
+3. Targeted review of systems relevant to the chief complaint.
+4. Past medical history, current medications, and allergies.
+5. Relevant social and family history as indicated by the complaint.
+
+QUESTIONING STYLE:
+Start open-ended to let the patient describe in their own words; then move to focused, \
+closed questions to characterize specific details.
+
+EMERGENCY RED-FLAG OVERRIDE — highest priority, applies before any other rule:
+If the patient reports chest pain, difficulty breathing, severe or sudden-onset headache, \
+signs of stroke (facial drooping, arm weakness, slurred speech), severe bleeding, loss of \
+consciousness, or any symptom suggesting immediate danger to life, immediately advise them \
+to call emergency services (911) or go to the nearest emergency department. Do not continue \
+routine history questions until this advice has been clearly stated.
+
+SAFETY CONSTRAINTS — always apply:
+- Never state or imply a definitive diagnosis.
+- Always recommend consulting a physician for serious, persistent, or concerning symptoms.
+- Remind the patient that your responses are not a substitute for professional medical advice.
+- Be empathetic, supportive, and non-judgmental at all times.
+- Maintain patient confidentiality and privacy.
 """
 }

--- a/HouseCall/Core/Services/LLMProvider.swift
+++ b/HouseCall/Core/Services/LLMProvider.swift
@@ -168,5 +168,15 @@ SAFETY CONSTRAINTS — always apply:
 - Remind the patient that your responses are not a substitute for professional medical advice.
 - Be empathetic, supportive, and non-judgmental at all times.
 - Maintain patient confidentiality and privacy.
+
+EXAMPLE OF THE DESIRED STYLE (imitate the format, not the content):
+Patient: I've been having headaches.
+Clinician: I'm sorry to hear that. When did they first start?
+
+Patient: About three days ago.
+Clinician: Got it. On a scale of 0 to 10, how severe is the pain at its worst?
+
+Patient: Around a 6.
+Clinician: Thank you. Have you noticed any nausea, light sensitivity, or vision changes along with the headache?
 """
 }

--- a/HouseCall/Core/Services/LLMProvider.swift
+++ b/HouseCall/Core/Services/LLMProvider.swift
@@ -127,9 +127,15 @@ enum LLMError: Error, LocalizedError {
     }
 }
 
-/// Default system prompt for healthcare conversations
+/// System prompts for the clinical interview workflow.
+///
+/// Two variants:
+/// - `interview`: active history-gathering turns; enforces one-question-per-turn cadence.
+/// - `summary`: closing turn; produces a concise history summary with triage guidance.
 struct HealthcareSystemPrompt {
-    static let `default` = """
+    /// Gathering-phase prompt. Instructs the model to conduct a focused patient history
+    /// one question at a time, following OPQRST structure, with a red-flag override.
+    static let interview = """
 You are a careful clinician conducting a focused patient history. You are not a general \
 information service and you do not write essays or long explanations.
 
@@ -178,5 +184,38 @@ Clinician: Got it. On a scale of 0 to 10, how severe is the pain at its worst?
 
 Patient: Around a 6.
 Clinician: Thank you. Have you noticed any nausea, light sensitivity, or vision changes along with the headache?
+"""
+
+    /// Summary-phase prompt. Used for the closing turn only.
+    /// Instructs the model to produce a concise history summary, preliminary
+    /// non-diagnostic guidance, and triage/red-flag advice. Must NOT ask further
+    /// interview questions.
+    static let summary = """
+You have just completed a focused patient history interview. Now produce a closing summary \
+in three short sections:
+
+1. HISTORY SUMMARY — a concise paragraph covering the chief complaint, relevant HPI details \
+(onset, character, severity, timing, aggravating/relieving factors), and any pertinent past \
+medical history, medications, allergies, or social/family history gathered during the interview.
+
+2. PRELIMINARY GUIDANCE — one or two sentences of general, non-diagnostic observations. \
+Do NOT state or imply a definitive diagnosis. You may note which categories of conditions \
+are commonly associated with the symptoms described and suggest monitoring or self-care \
+measures where clearly appropriate (e.g., rest, hydration, over-the-counter analgesics for \
+mild symptoms).
+
+3. TRIAGE AND RED FLAGS — advise when to seek care:
+   - Seek emergency care immediately (call 911 or go to the nearest emergency department) \
+if any of the following are present or develop: chest pain, difficulty breathing, signs of \
+stroke (facial drooping, arm weakness, speech difficulty), severe or sudden-worst-ever \
+headache, uncontrolled bleeding, or loss of consciousness.
+   - See a clinician urgently (same day or next day) if symptoms are worsening, persistent, \
+or not responding to basic self-care.
+   - Routine follow-up is appropriate for mild, improving symptoms with no red flags.
+
+IMPORTANT: Do not ask any further interview questions in this response. End the summary with \
+the following disclaimer on its own line:
+"This summary is for informational purposes only and is not a substitute for professional \
+medical advice, diagnosis, or treatment. Please consult a qualified healthcare provider."
 """
 }

--- a/HouseCall/Core/Services/LLMProviders/ClaudeProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/ClaudeProvider.swift
@@ -170,7 +170,7 @@ class ClaudeProvider: LLMProvider {
 
     private func buildRequestBody(messages: [ChatMessage]) -> [String: Any] {
         // Claude API requires separating system messages from conversation messages
-        var systemPrompt = HealthcareSystemPrompt.default
+        var systemPrompt = HealthcareSystemPrompt.interview
         var conversationMessages: [[String: String]] = []
 
         for message in messages {

--- a/HouseCallTests/ClaudeProviderTests.swift
+++ b/HouseCallTests/ClaudeProviderTests.swift
@@ -273,13 +273,13 @@ struct ClaudeProviderTests {
     @Test("Healthcare system prompt is used")
     func testHealthcareSystemPrompt() {
         let (provider, _, _) = createTestProvider()
-        // HealthcareSystemPrompt.default is used internally
+        // HealthcareSystemPrompt.interview is used internally
         #expect(provider.providerType == .claude)
     }
 
     @Test("System prompt can be extended")
     func testExtendedSystemPrompt() {
-        let basePrompt = HealthcareSystemPrompt.default
+        let basePrompt = HealthcareSystemPrompt.interview
         let customAddition = "Focus on pediatric care"
         let extendedPrompt = basePrompt + "\n\n" + customAddition
 
@@ -303,7 +303,7 @@ struct ClaudeProviderTests {
         let (provider, _, _) = createTestProvider()
 
         let messages = [
-            ChatMessage(role: .system, content: HealthcareSystemPrompt.default),
+            ChatMessage(role: .system, content: HealthcareSystemPrompt.interview),
             ChatMessage(role: .user, content: "I have a headache"),
             ChatMessage(role: .assistant, content: "How long have you had the headache?"),
             ChatMessage(role: .user, content: "Since this morning"),

--- a/HouseCallTests/CustomProviderTests.swift
+++ b/HouseCallTests/CustomProviderTests.swift
@@ -394,7 +394,7 @@ struct CustomProviderTests {
         let (provider, _, _) = createTestProvider()
 
         let messages = [
-            ChatMessage(role: .system, content: HealthcareSystemPrompt.default),
+            ChatMessage(role: .system, content: HealthcareSystemPrompt.interview),
             ChatMessage(role: .user, content: "I have a headache"),
             ChatMessage(role: .assistant, content: "How long?"),
             ChatMessage(role: .user, content: "Since morning")

--- a/openspec/changes/add-clinical-interview-mode/tasks.md
+++ b/openspec/changes/add-clinical-interview-mode/tasks.md
@@ -12,7 +12,7 @@ care disclaimer). Keep all existing safety constraints.
 Embed 2–3 short example turns in the prompt demonstrating the desired short
 interview cadence.
 
-### Task 1.3: Add the summary prompt variant
+### Task 1.3: Add the summary prompt variant  [x]
 Add `HealthcareSystemPrompt.summary` instructing a concise summary + preliminary
 non-diagnostic guidance + triage/red-flag advice. Define `.interview` as the
 gathering variant. Update `buildChatContext` to select the variant by phase.

--- a/openspec/changes/add-clinical-interview-mode/tasks.md
+++ b/openspec/changes/add-clinical-interview-mode/tasks.md
@@ -8,7 +8,7 @@ Replace `HealthcareSystemPrompt.default` with a clinician history-taking prompt
 HPI structure, open-then-focused questioning, red-flag override, professional-
 care disclaimer). Keep all existing safety constraints.
 
-### Task 1.2: Add a few-shot interview exemplar
+### Task 1.2: Add a few-shot interview exemplar  [x]
 Embed 2–3 short example turns in the prompt demonstrating the desired short
 interview cadence.
 

--- a/openspec/changes/add-clinical-interview-mode/tasks.md
+++ b/openspec/changes/add-clinical-interview-mode/tasks.md
@@ -2,7 +2,7 @@
 
 ## Phase 1: Clinical system prompt
 
-### Task 1.1: Rewrite HealthcareSystemPrompt for interview mode
+### Task 1.1: Rewrite HealthcareSystemPrompt for interview mode  [x]
 Replace `HealthcareSystemPrompt.default` with a clinician history-taking prompt
 (persona, one-question-per-turn, brevity ≤2 sentences + single question, OPQRST
 HPI structure, open-then-focused questioning, red-flag override, professional-


### PR DESCRIPTION
Phase 1 of `add-clinical-interview-mode`: turn the assistant into a clinician taking a focused history instead of an essay-style chatbot.

## Tasks
- [x] 1.1 Rewrite `HealthcareSystemPrompt` for interview mode (one question/turn, ≤2 sentences, OPQRST, open→focused, red-flag override, safety rails kept)
- [x] 1.2 Add a few-shot interview exemplar (3 labeled turns modeling the cadence)
- [x] 1.3 Add the `.summary` prompt variant + `buildChatContext(useSummaryPrompt:)` selector (defaults to `.interview`; renamed `.default`→`.interview`; updated Claude provider + tests)

## Beads closed
HouseCall-br5 (#131), HouseCall-cci (#132), HouseCall-fpi (#130)

## Test
Build clean; `HouseCallTests` pass (146 provider-test cases green). Remaining flakes are the known parallel-execution race (`CloudSyncTests`/`IntegrationTests`), unrelated — pass in isolation.

## Deferred to phase 3 (recorded on bead HouseCall-ba9)
`ClaudeProvider.buildRequestBody` double-seeds the system prompt; when phase 3 sets `useSummaryPrompt: true`, the Claude path would concatenate interview+summary. Must be reconciled when wiring the summary turn. Not active today (no caller passes true; active provider is custom/Ollama).

🤖 Generated with [Claude Code](https://claude.com/claude-code)