### PR TITLE
add-clinical-interview-mode: Phase 5 — Tests and evaluation

### DIFF
--- a/HouseCall/Core/Services/AIConversationService.swift
+++ b/HouseCall/Core/Services/AIConversationService.swift
@@ -72,8 +72,10 @@ class AIConversationService: ObservableObject {
     /// - `summaryMaxTokens` (~512): room for the structured closing summary.
     ///
     /// Phase 3 selects between them via the `summaryTurn` parameter on `sendMessage`.
-    private static let gatheringMaxTokens = 160
-    private static let summaryMaxTokens   = 512
+    /// Internal (not private) so that unit tests can assert their exact values
+    /// without hard-coding magic numbers.
+    static let gatheringMaxTokens = 160
+    static let summaryMaxTokens   = 512
 
     // MARK: - Dependencies
 

--- a/HouseCallTests/ClinicalInterviewPromptTests.swift
+++ b/HouseCallTests/ClinicalInterviewPromptTests.swift
@@ -1,0 +1,174 @@
+//
+//  ClinicalInterviewPromptTests.swift
+//  HouseCallTests
+//
+//  Unit tests for HealthcareSystemPrompt content invariants and
+//  per-phase token budget values.
+//
+//  Spec: openspec/changes/add-clinical-interview-mode/tasks.md — Task 5.1
+//
+
+import Testing
+import Foundation
+@testable import HouseCall
+
+// MARK: - HealthcareSystemPrompt — interview (gathering) variant
+
+@Suite("HealthcareSystemPrompt.interview content invariants")
+struct InterviewPromptTests {
+
+    private let prompt = HealthcareSystemPrompt.interview
+
+    // MARK: One-question-per-turn
+
+    @Test("Interview prompt enforces one question per turn")
+    func oneQuestionPerTurn() {
+        // The prompt must instruct the model to ask only one question at a time.
+        let lower = prompt.lowercased()
+        let containsOneQuestion = lower.contains("one question") || lower.contains("exactly one question")
+        #expect(containsOneQuestion, "Expected 'one question' guidance in interview prompt")
+    }
+
+    // MARK: OPQRST framework
+
+    @Test("Interview prompt references the OPQRST framework")
+    func opqrstFramework() {
+        #expect(prompt.contains("OPQRST"), "Expected OPQRST acronym/framework in interview prompt")
+    }
+
+    // MARK: Red-flag / emergency override
+
+    @Test("Interview prompt contains red-flag emergency language")
+    func redFlagLanguage() {
+        let lower = prompt.lowercased()
+        // Must mention emergency services or 911 as the red-flag override action.
+        let hasEmergency = lower.contains("emergency") || lower.contains("911")
+        #expect(hasEmergency, "Expected emergency/red-flag language in interview prompt")
+    }
+
+    // MARK: Safety constraints
+
+    @Test("Interview prompt prohibits stating a definitive diagnosis")
+    func noDefinitiveDiagnosis() {
+        let lower = prompt.lowercased()
+        #expect(
+            lower.contains("definitive diagnosis"),
+            "Expected 'definitive diagnosis' prohibition in interview prompt safety constraints"
+        )
+    }
+
+    @Test("Interview prompt includes professional-care disclaimer ('not a substitute')")
+    func professionalCareDisclaimer() {
+        let lower = prompt.lowercased()
+        #expect(
+            lower.contains("not a substitute"),
+            "Expected 'not a substitute' professional-care disclaimer in interview prompt"
+        )
+    }
+
+    // MARK: Few-shot exemplar
+
+    @Test("Interview prompt includes a few-shot exemplar section")
+    func fewShotExemplar() {
+        let lower = prompt.lowercased()
+        // The exemplar is labelled "EXAMPLE" and contains Patient/Clinician exchange.
+        let hasExampleLabel = lower.contains("example")
+        let hasExchangeFormat = prompt.contains("Patient:") && prompt.contains("Clinician:")
+        #expect(hasExampleLabel, "Expected 'EXAMPLE' label in interview prompt few-shot section")
+        #expect(hasExchangeFormat, "Expected Patient:/Clinician: exchange in interview prompt few-shot exemplar")
+    }
+}
+
+// MARK: - HealthcareSystemPrompt — summary (closing) variant
+
+@Suite("HealthcareSystemPrompt.summary content invariants")
+struct SummaryPromptTests {
+
+    private let prompt = HealthcareSystemPrompt.summary
+
+    // MARK: History summary instruction
+
+    @Test("Summary prompt instructs a history summary section")
+    func historySummarySection() {
+        let lower = prompt.lowercased()
+        #expect(
+            lower.contains("history summary") || lower.contains("summary"),
+            "Expected history summary instruction in summary prompt"
+        )
+    }
+
+    // MARK: Preliminary non-diagnostic guidance
+
+    @Test("Summary prompt includes preliminary non-diagnostic guidance")
+    func preliminaryNonDiagnosticGuidance() {
+        let lower = prompt.lowercased()
+        let hasPreliminary = lower.contains("preliminary") || lower.contains("non-diagnostic")
+        #expect(
+            hasPreliminary,
+            "Expected 'preliminary' or 'non-diagnostic' guidance instruction in summary prompt"
+        )
+    }
+
+    @Test("Summary prompt prohibits stating a definitive diagnosis")
+    func noDefinitiveDiagnosis() {
+        let lower = prompt.lowercased()
+        #expect(
+            lower.contains("definitive diagnosis"),
+            "Expected 'definitive diagnosis' prohibition in summary prompt"
+        )
+    }
+
+    // MARK: Triage / red-flag advice
+
+    @Test("Summary prompt includes triage and red-flag advice")
+    func triageRedFlagAdvice() {
+        let lower = prompt.lowercased()
+        let hasTriage = lower.contains("triage") || lower.contains("red flag")
+        #expect(hasTriage, "Expected triage/red-flag section in summary prompt")
+    }
+
+    // MARK: Disclaimer
+
+    @Test("Summary prompt ends with professional-care disclaimer")
+    func professionalCareDisclaimer() {
+        let lower = prompt.lowercased()
+        #expect(
+            lower.contains("not a substitute"),
+            "Expected 'not a substitute' disclaimer in summary prompt"
+        )
+    }
+
+    // MARK: No further interview questions
+
+    @Test("Summary prompt explicitly instructs model NOT to ask further interview questions")
+    func noFurtherInterviewQuestions() {
+        let lower = prompt.lowercased()
+        // The prompt must contain a clear instruction to stop asking questions.
+        let hasForbidsQuestions = lower.contains("do not ask") || lower.contains("no further")
+        #expect(
+            hasForbidsQuestions,
+            "Expected instruction not to ask further questions in summary prompt"
+        )
+    }
+}
+
+// MARK: - Per-phase token budgets
+
+@Suite("AIConversationService per-phase token budgets")
+struct InterviewTokenBudgetTests {
+
+    @Test("Gathering budget is 160 tokens")
+    func gatheringBudgetValue() {
+        #expect(AIConversationService.gatheringMaxTokens == 160)
+    }
+
+    @Test("Summary budget is 512 tokens")
+    func summaryBudgetValue() {
+        #expect(AIConversationService.summaryMaxTokens == 512)
+    }
+
+    @Test("Gathering budget is smaller than summary budget")
+    func gatheringLessThanSummary() {
+        #expect(AIConversationService.gatheringMaxTokens < AIConversationService.summaryMaxTokens)
+    }
+}

--- a/HouseCallTests/ClinicalInterviewPromptTests.swift
+++ b/HouseCallTests/ClinicalInterviewPromptTests.swift
@@ -92,7 +92,7 @@ struct SummaryPromptTests {
     func historySummarySection() {
         let lower = prompt.lowercased()
         #expect(
-            lower.contains("history summary") || lower.contains("summary"),
+            lower.contains("history summary"),
             "Expected history summary instruction in summary prompt"
         )
     }

--- a/HouseCallTests/InterviewPhaseTransitionTests.swift
+++ b/HouseCallTests/InterviewPhaseTransitionTests.swift
@@ -1,0 +1,308 @@
+//
+//  InterviewPhaseTransitionTests.swift
+//  HouseCallTests
+//
+//  Unit tests for AIConversationService phase-state transitions and
+//  per-phase prompt/budget routing.
+//
+//  Spec: openspec/changes/add-clinical-interview-mode/tasks.md — Task 5.2
+//
+//  Test coverage:
+//  1. Default interviewPhase is .gathering.
+//  2. requestSummary forwards HealthcareSystemPrompt.summary + summaryMaxTokens to the provider.
+//  3. sendMessage (gathering) forwards HealthcareSystemPrompt.interview + gatheringMaxTokens.
+//  4. interviewPhase resets to .gathering after a successful summary turn.
+//  5. interviewPhase resets to .gathering even when the summary turn fails synchronously.
+//
+
+import Testing
+import CoreData
+import CryptoKit
+@testable import HouseCall
+
+@Suite("Interview Phase Transition Tests")
+@MainActor
+struct InterviewPhaseTransitionTests {
+
+    // MARK: - Isolated Test Infrastructure
+
+    /// Creates a fresh in-memory Core Data context for test isolation.
+    func makeContext() -> NSManagedObjectContext {
+        let container = NSPersistentContainer(
+            name: "HouseCall",
+            managedObjectModel: TestCoreDataModel.shared
+        )
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Failed to load in-memory store: \(error)")
+            }
+        }
+        return container.viewContext
+    }
+
+    /// Creates a fully isolated `AIConversationService` with a per-test
+    /// `EncryptionManager` instance backed by an in-memory keychain.
+    ///
+    /// A per-test isolated `EncryptionManager` avoids the known parallel-test
+    /// encryption race where `SecurityTests.clearCache()` wipes the shared
+    /// singleton's master key mid-test, causing decryption of content encrypted
+    /// under the original key to fail.
+    ///
+    /// The supplied `provider` is injected via `_testProviderOverride` so no
+    /// real network or API key is needed.
+    func makeService(
+        context: NSManagedObjectContext,
+        userId: UUID,
+        provider: LLMProvider
+    ) -> AIConversationService {
+        let localKeychain = InMemoryKeychainManager()
+        let localEncryption = EncryptionManager._testMakeInstance(keychainManager: localKeychain)
+        localEncryption._testInjectMasterKey(SymmetricKey(size: .bits256))
+
+        let conversationRepo = CoreDataConversationRepository(
+            context: context,
+            encryptionManager: localEncryption,
+            auditLogger: AuditLogger(context: context)
+        )
+        let messageRepo = CoreDataMessageRepository(
+            context: context,
+            encryptionManager: localEncryption,
+            auditLogger: AuditLogger(context: context)
+        )
+        let service = AIConversationService(
+            userId: userId,
+            conversationRepository: conversationRepo,
+            messageRepository: messageRepo,
+            providerConfigManager: LLMProviderConfigManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        service._testProviderOverride = provider
+        return service
+    }
+
+    // MARK: - Test 1: Default Phase
+
+    @Test("Default interviewPhase is .gathering on a freshly constructed service")
+    func testDefaultPhaseIsGathering() async throws {
+        let context = makeContext()
+        let userId = UUID()
+        let capturer = CapturingStubProvider()
+        let service = makeService(context: context, userId: userId, provider: capturer)
+
+        #expect(service.interviewPhase == .gathering)
+    }
+
+    // MARK: - Test 2: Summary Turn — Prompt and Budget
+
+    @Test("requestSummary sends HealthcareSystemPrompt.summary and summaryMaxTokens to the provider")
+    func testSummaryTurnUsesSummaryPromptAndBudget() async throws {
+        let context = makeContext()
+        let userId = UUID()
+        let capturer = CapturingStubProvider()
+        let service = makeService(context: context, userId: userId, provider: capturer)
+
+        // Create a conversation and run one gathering turn so there is history to summarise.
+        let conversation = try await service.createConversation()
+        try await service.sendMessage(conversationId: conversation.id!, content: "I have a sore throat")
+
+        // Drain the main-actor Tasks spawned by handleStreamChunk / handleStreamComplete
+        // so the gathering turn's assistant message is fully persisted before the
+        // summary turn's buildChatContext fetches the message history.
+        for _ in 0..<10 { await Task.yield() }
+
+        // Clear captures from the gathering turn before asserting the summary turn.
+        capturer.reset()
+
+        // Run the summary turn.
+        try await service.requestSummary(conversationId: conversation.id!)
+
+        // streamCompletion is awaited inside requestSummary, so captures are ready now.
+        let capturedMsgs  = capturer.capturedMessages
+        let capturedTokens = capturer.capturedMaxTokens
+
+        #expect(
+            !capturedMsgs.isEmpty,
+            "Provider must receive at least a system message for the summary turn"
+        )
+        #expect(
+            capturedMsgs.first?.role == .system,
+            "The leading message must be the system role"
+        )
+        #expect(
+            capturedMsgs.first?.content == HealthcareSystemPrompt.summary,
+            "System message content must equal HealthcareSystemPrompt.summary for a summary turn"
+        )
+        let summaryBudget = AIConversationService.summaryMaxTokens
+        #expect(
+            capturedTokens == summaryBudget,
+            "maxTokensOverride must equal summaryMaxTokens (\(summaryBudget)) — got \(String(describing: capturedTokens))"
+        )
+    }
+
+    // MARK: - Test 3: Gathering Turn — Prompt and Budget
+
+    @Test("sendMessage sends HealthcareSystemPrompt.interview and gatheringMaxTokens to the provider")
+    func testGatheringTurnUsesInterviewPromptAndBudget() async throws {
+        let context = makeContext()
+        let userId = UUID()
+        let capturer = CapturingStubProvider()
+        let service = makeService(context: context, userId: userId, provider: capturer)
+
+        let conversation = try await service.createConversation()
+
+        // sendMessage (default summaryTurn: false) is the gathering path.
+        try await service.sendMessage(conversationId: conversation.id!, content: "I have a headache")
+
+        // streamCompletion is awaited synchronously inside sendMessage, so captures
+        // are ready immediately — no yield needed for the prompt/budget assertions.
+        let capturedMsgs  = capturer.capturedMessages
+        let capturedTokens = capturer.capturedMaxTokens
+
+        #expect(
+            !capturedMsgs.isEmpty,
+            "Provider must receive at least a system message for the gathering turn"
+        )
+        #expect(
+            capturedMsgs.first?.role == .system,
+            "The leading message must be the system role"
+        )
+        #expect(
+            capturedMsgs.first?.content == HealthcareSystemPrompt.interview,
+            "System message content must equal HealthcareSystemPrompt.interview for a gathering turn"
+        )
+        let gatheringBudget = AIConversationService.gatheringMaxTokens
+        #expect(
+            capturedTokens == gatheringBudget,
+            "maxTokensOverride must equal gatheringMaxTokens (\(gatheringBudget)) — got \(String(describing: capturedTokens))"
+        )
+    }
+
+    // MARK: - Test 4: Phase Resets After Successful Summary Turn
+
+    @Test("interviewPhase resets to .gathering after a successful summary turn")
+    func testPhaseResetsAfterSuccessfulSummaryTurn() async throws {
+        let context = makeContext()
+        let userId = UUID()
+        let capturer = CapturingStubProvider()
+        let service = makeService(context: context, userId: userId, provider: capturer)
+
+        let conversation = try await service.createConversation()
+        try await service.sendMessage(conversationId: conversation.id!, content: "I have fatigue")
+
+        // Drain gathering turn Tasks so the history is ready.
+        for _ in 0..<10 { await Task.yield() }
+
+        // Confirm precondition: phase is .gathering before the summary turn.
+        #expect(service.interviewPhase == .gathering, "Precondition: phase must start as .gathering")
+
+        try await service.requestSummary(conversationId: conversation.id!)
+
+        // handleStreamComplete (which resets interviewPhase) runs as a spawned
+        // Task { @MainActor in … }. Yield to drain it.
+        for _ in 0..<10 { await Task.yield() }
+
+        #expect(
+            service.interviewPhase == .gathering,
+            "interviewPhase must reset to .gathering after a successful summary turn completes"
+        )
+    }
+
+    // MARK: - Test 5: Phase Resets After Failed Summary Turn
+
+    @Test("interviewPhase resets to .gathering when the summary turn fails")
+    func testPhaseResetsAfterFailedSummaryTurn() async throws {
+        let context = makeContext()
+        let userId = UUID()
+        // ThrowingStubProvider throws synchronously from streamCompletion,
+        // which triggers the synchronous catch in requestSummary and immediately
+        // resets interviewPhase without requiring a Task yield.
+        let thrower = ThrowingStubProvider()
+        let service = makeService(context: context, userId: userId, provider: thrower)
+
+        // Only a conversation is needed; requestSummary does not require user messages.
+        let conversation = try await service.createConversation()
+
+        var caughtError: Error?
+        do {
+            try await service.requestSummary(conversationId: conversation.id!)
+        } catch {
+            caughtError = error
+        }
+
+        #expect(caughtError != nil, "requestSummary must surface the provider's error")
+        #expect(
+            service.interviewPhase == .gathering,
+            "interviewPhase must reset to .gathering after a failed summary turn"
+        )
+    }
+}
+
+// MARK: - CapturingStubProvider
+
+/// An `LLMProvider` that records the `messages` array and `maxTokensOverride`
+/// from each `streamCompletion` invocation, then emits a single-chunk success so
+/// the service's completion path runs cleanly.
+///
+/// Call `reset()` between turns to clear state from prior invocations.
+private final class CapturingStubProvider: LLMProvider {
+    let providerType: LLMProviderType = .openai
+    let isConfigured: Bool = true
+
+    /// Messages received in the most recent `streamCompletion` call.
+    private(set) var capturedMessages: [ChatMessage] = []
+
+    /// `maxTokensOverride` received in the most recent `streamCompletion` call.
+    private(set) var capturedMaxTokens: Int?
+
+    /// Clears captured state from a prior turn so that the next assertion
+    /// reflects only the turn under test.
+    func reset() {
+        capturedMessages = []
+        capturedMaxTokens = nil
+    }
+
+    func streamCompletion(
+        messages: [ChatMessage],
+        maxTokensOverride: Int?,
+        onChunk: @escaping (String) -> Void,
+        onComplete: @escaping (Result<String, LLMError>) -> Void
+    ) async throws {
+        capturedMessages = messages
+        capturedMaxTokens = maxTokensOverride
+        let response = "Capturing stub response."
+        onChunk(response)
+        onComplete(.success(response))
+    }
+
+    func cancelStreaming() {}
+}
+
+// MARK: - ThrowingStubProvider
+
+/// An `LLMProvider` whose `streamCompletion` always throws synchronously.
+///
+/// Used by `testPhaseResetsAfterFailedSummaryTurn` to verify that
+/// `requestSummary` resets `interviewPhase` to `.gathering` via its synchronous
+/// `catch` block when the stream setup fails before any chunks arrive.
+private final class ThrowingStubProvider: LLMProvider {
+    let providerType: LLMProviderType = .openai
+    let isConfigured: Bool = true
+
+    func streamCompletion(
+        messages: [ChatMessage],
+        maxTokensOverride: Int?,
+        onChunk: @escaping (String) -> Void,
+        onComplete: @escaping (Result<String, LLMError>) -> Void
+    ) async throws {
+        throw LLMError.networkError(NSError(
+            domain: "ThrowingStubProvider",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "Stubbed synchronous failure for phase-reset test"]
+        ))
+    }
+
+    func cancelStreaming() {}
+}

--- a/openspec/changes/add-clinical-interview-mode/tasks.md
+++ b/openspec/changes/add-clinical-interview-mode/tasks.md
@@ -55,11 +55,11 @@ with an accessibility identifier, wired to `requestSummary()`.
 Assert the interview/summary prompt content invariants (one-question guidance,
 disclaimer present, red-flag language) and the per-phase token budgets.
 
-### Task 5.2: Phase-state and summary-turn tests
+### Task 5.2: Phase-state and summary-turn tests  [x]
 Cover the `gathering → summary → gathering` transition and that the summary turn
 uses the summary prompt + larger budget (using the existing test provider
 override).
 
-### Task 5.3: Manual evaluation against local Ollama
+### Task 5.3: Manual evaluation against local Ollama  [ ] (manual — pending user validation)
 Verify with `medgemma:4b` that gathering turns are short single questions and
 the summarize action produces a coherent structured summary.

--- a/openspec/changes/add-clinical-interview-mode/tasks.md
+++ b/openspec/changes/add-clinical-interview-mode/tasks.md
@@ -51,7 +51,7 @@ with an accessibility identifier, wired to `requestSummary()`.
 
 ## Phase 5: Tests and evaluation
 
-### Task 5.1: Prompt and parameter unit tests
+### Task 5.1: Prompt and parameter unit tests  [x]
 Assert the interview/summary prompt content invariants (one-question guidance,
 disclaimer present, red-flag language) and the per-phase token budgets.
 


### PR DESCRIPTION
Phase 5 of `add-clinical-interview-mode`: automated coverage for the new clinical-interview behavior.

## Tasks
- [x] 5.1 `ClinicalInterviewPromptTests` (15 tests): interview/summary prompt invariants (one-question, OPQRST, red-flag, no-diagnosis, disclaimer, few-shot; summary: summary+guidance+triage+disclaimer+no-further-questions) and token budgets (gathering 160 < summary 512). Budget constants made `internal` to test the real symbols.
- [x] 5.2 `InterviewPhaseTransitionTests` (5 tests): default `.gathering`; summary turn captures `HealthcareSystemPrompt.summary` + 512 budget; gathering turn captures `.interview` + 160; phase resets to `.gathering` after success and after failure. Per-test isolated EncryptionManager (avoids the parallel race).
- [ ] 5.3 Manual evaluation against local Ollama `medgemma:4b` — **pending user validation** (bead HouseCall-55n deferred). Verify gathering turns are short single questions and the Summarize action yields a coherent structured summary.

## Beads closed
HouseCall-90y (#122), HouseCall-cg4 (#121). Deferred: HouseCall-55n (#120, manual).

## Test
Full `HouseCallTests`: 487 passed (20 new). Remaining flakes are the known parallel-execution race, pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)