### PR TITLE
add-clinical-soap-review-workflow: Phase 1 — Server-side interview engine

### DIFF
--- a/backend/internal/agent/drafter.go
+++ b/backend/internal/agent/drafter.go
@@ -12,6 +12,18 @@ import (
 	"github.com/markolonius/housecall/backend/internal/store"
 )
 
+// DefaultMaxInterviewTurns is the maximum number of assistant-role turns the
+// interview is allowed to produce before the runtime must force a SOAP note
+// draft. If the model never emits ReadyForNoteMarker the safety cap prevents
+// an interview from running indefinitely.
+//
+// Callers that need a different limit can pass a custom value to
+// interviewTurnCapReached; this constant is the production default.
+// Enforcement (switching from interview to draft when the cap is reached) is
+// wired in Tasks 1.3 and 2.2; this task only defines the constant and the
+// pure helper function.
+const DefaultMaxInterviewTurns = 12
+
 // ModelClient is the narrow interface the Drafter needs from the model. Using
 // an interface rather than *Client directly lets tests inject a stub without
 // standing up a real model endpoint.
@@ -217,6 +229,69 @@ func (d *Drafter) draft(ctx context.Context, tenantID store.TenantID, conv store
 	}))
 
 	return nil
+}
+
+// generateInterviewTurn assembles the full tenant-scoped conversation history
+// and calls the model to produce the next interview question. The leading
+// message in the model call is always InterviewSystemPrompt (system role) so
+// the model stays in interview mode; the rest is the raw conversation history.
+//
+// Error discipline mirrors draft(): a non-nil error means no usable model
+// output was obtained — the caller must not treat the returned string as
+// clinical content. Message content is never logged (PHI constraint). The
+// error type carries enough coarse information for draftFailureReason to
+// classify it without inspecting the body.
+//
+// Task 1.3 is responsible for inspecting the returned text for
+// ReadyForNoteMarker and branching between delivering an interview question
+// and triggering SOAP note drafting. This method is intentionally output-
+// agnostic: it returns whatever the model produced.
+func (d *Drafter) generateInterviewTurn(ctx context.Context, tenantID store.TenantID, conv store.Conversation) (string, error) {
+	// Fetch the full conversation history scoped to this tenant. The query
+	// includes tenant_id in the WHERE clause so cross-tenant bleed is
+	// impossible even when two tenants share a conversation UUID.
+	msgs, err := d.store.ListMessagesByConversation(ctx, tenantID, conv.ID)
+	if err != nil {
+		return "", err
+	}
+
+	// Build the model message slice: the clinical interview system prompt as
+	// the sole system message, followed by every stored turn in order.
+	// Content goes to the model call only — never written to logs or audit.
+	modelMsgs := make([]Message, 0, len(msgs)+1)
+	modelMsgs = append(modelMsgs, Message{
+		Role:    "system",
+		Content: InterviewSystemPrompt,
+	})
+	for _, m := range msgs {
+		modelMsgs = append(modelMsgs, Message{
+			Role:    m.Role,
+			Content: m.Content,
+		})
+	}
+
+	return d.client.Complete(ctx, modelMsgs)
+}
+
+// interviewTurnCapReached reports whether the number of assistant-role turns
+// already present in msgs has reached or exceeded max. When true, the agent
+// runtime should switch from interviewing to SOAP note drafting regardless of
+// whether ReadyForNoteMarker has been emitted, so an interview cannot run
+// unbounded.
+//
+// Only "assistant" role messages are counted — "user" messages (patient input)
+// and "system" messages do not count toward the cap.
+//
+// The function is pure and side-effect-free so it can be unit-tested in
+// isolation without a store or model client.
+func interviewTurnCapReached(msgs []store.Message, max int) bool {
+	count := 0
+	for _, m := range msgs {
+		if m.Role == "assistant" {
+			count++
+		}
+	}
+	return count >= max
 }
 
 // draftFailureReason maps a draft error to a coarse, safe string reason that

--- a/backend/internal/agent/interview_outcome.go
+++ b/backend/internal/agent/interview_outcome.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"strings"
+
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// InterviewOutcome is the result of classifying one raw model turn. It is a
+// value type with no I/O and no logging so it is safe to use anywhere — even
+// in the hot path where PHI would otherwise leak through logs.
+//
+// Exactly one of the two semantic states is true for every turn:
+//   - ReadyForNote == true  → the interview is complete; draft the SOAP note
+//     now. Question is always empty in this state.
+//   - ReadyForNote == false → continue the interview; deliver Question to the
+//     patient as the next history-taking question.
+type InterviewOutcome struct {
+	// ReadyForNote is true when the agent runtime should stop interviewing and
+	// switch to SOAP note drafting. This happens either because the model
+	// voluntarily emitted ReadyForNoteMarker or because the turn cap was
+	// reached (forced draft). Question is always empty when ReadyForNote is true.
+	ReadyForNote bool
+
+	// Question is the trimmed interview question to deliver to the patient. It
+	// is non-empty only when ReadyForNote is false. When ReadyForNote is true,
+	// Question is always "".
+	Question string
+}
+
+// parseInterviewTurn inspects the raw model output from one interview turn and
+// classifies it as either a readiness signal or an interview question.
+//
+// If raw contains ReadyForNoteMarker (the constant defined in prompt.go), the
+// turn is treated as a readiness signal: the function returns
+// InterviewOutcome{ReadyForNote: true, Question: ""} and discards all text —
+// neither the marker nor any prefix or suffix text is returned as a question.
+// This prevents the server-internal marker token from ever being forwarded to
+// the patient, and discards any partial question text the model may have emitted
+// before or after the marker in the same turn.
+//
+// The check is tolerant of surrounding whitespace and newlines: it uses
+// strings.Contains against the unmodified raw string, so the marker is detected
+// whether it appears on its own line, at the start, at the end, or embedded in
+// surrounding whitespace.
+//
+// If raw does not contain ReadyForNoteMarker, the trimmed raw text is returned
+// as the interview question.
+//
+// Constraints: pure function, no I/O, no logging. raw is never written to any
+// log or audit trail (PHI constraint).
+func parseInterviewTurn(raw string) InterviewOutcome {
+	if strings.Contains(raw, ReadyForNoteMarker) {
+		return InterviewOutcome{ReadyForNote: true}
+	}
+	return InterviewOutcome{Question: strings.TrimSpace(raw)}
+}
+
+// decideInterviewAction returns whether to draft the SOAP note now — either
+// because the model voluntarily signalled readiness or because the turn cap
+// was reached — and, when continuing the interview, the question to deliver.
+//
+// Precedence (highest to lowest):
+//
+//  1. Model emitted ReadyForNoteMarker → ReadyForNote true (voluntary completion).
+//     All marker and surrounding text is discarded; Question is "".
+//  2. Turn cap reached (assistant-role turns in priorMsgs >= maxTurns) →
+//     ReadyForNote true (forced draft). Question is "" regardless of what the
+//     model said. This prevents an interview from running unbounded if the model
+//     never emits the marker.
+//  3. Neither → ReadyForNote false; the model's trimmed output is returned as
+//     Question.
+//
+// priorMsgs must contain the conversation messages that were present BEFORE this
+// turn (i.e., not including the turn being classified). maxTurns is typically
+// DefaultMaxInterviewTurns but callers may pass a custom value for testing.
+//
+// Constraints: pure function, no I/O, no logging. raw is never written to any
+// log or audit trail (PHI constraint).
+func decideInterviewAction(raw string, priorMsgs []store.Message, maxTurns int) InterviewOutcome {
+	outcome := parseInterviewTurn(raw)
+	if outcome.ReadyForNote {
+		// Rule 1: model voluntarily signalled readiness — highest precedence.
+		return outcome
+	}
+	if interviewTurnCapReached(priorMsgs, maxTurns) {
+		// Rule 2: turn cap exhausted — force a draft regardless of the model
+		// output. Return a clean ReadyForNote outcome with no question so the
+		// caller does not accidentally deliver partial output.
+		return InterviewOutcome{ReadyForNote: true}
+	}
+	// Rule 3: continue the interview with the model's question.
+	return outcome
+}

--- a/backend/internal/agent/interview_outcome_test.go
+++ b/backend/internal/agent/interview_outcome_test.go
@@ -1,0 +1,320 @@
+// Package agent — unit tests for parseInterviewTurn and decideInterviewAction
+// (Task 1.3).
+//
+// All tests in this file are pure: no DB, no model client, no I/O. They use
+// the internal package access of "package agent" to reach unexported helpers.
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Tests: parseInterviewTurn
+// ---------------------------------------------------------------------------
+
+// TestParseInterviewTurn_MarkerAlone verifies that a raw string consisting only
+// of ReadyForNoteMarker (with whitespace trimmed) returns ReadyForNote true and
+// an empty Question.
+func TestParseInterviewTurn_MarkerAlone(t *testing.T) {
+	raw := ReadyForNoteMarker
+	got := parseInterviewTurn(raw)
+	if !got.ReadyForNote {
+		t.Errorf("ReadyForNote = false, want true for raw = %q", raw)
+	}
+	if got.Question != "" {
+		t.Errorf("Question = %q, want \"\" when ReadyForNote is true", got.Question)
+	}
+}
+
+// TestParseInterviewTurn_MarkerOnOwnLineAfterQuestion verifies that when the
+// model emits some text followed by a newline and then the marker, the result is
+// ReadyForNote true with no question — the text before the marker is discarded.
+func TestParseInterviewTurn_MarkerOnOwnLineAfterQuestion(t *testing.T) {
+	raw := "Do you have any known allergies?\n" + ReadyForNoteMarker
+	got := parseInterviewTurn(raw)
+	if !got.ReadyForNote {
+		t.Errorf("ReadyForNote = false, want true; raw = %q", raw)
+	}
+	if got.Question != "" {
+		t.Errorf("Question = %q, want \"\" — pre-marker text must be discarded", got.Question)
+	}
+}
+
+// TestParseInterviewTurn_MarkerWithTrailingText verifies that text after the
+// marker is also discarded: ReadyForNote is true and Question is empty.
+func TestParseInterviewTurn_MarkerWithTrailingText(t *testing.T) {
+	raw := ReadyForNoteMarker + "\nSome additional text the model appended."
+	got := parseInterviewTurn(raw)
+	if !got.ReadyForNote {
+		t.Errorf("ReadyForNote = false, want true; raw = %q", raw)
+	}
+	if got.Question != "" {
+		t.Errorf("Question = %q, want \"\" — trailing text must be discarded", got.Question)
+	}
+}
+
+// TestParseInterviewTurn_MarkerEmbeddedBothSides verifies that marker embedded
+// between a preamble and trailing content is still detected; all text is
+// discarded and ReadyForNote is true.
+func TestParseInterviewTurn_MarkerEmbeddedBothSides(t *testing.T) {
+	raw := "Some prefix text.\n" + ReadyForNoteMarker + "\nSome trailing text."
+	got := parseInterviewTurn(raw)
+	if !got.ReadyForNote {
+		t.Errorf("ReadyForNote = false, want true; raw = %q", raw)
+	}
+	if got.Question != "" {
+		t.Errorf("Question = %q, want \"\"", got.Question)
+	}
+}
+
+// TestParseInterviewTurn_NoMarker_QuestionReturned verifies that when the raw
+// string contains no marker, ReadyForNote is false and Question equals the
+// trimmed raw text.
+func TestParseInterviewTurn_NoMarker_QuestionReturned(t *testing.T) {
+	const wantQ = "How would you rate the pain on a scale of 0 to 10?"
+	raw := "  " + wantQ + "  "
+	got := parseInterviewTurn(raw)
+	if got.ReadyForNote {
+		t.Errorf("ReadyForNote = true, want false for a normal question")
+	}
+	if got.Question != wantQ {
+		t.Errorf("Question = %q, want %q", got.Question, wantQ)
+	}
+}
+
+// TestParseInterviewTurn_NoMarker_WhitespaceTrimmed verifies that leading and
+// trailing whitespace (including newlines) is stripped from the returned Question
+// when no marker is present.
+func TestParseInterviewTurn_NoMarker_WhitespaceTrimmed(t *testing.T) {
+	const inner = "When did the pain start?"
+	raw := "\n\t  " + inner + "  \n\t"
+	got := parseInterviewTurn(raw)
+	if got.ReadyForNote {
+		t.Error("ReadyForNote = true, want false")
+	}
+	if got.Question != inner {
+		t.Errorf("Question = %q, want %q (whitespace not trimmed)", got.Question, inner)
+	}
+}
+
+// TestParseInterviewTurn_WhitespaceSurroundingMarker verifies that the marker is
+// detected even when it is surrounded by whitespace characters (spaces, newlines,
+// tabs), matching the tolerance requirement.
+func TestParseInterviewTurn_WhitespaceSurroundingMarker(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"leading spaces", "   " + ReadyForNoteMarker},
+		{"trailing spaces", ReadyForNoteMarker + "   "},
+		{"leading newline", "\n" + ReadyForNoteMarker},
+		{"trailing newline", ReadyForNoteMarker + "\n"},
+		{"tabs and newlines", "\t\n  " + ReadyForNoteMarker + "  \t\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseInterviewTurn(tc.raw)
+			if !got.ReadyForNote {
+				t.Errorf("ReadyForNote = false, want true; raw = %q", tc.raw)
+			}
+			if got.Question != "" {
+				t.Errorf("Question = %q, want \"\"", got.Question)
+			}
+		})
+	}
+}
+
+// TestParseInterviewTurn_MarkerConstantUsed verifies that the check is driven by
+// the ReadyForNoteMarker constant and not a hardcoded literal: a string that
+// contains ReadyForNoteMarker (built from the constant) must be detected, and
+// a string that replaces the angle brackets with different delimiters must not.
+func TestParseInterviewTurn_MarkerConstantUsed(t *testing.T) {
+	// Built from the constant — must be detected.
+	rawWithMarker := "Some text\n" + ReadyForNoteMarker + "\n"
+	if got := parseInterviewTurn(rawWithMarker); !got.ReadyForNote {
+		t.Errorf("expected ReadyForNote true for string built with ReadyForNoteMarker constant")
+	}
+
+	// Different delimiters — must NOT be detected.
+	mangled := strings.ReplaceAll(ReadyForNoteMarker, "<", "[")
+	mangled = strings.ReplaceAll(mangled, ">", "]")
+	if got := parseInterviewTurn(mangled); got.ReadyForNote {
+		t.Errorf("expected ReadyForNote false for mangled marker %q", mangled)
+	}
+}
+
+// TestParseInterviewTurn_EmptyString verifies that an empty raw string returns
+// ReadyForNote false with an empty Question (not a panic).
+func TestParseInterviewTurn_EmptyString(t *testing.T) {
+	got := parseInterviewTurn("")
+	if got.ReadyForNote {
+		t.Error("ReadyForNote = true, want false for empty string")
+	}
+	if got.Question != "" {
+		t.Errorf("Question = %q, want \"\" for empty string", got.Question)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: decideInterviewAction
+// ---------------------------------------------------------------------------
+
+// TestDecideInterviewAction_MarkerWins_BelowCap verifies that when the model
+// emits ReadyForNoteMarker, the outcome is ReadyForNote regardless of whether
+// the turn cap has been reached (marker has highest precedence).
+func TestDecideInterviewAction_MarkerWins_BelowCap(t *testing.T) {
+	// priorMsgs has only 1 assistant turn — well below DefaultMaxInterviewTurns.
+	priorMsgs := makeTestMessages("user", "assistant")
+	raw := ReadyForNoteMarker
+	got := decideInterviewAction(raw, priorMsgs, DefaultMaxInterviewTurns)
+	if !got.ReadyForNote {
+		t.Errorf("ReadyForNote = false, want true when marker present")
+	}
+	if got.Question != "" {
+		t.Errorf("Question = %q, want \"\"", got.Question)
+	}
+}
+
+// TestDecideInterviewAction_MarkerWins_AtCap verifies that the marker still wins
+// when the cap would independently force a draft (both are ReadyForNote true, but
+// the code takes the marker path first).
+func TestDecideInterviewAction_MarkerWins_AtCap(t *testing.T) {
+	// Exactly DefaultMaxInterviewTurns assistant turns.
+	roles := make([]string, DefaultMaxInterviewTurns*2)
+	for i := range roles {
+		if i%2 == 0 {
+			roles[i] = "user"
+		} else {
+			roles[i] = "assistant"
+		}
+	}
+	priorMsgs := makeTestMessages(roles...)
+	raw := "Good to know.\n" + ReadyForNoteMarker
+	got := decideInterviewAction(raw, priorMsgs, DefaultMaxInterviewTurns)
+	if !got.ReadyForNote {
+		t.Errorf("ReadyForNote = false, want true")
+	}
+	if got.Question != "" {
+		t.Errorf("Question = %q, want \"\"", got.Question)
+	}
+}
+
+// TestDecideInterviewAction_CapForcesDraft verifies that when the turn cap is
+// reached and the model did NOT emit the marker, the outcome is still
+// ReadyForNote true (forced draft) with an empty Question.
+func TestDecideInterviewAction_CapForcesDraft(t *testing.T) {
+	// Exactly DefaultMaxInterviewTurns assistant turns, no marker.
+	roles := make([]string, DefaultMaxInterviewTurns*2)
+	for i := range roles {
+		if i%2 == 0 {
+			roles[i] = "user"
+		} else {
+			roles[i] = "assistant"
+		}
+	}
+	priorMsgs := makeTestMessages(roles...)
+	const raw = "Do you have a family history of diabetes?"
+	got := decideInterviewAction(raw, priorMsgs, DefaultMaxInterviewTurns)
+	if !got.ReadyForNote {
+		t.Errorf("ReadyForNote = false, want true when cap reached without marker")
+	}
+	if got.Question != "" {
+		t.Errorf("Question = %q, want \"\" on forced draft", got.Question)
+	}
+}
+
+// TestDecideInterviewAction_CapForcesDraft_AboveCap verifies that exceeding the
+// cap also forces a draft (not just reaching it exactly).
+func TestDecideInterviewAction_CapForcesDraft_AboveCap(t *testing.T) {
+	// DefaultMaxInterviewTurns + 2 assistant turns.
+	count := DefaultMaxInterviewTurns + 2
+	roles := make([]string, count*2)
+	for i := range roles {
+		if i%2 == 0 {
+			roles[i] = "user"
+		} else {
+			roles[i] = "assistant"
+		}
+	}
+	priorMsgs := makeTestMessages(roles...)
+	got := decideInterviewAction("Are you on any medication?", priorMsgs, DefaultMaxInterviewTurns)
+	if !got.ReadyForNote {
+		t.Errorf("ReadyForNote = false, want true when above cap")
+	}
+	if got.Question != "" {
+		t.Errorf("Question = %q, want \"\"", got.Question)
+	}
+}
+
+// TestDecideInterviewAction_NormalQuestion verifies the non-terminal path: no
+// marker, cap not reached → ReadyForNote false, Question is the trimmed model
+// output.
+func TestDecideInterviewAction_NormalQuestion(t *testing.T) {
+	// 2 assistant turns, cap is 12 → well below.
+	priorMsgs := makeTestMessages("user", "assistant", "user", "assistant")
+	const wantQ = "On a scale of 0 to 10, how severe is the pain?"
+	raw := "  " + wantQ + "\n"
+	got := decideInterviewAction(raw, priorMsgs, DefaultMaxInterviewTurns)
+	if got.ReadyForNote {
+		t.Errorf("ReadyForNote = true, want false for normal question below cap")
+	}
+	if got.Question != wantQ {
+		t.Errorf("Question = %q, want %q", got.Question, wantQ)
+	}
+}
+
+// TestDecideInterviewAction_EmptyPriorMsgs_NormalQuestion verifies that with no
+// prior messages and no marker, a normal question is returned.
+func TestDecideInterviewAction_EmptyPriorMsgs_NormalQuestion(t *testing.T) {
+	const wantQ = "What brings you in today?"
+	got := decideInterviewAction(wantQ, nil, DefaultMaxInterviewTurns)
+	if got.ReadyForNote {
+		t.Errorf("ReadyForNote = true, want false for first turn with no marker")
+	}
+	if got.Question != wantQ {
+		t.Errorf("Question = %q, want %q", got.Question, wantQ)
+	}
+}
+
+// TestDecideInterviewAction_CustomMaxTurns verifies that a caller-supplied
+// maxTurns different from DefaultMaxInterviewTurns is respected.
+func TestDecideInterviewAction_CustomMaxTurns(t *testing.T) {
+	const customMax = 2
+	// 2 assistant turns → cap reached with customMax=2.
+	priorMsgs := makeTestMessages("user", "assistant", "user", "assistant")
+	got := decideInterviewAction("Anything else you'd like to mention?", priorMsgs, customMax)
+	if !got.ReadyForNote {
+		t.Errorf("ReadyForNote = false, want true: 2 assistant turns at customMax=2")
+	}
+	// Same history but cap=3 → not yet reached.
+	got2 := decideInterviewAction("Anything else you'd like to mention?", priorMsgs, 3)
+	if got2.ReadyForNote {
+		t.Errorf("ReadyForNote = true, want false: 2 assistant turns below cap=3")
+	}
+}
+
+// TestDecideInterviewAction_OneBelowCap_NormalQuestion verifies the boundary:
+// one turn below the cap and no marker → continue interviewing.
+func TestDecideInterviewAction_OneBelowCap_NormalQuestion(t *testing.T) {
+	// DefaultMaxInterviewTurns - 1 assistant turns.
+	count := DefaultMaxInterviewTurns - 1
+	roles := make([]string, count*2)
+	for i := range roles {
+		if i%2 == 0 {
+			roles[i] = "user"
+		} else {
+			roles[i] = "assistant"
+		}
+	}
+	priorMsgs := makeTestMessages(roles...)
+	const wantQ = "Do you smoke or use tobacco products?"
+	got := decideInterviewAction(wantQ, priorMsgs, DefaultMaxInterviewTurns)
+	if got.ReadyForNote {
+		t.Errorf("ReadyForNote = true, want false: one turn below cap, no marker")
+	}
+	if got.Question != wantQ {
+		t.Errorf("Question = %q, want %q", got.Question, wantQ)
+	}
+}

--- a/backend/internal/agent/interview_turn_test.go
+++ b/backend/internal/agent/interview_turn_test.go
@@ -1,0 +1,354 @@
+// Package agent — internal test file for interview-turn generation (Task 1.2).
+//
+// This file uses "package agent" (not "package agent_test") so it can access
+// the unexported generateInterviewTurn and interviewTurnCapReached symbols.
+// DB-backed tests reuse the same TEST_DATABASE_URL convention as drafter_test.go
+// but define their own helpers to avoid cross-package symbol conflicts.
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/markolonius/housecall/backend/internal/migrate"
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Internal test helpers
+// ---------------------------------------------------------------------------
+
+// itTestPool returns a pool connected to TEST_DATABASE_URL with migrations
+// applied. Skips when the env var is unset.
+func itTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping DB-bound test")
+	}
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer conn.Close(ctx)
+
+	if _, err := migrate.Apply(ctx, conn, os.DirFS(itMigrationsDir(t))); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func itMigrationsDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// agent/ → backend/migrations
+	return filepath.Join(filepath.Dir(file), "..", "..", "migrations")
+}
+
+// spyClient captures the messages passed to Complete so tests can assert the
+// model call was assembled correctly. It is intentionally separate from the
+// stubClient in drafter_test.go (different package) and records ALL calls.
+type spyClient struct {
+	// captured holds the message slices from each Complete call, in order.
+	captured [][]Message
+	text     string
+	err      error
+}
+
+func (s *spyClient) Complete(_ context.Context, msgs []Message) (string, error) {
+	// Take a copy so later modifications by the caller don't affect captured.
+	cp := make([]Message, len(msgs))
+	copy(cp, msgs)
+	s.captured = append(s.captured, cp)
+	return s.text, s.err
+}
+
+// itSetupConversation creates the minimum DB rows needed to exercise
+// generateInterviewTurn: one tenant, one patient, one conversation, and the
+// given messages.
+type itFixture struct {
+	TenantID store.TenantID
+	Conv     store.Conversation
+}
+
+func itSetupConversation(t *testing.T, s *store.Store, messages []struct{ Role, Content string }) itFixture {
+	t.Helper()
+	ctx := context.Background()
+	suffix := uuid.New().String()
+
+	tenant, err := s.CreateTenant(ctx, "dtc", "it-test-"+suffix)
+	if err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	tid := store.TenantID(tenant.ID)
+
+	patient, err := s.CreatePatient(ctx, tid, store.Patient{
+		Email:        "p+" + suffix + "@it.test",
+		FullName:     "Test Patient",
+		State:        "CA",
+		PasswordHash: "hash",
+	})
+	if err != nil {
+		t.Fatalf("create patient: %v", err)
+	}
+
+	conv, err := s.CreateConversation(ctx, tid, patient.ID, "interview test")
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	for _, m := range messages {
+		if _, err := s.CreateMessage(ctx, tid, conv.ID, m.Role, m.Content); err != nil {
+			t.Fatalf("create message role=%s: %v", m.Role, err)
+		}
+	}
+
+	return itFixture{TenantID: tid, Conv: conv}
+}
+
+// stubNotifierNoop satisfies PhysicianNotifier for Drafter construction.
+type stubNotifierNoop struct{}
+
+func (stubNotifierNoop) SendToPhysicians(_ string, _ []byte) {}
+
+// ---------------------------------------------------------------------------
+// Tests: generateInterviewTurn
+// ---------------------------------------------------------------------------
+
+// TestGenerateInterviewTurn_LeadingSystemPrompt asserts that generateInterviewTurn
+// always places InterviewSystemPrompt as the first (system-role) message
+// regardless of what is in the conversation history.
+func TestGenerateInterviewTurn_LeadingSystemPrompt(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+
+	msgs := []struct{ Role, Content string }{
+		{"user", "I have a headache."},
+	}
+	f := itSetupConversation(t, s, msgs)
+
+	spy := &spyClient{text: "When did it start?"}
+	d := NewDrafter(spy, s, stubNotifierNoop{})
+
+	_, err := d.generateInterviewTurn(context.Background(), f.TenantID, f.Conv)
+	if err != nil {
+		t.Fatalf("generateInterviewTurn: unexpected error: %v", err)
+	}
+
+	if len(spy.captured) != 1 {
+		t.Fatalf("expected exactly 1 Complete call, got %d", len(spy.captured))
+	}
+	got := spy.captured[0]
+	if len(got) == 0 {
+		t.Fatal("model message slice is empty; expected at least the system prompt")
+	}
+	first := got[0]
+	if first.Role != "system" {
+		t.Errorf("first message role = %q, want %q", first.Role, "system")
+	}
+	if first.Content != InterviewSystemPrompt {
+		t.Errorf("first message content is not InterviewSystemPrompt (got %d chars, want %d chars)",
+			len(first.Content), len(InterviewSystemPrompt))
+	}
+}
+
+// TestGenerateInterviewTurn_ConversationHistory asserts that the full
+// conversation history is appended after the system prompt, in order, with
+// roles and content preserved.
+func TestGenerateInterviewTurn_ConversationHistory(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+
+	seedMsgs := []struct{ Role, Content string }{
+		{"user", "I have a headache."},
+		{"assistant", "When did it start?"},
+		{"user", "Yesterday morning."},
+	}
+	f := itSetupConversation(t, s, seedMsgs)
+
+	spy := &spyClient{text: "How would you rate the pain on a scale of 0-10?"}
+	d := NewDrafter(spy, s, stubNotifierNoop{})
+
+	_, err := d.generateInterviewTurn(context.Background(), f.TenantID, f.Conv)
+	if err != nil {
+		t.Fatalf("generateInterviewTurn: unexpected error: %v", err)
+	}
+
+	if len(spy.captured) != 1 {
+		t.Fatalf("expected exactly 1 Complete call, got %d", len(spy.captured))
+	}
+	got := spy.captured[0]
+
+	// Message slice must be: 1 system + len(seedMsgs) history messages.
+	wantLen := 1 + len(seedMsgs)
+	if len(got) != wantLen {
+		t.Fatalf("model message count = %d, want %d", len(got), wantLen)
+	}
+
+	// Verify system prompt is first.
+	if got[0].Role != "system" || got[0].Content != InterviewSystemPrompt {
+		t.Errorf("got[0] = {%q, %d chars}, want {system, InterviewSystemPrompt}", got[0].Role, len(got[0].Content))
+	}
+
+	// Verify conversation history follows in order.
+	for i, want := range seedMsgs {
+		m := got[i+1]
+		if m.Role != want.Role {
+			t.Errorf("got[%d].Role = %q, want %q", i+1, m.Role, want.Role)
+		}
+		if m.Content != want.Content {
+			t.Errorf("got[%d].Content = %q, want %q", i+1, m.Content, want.Content)
+		}
+	}
+}
+
+// TestGenerateInterviewTurn_ReturnsModelText asserts that generateInterviewTurn
+// returns exactly the string the model client returned.
+func TestGenerateInterviewTurn_ReturnsModelText(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+
+	f := itSetupConversation(t, s, []struct{ Role, Content string }{
+		{"user", "My stomach hurts."},
+	})
+
+	const wantText = "I'm sorry to hear that. Can you point to where the pain is located?"
+	spy := &spyClient{text: wantText}
+	d := NewDrafter(spy, s, stubNotifierNoop{})
+
+	got, err := d.generateInterviewTurn(context.Background(), f.TenantID, f.Conv)
+	if err != nil {
+		t.Fatalf("generateInterviewTurn: unexpected error: %v", err)
+	}
+	if got != wantText {
+		t.Errorf("returned text = %q, want %q", got, wantText)
+	}
+}
+
+// TestGenerateInterviewTurn_PropagatesModelError asserts that a model client
+// error is returned as-is so the caller can classify it via draftFailureReason.
+func TestGenerateInterviewTurn_PropagatesModelError(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+
+	f := itSetupConversation(t, s, []struct{ Role, Content string }{
+		{"user", "My arm hurts."},
+	})
+
+	wantErr := &ModelError{StatusCode: 503}
+	spy := &spyClient{err: wantErr}
+	d := NewDrafter(spy, s, stubNotifierNoop{})
+
+	text, err := d.generateInterviewTurn(context.Background(), f.TenantID, f.Conv)
+	if err == nil {
+		t.Fatal("expected error from model client, got nil")
+	}
+	if text != "" {
+		t.Errorf("expected empty text on error, got %q", text)
+	}
+	var me *ModelError
+	if !errors.As(err, &me) {
+		t.Errorf("expected *ModelError, got %T", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: interviewTurnCapReached (pure — no DB needed)
+// ---------------------------------------------------------------------------
+
+// TestInterviewTurnCapReached_BelowCap verifies that fewer assistant turns
+// than the cap returns false.
+func TestInterviewTurnCapReached_BelowCap(t *testing.T) {
+	msgs := makeTestMessages(
+		"user", "assistant", "user", "assistant", // 2 assistant turns
+	)
+	if interviewTurnCapReached(msgs, 3) {
+		t.Error("expected false when assistant turns (2) < cap (3), got true")
+	}
+}
+
+// TestInterviewTurnCapReached_AtCap verifies that exactly cap assistant turns
+// returns true.
+func TestInterviewTurnCapReached_AtCap(t *testing.T) {
+	msgs := makeTestMessages(
+		"user", "assistant", "user", "assistant", "user", "assistant", // 3 assistant turns
+	)
+	if !interviewTurnCapReached(msgs, 3) {
+		t.Error("expected true when assistant turns (3) == cap (3), got false")
+	}
+}
+
+// TestInterviewTurnCapReached_AboveCap verifies that more than cap assistant
+// turns also returns true.
+func TestInterviewTurnCapReached_AboveCap(t *testing.T) {
+	msgs := makeTestMessages(
+		"user", "assistant", "user", "assistant", "user", "assistant", "user", "assistant", // 4 assistant turns
+	)
+	if !interviewTurnCapReached(msgs, 3) {
+		t.Error("expected true when assistant turns (4) > cap (3), got false")
+	}
+}
+
+// TestInterviewTurnCapReached_NoAssistantTurns verifies that a conversation
+// with only user messages never reaches the cap.
+func TestInterviewTurnCapReached_NoAssistantTurns(t *testing.T) {
+	msgs := makeTestMessages("user", "user", "user")
+	if interviewTurnCapReached(msgs, 1) {
+		t.Error("expected false for all-user conversation even with cap=1, got true")
+	}
+}
+
+// TestInterviewTurnCapReached_EmptyConversation verifies an empty message
+// slice never reaches the cap (as long as cap > 0).
+func TestInterviewTurnCapReached_EmptyConversation(t *testing.T) {
+	if interviewTurnCapReached(nil, DefaultMaxInterviewTurns) {
+		t.Error("expected false for empty message slice, got true")
+	}
+}
+
+// TestInterviewTurnCapReached_DefaultCap verifies the constant DefaultMaxInterviewTurns
+// is 12 (documented production value).
+func TestInterviewTurnCapReached_DefaultCap(t *testing.T) {
+	const want = 12
+	if DefaultMaxInterviewTurns != want {
+		t.Errorf("DefaultMaxInterviewTurns = %d, want %d", DefaultMaxInterviewTurns, want)
+	}
+}
+
+// TestInterviewTurnCapReached_SystemRoleNotCounted verifies that "system" role
+// messages do not count toward the cap.
+func TestInterviewTurnCapReached_SystemRoleNotCounted(t *testing.T) {
+	msgs := makeTestMessages("system", "system", "system") // no assistant turns
+	if interviewTurnCapReached(msgs, 1) {
+		t.Error("system-role messages must not count toward the turn cap")
+	}
+}
+
+// makeTestMessages builds a []store.Message slice from a list of roles, with
+// placeholder content and zero UUIDs. It is a convenience for pure unit tests
+// of interviewTurnCapReached that only care about the Role field.
+func makeTestMessages(roles ...string) []store.Message {
+	out := make([]store.Message, len(roles))
+	for i, r := range roles {
+		out[i] = store.Message{Role: r, Content: "content"}
+	}
+	return out
+}

--- a/backend/internal/agent/prompt.go
+++ b/backend/internal/agent/prompt.go
@@ -1,0 +1,95 @@
+// Package agent implements the AI Agent Runtime. This file defines the
+// clinical interview system prompt and the shared completion-marker constant
+// used by both the prompt and the server-side marker parser (Task 1.3).
+//
+// Nothing in this file is logged or included in audit metadata; the constants
+// are compile-time values consumed only at the point a model message slice is
+// built.
+package agent
+
+// ReadyForNoteMarker is the sentinel token the interview model emits on its own
+// line — and nothing else for that turn — when it judges that enough clinical
+// history has been gathered to write a SOAP note. The agent runtime detects
+// this marker server-side, strips it (and any trailing text), and branches to
+// SOAP note drafting. The marker is never forwarded to the patient; it is a
+// server-internal protocol token, not a clinical message.
+const ReadyForNoteMarker = "<READY_FOR_NOTE>"
+
+// InterviewSystemPrompt instructs the model to act as a clinician conducting a
+// focused history-taking interview. It is used as the system message in every
+// interview turn; the full conversation history follows so the model can track
+// what has already been asked and answered.
+//
+// Design constraints (see design.md Key decisions 1–3):
+//   - One question per turn; no lectures, no lists, no differential dumps.
+//   - No-repeat / no-re-ask: the model MUST read the full history each turn and
+//     skip any dimension the patient already answered.
+//   - Emergency red-flag override: advise emergency care immediately; do not
+//     continue routine questions before giving that advice.
+//   - Safety constraints: never give a definitive diagnosis; recommend a
+//     physician for serious symptoms; responses are preliminary.
+//   - Completion rule: emit ReadyForNoteMarker on its own line (and nothing
+//     else) when sufficient history has been gathered.
+const InterviewSystemPrompt = `You are a licensed clinician conducting a focused medical history interview with a patient. You are NOT a general health-information service. Your sole purpose in this conversation is to gather the clinical history needed to write a SOAP note; a physician will review your note before any assessment or plan is shared with the patient.
+
+## Conversational rules — read carefully before every turn
+
+1. **One question per turn.** Your entire response must be at most two short sentences followed by exactly one question. A brief empathic acknowledgment is allowed (e.g. "I understand, thank you."). No bullet lists. No differential diagnoses. No lectures. No unsolicited information.
+
+2. **No repeating, no re-asking.** Before you write your question, silently read the ENTIRE conversation above. If a piece of information has already been provided — even if the patient mentioned it in passing — do NOT ask for it again. Move to the single most valuable question not yet answered. Ask for clarification only when a prior answer was genuinely ambiguous or incomplete.
+
+3. **Interview structure (follow in order, but skip answered items):**
+   - Chief complaint — open-ended ("What brings you in today?")
+   - History of Present Illness via OPQRST:
+     - Onset — when it started, how it started (sudden vs. gradual)
+     - Provocation / Palliation — what makes it better or worse
+     - Quality — character of the symptom (sharp, dull, aching, burning, etc.)
+     - Region / Radiation — location and any spread
+     - Severity — 0–10 scale or descriptive
+     - Timing — constant vs. intermittent, frequency, duration of episodes
+   - Targeted Review of Systems relevant to the chief complaint
+   - Past Medical History — diagnoses, surgeries, hospitalizations
+   - Current Medications — names, doses, how long taken
+   - Allergies — medications, environmental, food; reaction type
+   - Relevant Social / Family History — only what is clinically pertinent
+
+4. **Question style.** Start with open-ended questions; shift to focused or closed questions once the patient needs to narrow a detail.
+
+5. **Emergency red-flag override.** If the patient reports any emergency feature — chest pain, difficulty breathing, severe or sudden-onset bleeding, signs of stroke (sudden face droop, arm weakness, speech difficulty), severe allergic reaction, altered consciousness, or similar — immediately advise them to call emergency services or go to the nearest emergency room. Give that advice first. Do not ask another routine history question before delivering the emergency advisory.
+
+6. **Safety constraints (always apply):**
+   - Never state or imply a definitive diagnosis.
+   - If symptoms sound serious, recommend the patient see a physician promptly.
+   - Make clear that your questions are for information-gathering only and are not a substitute for professional medical evaluation.
+   - Be empathetic, non-judgmental, and treat all information as confidential.
+
+7. **Completion rule.** When — and only when — you have gathered enough history across all relevant OPQRST dimensions, targeted ROS, PMH, medications, allergies, and social/family history to write a complete SOAP note, output the following marker on its own line and nothing else for that turn:
+
+` + ReadyForNoteMarker + `
+
+Do NOT emit the marker early. Do NOT emit it mid-sentence or with trailing text. The marker must be the sole content of the response when you are ready.
+
+---
+
+## Few-shot exemplar
+
+The following example shows the expected cadence. Notice that in Turn 3 the clinician SKIPS onset (already answered) and asks about severity instead.
+
+**Patient:** I've had a headache for the past two days. It started suddenly yesterday morning.
+
+**Clinician Turn 1 (chief complaint, open-ended):**
+I'm sorry to hear that — headaches can be really uncomfortable. Can you describe what the headache feels like, for example is it throbbing, pressing, or sharp?
+
+**Patient:** It's a throbbing pain on the right side of my head.
+
+**Clinician Turn 2 (region confirmed, moves to provocation/palliation):**
+Thank you. Does anything make the headache better or worse, such as light, noise, movement, or lying down?
+
+**Patient:** Bright light makes it much worse. Lying in a dark room helps a little.
+
+**Clinician Turn 3 (onset already known from first message — SKIP onset, move to severity):**
+That's helpful to know. On a scale of 0 to 10, with 10 being the worst pain you've ever felt, how would you rate the headache right now?
+
+---
+
+Begin the interview with the patient's first message.`

--- a/openspec/changes/add-clinical-soap-review-workflow/tasks.md
+++ b/openspec/changes/add-clinical-soap-review-workflow/tasks.md
@@ -2,7 +2,7 @@
 
 ## Phase 1: Server-side interview engine (backend)
 
-### Task 1.1: Add the clinical interview system prompt server-side
+### Task 1.1: Add the clinical interview system prompt server-side  [x]
 Add the clinician history-taking prompt to the agent runtime (one question per
 turn, OPQRST, red-flag override, safety constraints, no-diagnosis) including the
 no-repeat / no-re-ask-answered instructions and a few-shot exemplar that skips an

--- a/openspec/changes/add-clinical-soap-review-workflow/tasks.md
+++ b/openspec/changes/add-clinical-soap-review-workflow/tasks.md
@@ -9,7 +9,7 @@ no-repeat / no-re-ask-answered instructions and a few-shot exemplar that skips a
 already-answered dimension. Define the completion marker constant
 (`<READY_FOR_NOTE>`) shared by prompt and parser.
 
-### Task 1.2: Generate an interview turn per patient message
+### Task 1.2: Generate an interview turn per patient message  [x]
 Replace the single-shot guidance draft with an interview step: assemble the
 tenant-scoped conversation, call the model, and produce the next turn. Add a
 configurable max-interview-turn safety cap that forces note drafting if exceeded.

--- a/openspec/changes/add-clinical-soap-review-workflow/tasks.md
+++ b/openspec/changes/add-clinical-soap-review-workflow/tasks.md
@@ -14,7 +14,7 @@ Replace the single-shot guidance draft with an interview step: assemble the
 tenant-scoped conversation, call the model, and produce the next turn. Add a
 configurable max-interview-turn safety cap that forces note drafting if exceeded.
 
-### Task 1.3: Detect the completion marker
+### Task 1.3: Detect the completion marker  [x]
 Parse the model output for the marker: if present, strip it (and any trailing
 text) and branch to note drafting; otherwise treat the output as an interview
 question. Marker handling is server-side only and never patient-visible.


### PR DESCRIPTION
Phase 1 of `add-clinical-soap-review-workflow`: server-side clinical interview building blocks (additive — existing guidance draft path untouched, entry-point flip comes in phase 3).

## Tasks
- [x] 1.1 `backend/internal/agent/prompt.go`: `InterviewSystemPrompt` (one question/turn, no-repeat/no-re-ask, OPQRST, red-flag, safety, completion-marker rule, few-shot skipping an answered dimension) + `ReadyForNoteMarker` constant.
- [x] 1.2 `generateInterviewTurn` (tenant-scoped, InterviewSystemPrompt-led) + `DefaultMaxInterviewTurns = 12` + pure `interviewTurnCapReached` + 11 tests.
- [x] 1.3 `parseInterviewTurn` / `decideInterviewAction` (precedence: marker → ready; cap → forced draft; else question; all text stripped on marker so no control tokens/partial text reach the patient) + 22 pure tests.

## Beads closed
HouseCall-41l (#154), HouseCall-awe (#153), HouseCall-gbw (#152)

## Test
`make test` (Postgres via colima) + `go vet ./...` green. Guidance `draft()`/`DraftAsync` path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)