### PR TITLE
add-clinical-interview-mode: Phase 4 — Summarize-now UI

### DIFF
--- a/HouseCall/Features/Conversation/ViewModels/ConversationViewModel.swift
+++ b/HouseCall/Features/Conversation/ViewModels/ConversationViewModel.swift
@@ -140,6 +140,32 @@ class ConversationViewModel: ObservableObject {
         errorMessage = nil
     }
 
+    /// Whether a summary request can be issued right now.
+    ///
+    /// Returns `false` while a streaming turn is in progress (to avoid
+    /// concurrent AI calls) and `false` when no user messages exist yet
+    /// (a summary requires gathered history to be meaningful).
+    var canSummarize: Bool {
+        guard !isStreaming else { return false }
+        return messages.contains { $0.role == "user" }
+    }
+
+    /// Request a clinical-interview summary turn for this conversation.
+    ///
+    /// Forwards to `AIConversationService.requestSummary(conversationId:)`.
+    /// Returns early without calling the service when `canSummarize` is
+    /// `false` — this is a defensive guard in addition to the View disabling
+    /// the control via the same property.
+    func requestSummary() async {
+        guard canSummarize else { return }
+
+        do {
+            try await aiService.requestSummary(conversationId: conversationId)
+        } catch {
+            handleError(error)
+        }
+    }
+
     // MARK: - Private Methods
 
     private func setupServiceObservers() {

--- a/HouseCall/Features/Conversation/Views/ChatView.swift
+++ b/HouseCall/Features/Conversation/Views/ChatView.swift
@@ -77,6 +77,18 @@ struct ChatView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
+                    Task {
+                        await viewModel.requestSummary()
+                    }
+                }) {
+                    Image(systemName: "list.clipboard")
+                        .accessibilityLabel("Summarize conversation")
+                }
+                .disabled(!viewModel.canSummarize)
+                .accessibilityIdentifier("summarizeButton")
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
                     showProfile = true
                 }) {
                     Image(systemName: "person.circle")

--- a/openspec/changes/add-clinical-interview-mode/tasks.md
+++ b/openspec/changes/add-clinical-interview-mode/tasks.md
@@ -45,7 +45,7 @@ transition (event name + identifiers only, no PHI).
 Forward to the service summary-turn method; guard against empty conversations
 and concurrent streaming.
 
-### Task 4.2: Add the summarize control to ChatView
+### Task 4.2: Add the summarize control to ChatView  [x]
 Add a "Summarize" control (disabled while streaming or with no user messages)
 with an accessibility identifier, wired to `requestSummary()`.
 

--- a/openspec/changes/add-clinical-interview-mode/tasks.md
+++ b/openspec/changes/add-clinical-interview-mode/tasks.md
@@ -41,7 +41,7 @@ transition (event name + identifiers only, no PHI).
 
 ## Phase 4: Summarize-now UI
 
-### Task 4.1: Expose requestSummary() on ConversationViewModel
+### Task 4.1: Expose requestSummary() on ConversationViewModel  [x]
 Forward to the service summary-turn method; guard against empty conversations
 and concurrent streaming.
 


### PR DESCRIPTION
Phase 4 of `add-clinical-interview-mode`: patient-facing control to end the interview and get a summary.

## Tasks
- [x] 4.1 `ConversationViewModel.requestSummary()` + `canSummarize` (false while streaming or when no user messages); internal guard; errors via `handleError`.
- [x] 4.2 ChatView toolbar "Summarize" button (`accessibilityIdentifier("summarizeButton")` + VoiceOver label), disabled via `!canSummarize`, wired to `requestSummary()`.

## Beads closed
HouseCall-1n3 (#124), HouseCall-4cg (#123)

## Test
`HouseCallTests` pass; only the known parallel-execution flakes remain (pass in isolation). UI/unit tests for the new control land in phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)