### PR TITLE
add-clinical-interview-mode: Phase 2 — Interview-turn generation parameters

### DIFF
--- a/HouseCall/Core/Services/AIConversationService.swift
+++ b/HouseCall/Core/Services/AIConversationService.swift
@@ -330,6 +330,10 @@ class AIConversationService: ObservableObject {
             ? AIConversationService.summaryMaxTokens
             : AIConversationService.gatheringMaxTokens
 
+        // Phase 3: when wiring the summary turn, also pass
+        // `useSummaryPrompt: summaryTurn` here so the summary prompt is swapped
+        // in alongside the larger budget — otherwise a `summaryTurn: true` call
+        // silently keeps the gathering prompt.
         let chatMessages = try buildChatContext(conversationId: conversationId)
 
         try? auditLogger.log(

--- a/HouseCall/Core/Services/AIConversationService.swift
+++ b/HouseCall/Core/Services/AIConversationService.swift
@@ -41,6 +41,20 @@ class AIConversationService: ObservableObject {
     /// ID of the message currently being streamed
     @Published private(set) var streamingMessageId: UUID?
 
+    // MARK: - Interview Turn Budgets
+
+    /// Per-phase token budgets for clinical interview turns.
+    ///
+    /// A small budget physically caps turn length, preventing essay-length replies
+    /// even when the model ignores the brevity instruction in the system prompt.
+    ///
+    /// - `gatheringMaxTokens` (~160): one short question per gathering turn.
+    /// - `summaryMaxTokens` (~512): room for the structured closing summary.
+    ///
+    /// Phase 3 selects between them via the `summaryTurn` parameter on `sendMessage`.
+    private static let gatheringMaxTokens = 160
+    private static let summaryMaxTokens   = 512
+
     // MARK: - Dependencies
 
     private let conversationRepository: ConversationRepositoryProtocol
@@ -193,7 +207,7 @@ class AIConversationService: ObservableObject {
     ///   - conversationId: UUID of the conversation
     ///   - content: User's message content
     /// - Throws: Various errors from repositories and LLM providers
-    func sendMessage(conversationId: UUID, content: String) async throws {
+    func sendMessage(conversationId: UUID, content: String, summaryTurn: Bool = false) async throws {
         // Clear any previous errors
         errorMessage = nil
 
@@ -309,6 +323,13 @@ class AIConversationService: ObservableObject {
         streamingText = ""
         isStreaming = true
 
+        // Choose the per-phase token budget.  Phase 3 will pass `summaryTurn: true`
+        // when triggering the closing summary turn; all gathering turns use the
+        // smaller budget to cap reply length regardless of model behaviour.
+        let maxTokens = summaryTurn
+            ? AIConversationService.summaryMaxTokens
+            : AIConversationService.gatheringMaxTokens
+
         let chatMessages = try buildChatContext(conversationId: conversationId)
 
         try? auditLogger.log(
@@ -325,6 +346,7 @@ class AIConversationService: ObservableObject {
         do {
             try await provider.streamCompletion(
                 messages: chatMessages,
+                maxTokensOverride: maxTokens,
                 onChunk: { [weak self] chunk in
                     Task { @MainActor in
                         self?.handleStreamChunk(chunk, messageId: aiMessage.id!)

--- a/HouseCall/Core/Services/LLMProvider.swift
+++ b/HouseCall/Core/Services/LLMProvider.swift
@@ -20,17 +20,40 @@ protocol LLMProvider {
     /// Stream a completion response from the LLM
     /// - Parameters:
     ///   - messages: Array of chat messages forming the conversation context
+    ///   - maxTokensOverride: Per-request token budget that overrides the stored config
+    ///     value for this call only. Pass `nil` (the default) to use the configured value.
     ///   - onChunk: Callback invoked for each streamed token/chunk of text
     ///   - onComplete: Callback invoked when streaming completes (success or error)
     /// - Throws: LLMError if the request cannot be initiated
     func streamCompletion(
         messages: [ChatMessage],
+        maxTokensOverride: Int?,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws
 
     /// Cancel an ongoing streaming request
     func cancelStreaming()
+}
+
+// MARK: - LLMProvider default overload
+
+extension LLMProvider {
+    /// Convenience overload that omits `maxTokensOverride`, defaulting it to `nil`.
+    /// Allows existing call sites to continue compiling unchanged while the
+    /// four-argument form is the canonical protocol requirement.
+    func streamCompletion(
+        messages: [ChatMessage],
+        onChunk: @escaping (String) -> Void,
+        onComplete: @escaping (Result<String, LLMError>) -> Void
+    ) async throws {
+        try await streamCompletion(
+            messages: messages,
+            maxTokensOverride: nil,
+            onChunk: onChunk,
+            onComplete: onComplete
+        )
+    }
 }
 
 /// Enumeration of supported LLM provider types

--- a/HouseCall/Core/Services/LLMProviders/ClaudeProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/ClaudeProvider.swift
@@ -57,6 +57,7 @@ class ClaudeProvider: LLMProvider {
 
     func streamCompletion(
         messages: [ChatMessage],
+        maxTokensOverride: Int? = nil,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws {
@@ -72,6 +73,7 @@ class ClaudeProvider: LLMProvider {
         try await performRequestWithRetry(
             messages: messages,
             apiKey: apiKey,
+            maxTokensOverride: maxTokensOverride,
             onChunk: onChunk,
             onComplete: onComplete
         )
@@ -93,6 +95,7 @@ class ClaudeProvider: LLMProvider {
     private func performRequestWithRetry(
         messages: [ChatMessage],
         apiKey: String,
+        maxTokensOverride: Int? = nil,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void,
         retryCount: Int = 0
@@ -101,6 +104,7 @@ class ClaudeProvider: LLMProvider {
             try await performRequest(
                 messages: messages,
                 apiKey: apiKey,
+                maxTokensOverride: maxTokensOverride,
                 onChunk: onChunk,
                 onComplete: onComplete
             )
@@ -115,6 +119,7 @@ class ClaudeProvider: LLMProvider {
                 try await performRequestWithRetry(
                     messages: messages,
                     apiKey: apiKey,
+                    maxTokensOverride: maxTokensOverride,
                     onChunk: onChunk,
                     onComplete: onComplete,
                     retryCount: retryCount + 1
@@ -128,6 +133,7 @@ class ClaudeProvider: LLMProvider {
     private func performRequest(
         messages: [ChatMessage],
         apiKey: String,
+        maxTokensOverride: Int? = nil,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws {
@@ -146,7 +152,7 @@ class ClaudeProvider: LLMProvider {
         request.setValue("application/json", forHTTPHeaderField: "content-type")
 
         // Build request body
-        let requestBody = buildRequestBody(messages: messages)
+        let requestBody = buildRequestBody(messages: messages, maxTokensOverride: maxTokensOverride)
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
         // Create a fresh SSEParser per request to isolate parser state across
@@ -168,7 +174,7 @@ class ClaudeProvider: LLMProvider {
         task.resume()
     }
 
-    private func buildRequestBody(messages: [ChatMessage]) -> [String: Any] {
+    private func buildRequestBody(messages: [ChatMessage], maxTokensOverride: Int? = nil) -> [String: Any] {
         // Claude API requires separating system messages from conversation messages
         var systemPrompt = HealthcareSystemPrompt.interview
         var conversationMessages: [[String: String]] = []
@@ -188,7 +194,7 @@ class ClaudeProvider: LLMProvider {
 
         return [
             "model": config.model,
-            "max_tokens": config.maxTokens,
+            "max_tokens": maxTokensOverride ?? config.maxTokens,
             "temperature": config.temperature,
             "system": systemPrompt,
             "messages": conversationMessages,

--- a/HouseCall/Core/Services/LLMProviders/CustomProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/CustomProvider.swift
@@ -57,6 +57,7 @@ class CustomProvider: LLMProvider {
 
     func streamCompletion(
         messages: [ChatMessage],
+        maxTokensOverride: Int? = nil,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws {
@@ -71,6 +72,7 @@ class CustomProvider: LLMProvider {
         try await performRequestWithRetry(
             messages: messages,
             apiKey: apiKey,
+            maxTokensOverride: maxTokensOverride,
             onChunk: onChunk,
             onComplete: onComplete
         )
@@ -97,6 +99,7 @@ class CustomProvider: LLMProvider {
     private func performRequestWithRetry(
         messages: [ChatMessage],
         apiKey: String?,
+        maxTokensOverride: Int? = nil,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void,
         retryCount: Int = 0
@@ -105,6 +108,7 @@ class CustomProvider: LLMProvider {
             try await performRequest(
                 messages: messages,
                 apiKey: apiKey,
+                maxTokensOverride: maxTokensOverride,
                 onChunk: onChunk,
                 onComplete: onComplete
             )
@@ -119,6 +123,7 @@ class CustomProvider: LLMProvider {
                 try await performRequestWithRetry(
                     messages: messages,
                     apiKey: apiKey,
+                    maxTokensOverride: maxTokensOverride,
                     onChunk: onChunk,
                     onComplete: onComplete,
                     retryCount: retryCount + 1
@@ -132,6 +137,7 @@ class CustomProvider: LLMProvider {
     private func performRequest(
         messages: [ChatMessage],
         apiKey: String?,
+        maxTokensOverride: Int? = nil,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws {
@@ -159,7 +165,7 @@ class CustomProvider: LLMProvider {
         }
 
         // Build request body (OpenAI-compatible format)
-        let requestBody = buildRequestBody(messages: messages)
+        let requestBody = buildRequestBody(messages: messages, maxTokensOverride: maxTokensOverride)
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
         // Reset SSE parser
@@ -221,7 +227,7 @@ class CustomProvider: LLMProvider {
         task.resume()
     }
 
-    private func buildRequestBody(messages: [ChatMessage]) -> [String: Any] {
+    private func buildRequestBody(messages: [ChatMessage], maxTokensOverride: Int? = nil) -> [String: Any] {
         // Convert ChatMessages to OpenAI-compatible format
         let formattedMessages = messages.map { message in
             return [
@@ -241,7 +247,8 @@ class CustomProvider: LLMProvider {
             body["temperature"] = temperature
         }
 
-        if let maxTokens = config.maxTokens {
+        // Prefer the per-request override; fall back to stored config value (itself optional)
+        if let maxTokens = maxTokensOverride ?? config.maxTokens {
             body["max_tokens"] = maxTokens
         }
 

--- a/HouseCall/Core/Services/LLMProviders/OpenAIProvider.swift
+++ b/HouseCall/Core/Services/LLMProviders/OpenAIProvider.swift
@@ -54,6 +54,7 @@ class OpenAIProvider: LLMProvider {
 
     func streamCompletion(
         messages: [ChatMessage],
+        maxTokensOverride: Int? = nil,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws {
@@ -69,6 +70,7 @@ class OpenAIProvider: LLMProvider {
         try await performRequestWithRetry(
             messages: messages,
             apiKey: apiKey,
+            maxTokensOverride: maxTokensOverride,
             onChunk: onChunk,
             onComplete: onComplete
         )
@@ -90,6 +92,7 @@ class OpenAIProvider: LLMProvider {
     private func performRequestWithRetry(
         messages: [ChatMessage],
         apiKey: String,
+        maxTokensOverride: Int? = nil,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void,
         retryCount: Int = 0
@@ -98,6 +101,7 @@ class OpenAIProvider: LLMProvider {
             try await performRequest(
                 messages: messages,
                 apiKey: apiKey,
+                maxTokensOverride: maxTokensOverride,
                 onChunk: onChunk,
                 onComplete: onComplete
             )
@@ -112,6 +116,7 @@ class OpenAIProvider: LLMProvider {
                 try await performRequestWithRetry(
                     messages: messages,
                     apiKey: apiKey,
+                    maxTokensOverride: maxTokensOverride,
                     onChunk: onChunk,
                     onComplete: onComplete,
                     retryCount: retryCount + 1
@@ -125,6 +130,7 @@ class OpenAIProvider: LLMProvider {
     private func performRequest(
         messages: [ChatMessage],
         apiKey: String,
+        maxTokensOverride: Int? = nil,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws {
@@ -140,7 +146,7 @@ class OpenAIProvider: LLMProvider {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         // Build request body
-        let requestBody = buildRequestBody(messages: messages)
+        let requestBody = buildRequestBody(messages: messages, maxTokensOverride: maxTokensOverride)
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
         // Create a fresh SSEParser per request to isolate parser state across
@@ -162,7 +168,7 @@ class OpenAIProvider: LLMProvider {
         task.resume()
     }
 
-    private func buildRequestBody(messages: [ChatMessage]) -> [String: Any] {
+    private func buildRequestBody(messages: [ChatMessage], maxTokensOverride: Int? = nil) -> [String: Any] {
         // Convert ChatMessages to OpenAI format
         let openAIMessages = messages.map { message in
             return [
@@ -175,7 +181,7 @@ class OpenAIProvider: LLMProvider {
             "model": config.model,
             "messages": openAIMessages,
             "temperature": config.temperature,
-            "max_tokens": config.maxTokens,
+            "max_tokens": maxTokensOverride ?? config.maxTokens,
             "stream": true
         ]
     }

--- a/HouseCallTests/AIConversationServiceTests.swift
+++ b/HouseCallTests/AIConversationServiceTests.swift
@@ -638,6 +638,7 @@ private class StubLLMProvider: LLMProvider {
 
     func streamCompletion(
         messages: [ChatMessage],
+        maxTokensOverride: Int?,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws {
@@ -677,6 +678,7 @@ private class MultiChunkStubProvider: LLMProvider {
 
     func streamCompletion(
         messages: [ChatMessage],
+        maxTokensOverride: Int?,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws {

--- a/HouseCallTests/IntegrationTests.swift
+++ b/HouseCallTests/IntegrationTests.swift
@@ -865,6 +865,7 @@ private class MockLLMProvider: LLMProvider {
 
     func streamCompletion(
         messages: [ChatMessage],
+        maxTokensOverride: Int?,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws {
@@ -909,6 +910,7 @@ private class AIChatStubProvider: LLMProvider {
 
     func streamCompletion(
         messages: [ChatMessage],
+        maxTokensOverride: Int?,
         onChunk: @escaping (String) -> Void,
         onComplete: @escaping (Result<String, LLMError>) -> Void
     ) async throws {

--- a/openspec/changes/add-clinical-interview-mode/tasks.md
+++ b/openspec/changes/add-clinical-interview-mode/tasks.md
@@ -19,7 +19,7 @@ gathering variant. Update `buildChatContext` to select the variant by phase.
 
 ## Phase 2: Interview-turn generation parameters
 
-### Task 2.1: Thread a per-request maxTokens override through the provider path
+### Task 2.1: Thread a per-request maxTokens override through the provider path  [x]
 Allow `AIConversationService` to pass a per-request `maxTokens` to the provider
 for the current turn without mutating stored provider config (OpenAI, Claude,
 Custom request bodies).

--- a/openspec/changes/add-clinical-interview-mode/tasks.md
+++ b/openspec/changes/add-clinical-interview-mode/tasks.md
@@ -24,7 +24,7 @@ Allow `AIConversationService` to pass a per-request `maxTokens` to the provider
 for the current turn without mutating stored provider config (OpenAI, Claude,
 Custom request bodies).
 
-### Task 2.2: Apply per-phase token budgets
+### Task 2.2: Apply per-phase token budgets  [x]
 Use a small budget (~160) for gathering turns and a larger budget (~512) for the
 summary turn.
 


### PR DESCRIPTION
Phase 2 of `add-clinical-interview-mode`: physically cap interview turn length via per-request token budgets.

## Tasks
- [x] 2.1 Thread `maxTokensOverride: Int? = nil` through `streamCompletion` (protocol + OpenAI/Claude/Custom) via a forwarding extension; applied as `override ?? config.maxTokens`, no config write-back.
- [x] 2.2 Add gathering (160) / summary (512) budgets in `AIConversationService`; `sendMessage` passes the gathering budget and gains `summaryTurn: Bool = false` reserving the summary budget for phase 3.

## Beads closed
HouseCall-c2i (#129), HouseCall-bbf (#128)

## Behavior change
Gathering turns are now capped at 160 tokens, so the assistant can no longer return essay-length replies even if it ignores the brevity prompt.

## Test
`HouseCallTests` pass (469). Remaining flakes are the known parallel-execution race, pass in isolation.

## Note for phase 3 (recorded on bead HouseCall-ba9)
`sendMessage(summaryTurn:)` selects the budget but `buildChatContext` is still called without `useSummaryPrompt`; phase 3 must pass `useSummaryPrompt: summaryTurn` there too (inline breadcrumb added). Plus the earlier ClaudeProvider double-seed reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)