### PR TITLE
add-clinical-soap-review-workflow: Phase 2 — SOAP payload + drafting

### DIFF
--- a/backend/internal/agent/drafter.go
+++ b/backend/internal/agent/drafter.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log"
 	"net"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/markolonius/housecall/backend/internal/domain"
@@ -331,6 +332,202 @@ func draftFailureReason(err error) string {
 		return "model_unavailable"
 	}
 	return "internal_error"
+}
+
+// parseSOAPSections extracts the four required SOAP sections from raw model
+// output. Section headers SUBJECTIVE:, OBJECTIVE:, ASSESSMENT:, and PLAN: are
+// recognised case-insensitively with whitespace trimmed. Content may appear
+// inline on the header line (after the colon) or on the lines that follow.
+//
+// Returns a *ParseError if fewer than four distinct headers are found. The
+// caller must separately call domain.SOAPPayload.Validate() to check that no
+// extracted section is empty or whitespace-only (validator task 2.1).
+//
+// No content is logged (PHI constraint).
+func parseSOAPSections(raw string) (domain.SOAPPayload, error) {
+	const (
+		labelSubjective = "SUBJECTIVE"
+		labelObjective  = "OBJECTIVE"
+		labelAssessment = "ASSESSMENT"
+		labelPlan       = "PLAN"
+	)
+	orderedLabels := []string{labelSubjective, labelObjective, labelAssessment, labelPlan}
+
+	lines := strings.Split(raw, "\n")
+
+	type span struct {
+		label   string
+		lineIdx int
+	}
+	seen := map[string]bool{}
+	var spans []span
+
+	for i, line := range lines {
+		upper := strings.ToUpper(strings.TrimSpace(line))
+		for _, label := range orderedLabels {
+			if !seen[label] && (upper == label || upper == label+":" || strings.HasPrefix(upper, label+":")) {
+				seen[label] = true
+				spans = append(spans, span{label: label, lineIdx: i})
+				break
+			}
+		}
+	}
+
+	if len(spans) < 4 {
+		return domain.SOAPPayload{}, &ParseError{
+			Detail: "model output is missing one or more SOAP section headers (SUBJECTIVE, OBJECTIVE, ASSESSMENT, PLAN)",
+		}
+	}
+
+	// Extract content for each section: inline text after the first colon on the
+	// header line (if any), then all subsequent lines up to the next header.
+	sections := make(map[string]string, 4)
+	for i, sp := range spans {
+		endIdx := len(lines)
+		if i+1 < len(spans) {
+			endIdx = spans[i+1].lineIdx
+		}
+
+		var parts []string
+
+		// Inline content: text after the colon on the header line itself.
+		headerLine := lines[sp.lineIdx]
+		if colonPos := strings.Index(headerLine, ":"); colonPos >= 0 {
+			if inline := strings.TrimSpace(headerLine[colonPos+1:]); inline != "" {
+				parts = append(parts, inline)
+			}
+		}
+
+		// Body lines between this header and the next.
+		for j := sp.lineIdx + 1; j < endIdx; j++ {
+			parts = append(parts, lines[j])
+		}
+
+		sections[sp.label] = strings.TrimSpace(strings.Join(parts, "\n"))
+	}
+
+	return domain.SOAPPayload{
+		Subjective: sections[labelSubjective],
+		Objective:  sections[labelObjective],
+		Assessment: sections[labelAssessment],
+		Plan:       sections[labelPlan],
+	}, nil
+}
+
+// draftSOAPNote assembles the conversation history, calls the model with
+// SOAPDraftSystemPrompt, parses the four SOAP sections, validates them, and
+// atomically persists a soap_note recommendation at PENDING_REVIEW — mirroring
+// the DRAFT→PENDING_REVIEW transaction pattern in draft().
+//
+// Error discipline is identical to draft(): a non-nil return means no
+// recommendation was persisted; the caller (DraftAsync or the phase-3 entry
+// point) is responsible for writing the ai_interaction_failed audit event.
+// No model output is logged (PHI constraint).
+func (d *Drafter) draftSOAPNote(ctx context.Context, tenantID store.TenantID, conv store.Conversation, patient store.Patient) error {
+	// Assemble tenant-scoped conversation context. The query includes tenant_id
+	// in the WHERE clause so cross-tenant bleed is impossible.
+	msgs, err := d.store.ListMessagesByConversation(ctx, tenantID, conv.ID)
+	if err != nil {
+		return err
+	}
+
+	// Build the model message slice: SOAPDraftSystemPrompt as the sole system
+	// message, followed by the full conversation history so the model has
+	// the complete interview context to write from.
+	// Content goes to the model call only — never written to logs or audit.
+	modelMsgs := make([]Message, 0, len(msgs)+1)
+	modelMsgs = append(modelMsgs, Message{
+		Role:    "system",
+		Content: SOAPDraftSystemPrompt,
+	})
+	for _, m := range msgs {
+		modelMsgs = append(modelMsgs, Message{
+			Role:    m.Role,
+			Content: m.Content,
+		})
+	}
+
+	text, err := d.client.Complete(ctx, modelMsgs)
+	if err != nil {
+		// Non-nil error means no valid model output — do NOT persist.
+		return err
+	}
+
+	// Parse the model output into the four SOAP sections.
+	soapPayload, err := parseSOAPSections(text)
+	if err != nil {
+		return err
+	}
+	// Domain validation: all four sections must be non-empty (whitespace-only
+	// content is treated as empty by the validator tightened in task 2.1).
+	if err := soapPayload.Validate(); err != nil {
+		return err
+	}
+
+	// Marshal the structured payload for storage.
+	payloadJSON, err := json.Marshal(soapPayload)
+	if err != nil {
+		return err
+	}
+
+	agentActor := domain.Actor{Type: domain.ActorAgent, ID: uuid.Nil}
+
+	// Persist DRAFT → PENDING_REVIEW + audit event atomically.
+	var recID uuid.UUID
+	if err := d.store.Txn(ctx, func(tx *store.TxStore) error {
+		// Step 1: insert at DRAFT.
+		rec, err := tx.CreateRecommendation(ctx, tenantID, store.Recommendation{
+			ConversationID: conv.ID,
+			PatientID:      patient.ID,
+			State:          domain.StateDraft,
+			PayloadType:    domain.PayloadTypeSOAPNote,
+			Payload:        payloadJSON,
+			DraftContent:   strings.TrimSpace(text),
+		})
+		if err != nil {
+			return err
+		}
+		recID = rec.ID
+
+		// Step 2: pure state-machine transition DRAFT → PENDING_REVIEW.
+		nextState, err := domain.Transition(rec.State, domain.ActionSubmitForReview, agentActor, patient.State)
+		if err != nil {
+			return err
+		}
+
+		// Step 3: persist the new state within the same transaction.
+		if err := tx.UpdateRecommendationState(ctx, tenantID, rec.ID, nextState, nil, nil); err != nil {
+			return err
+		}
+
+		// Step 4: write the audit event. Metadata contains identifiers +
+		// payload_type only — no PHI, no model output.
+		return tx.CreateAuditEvent(ctx, tenantID, store.AuditEvent{
+			ActorType: string(domain.ActorAgent),
+			ActorID:   nil, // agent has no user UUID
+			EventType: "recommendation.submitted_for_review",
+			Metadata: mustMarshalJSON(map[string]any{
+				"recommendation_id": recID.String(),
+				"conversation_id":   conv.ID.String(),
+				"new_state":         nextState,
+				"payload_type":      domain.PayloadTypeSOAPNote,
+			}),
+		})
+	}); err != nil {
+		return err
+	}
+
+	// Emit queue.updated AFTER the successful commit so physicians only
+	// receive the event when the row is durably visible.
+	d.notifier.SendToPhysicians(tenantID.String(), mustMarshalJSON(map[string]any{
+		"type": "queue.updated",
+		"data": map[string]any{
+			"recommendation_id": recID.String(),
+			"conversation_id":   conv.ID.String(),
+		},
+	}))
+
+	return nil
 }
 
 func mustMarshalJSON(v any) []byte {

--- a/backend/internal/agent/prompt.go
+++ b/backend/internal/agent/prompt.go
@@ -1,6 +1,7 @@
 // Package agent implements the AI Agent Runtime. This file defines the
-// clinical interview system prompt and the shared completion-marker constant
-// used by both the prompt and the server-side marker parser (Task 1.3).
+// clinical interview system prompt, the SOAP note drafting system prompt, and
+// the shared completion-marker constant used by both the prompt and the
+// server-side marker parser (Task 1.3).
 //
 // Nothing in this file is logged or included in audit metadata; the constants
 // are compile-time values consumed only at the point a model message slice is
@@ -93,3 +94,53 @@ That's helpful to know. On a scale of 0 to 10, with 10 being the worst pain you'
 ---
 
 Begin the interview with the patient's first message.`
+
+// SOAPDraftSystemPrompt instructs the model to synthesise a structured SOAP
+// note from a completed patient history interview. It is used as the system
+// message in draftSOAPNote; the full conversation history follows.
+//
+// Output format contract (MUST be preserved so parseSOAPSections can parse it):
+// The model MUST output the note using exactly these four section headers on
+// their own lines, each followed by the section content:
+//
+//	SUBJECTIVE:
+//	OBJECTIVE:
+//	ASSESSMENT:
+//	PLAN:
+//
+// Labels are matched case-insensitively and whitespace-tolerantly by the
+// parser, but the prompt uses uppercase for consistency.
+//
+// Design constraints (see design.md SOAP payload shape):
+//   - Subjective: history of present illness in the patient's words.
+//   - Objective: ONLY objective data the patient actually reported
+//     (e.g. self-measured vitals). Must NOT fabricate exam findings.
+//     If none reported, write "None reported".
+//   - Assessment: preliminary clinical impression — NOT a definitive diagnosis.
+//   - Plan: recommended follow-up, monitoring, or referral.
+const SOAPDraftSystemPrompt = `You are a licensed clinician writing a structured clinical SOAP note based on a completed patient history interview. A physician will review and may edit this note before any part of it reaches the patient.
+
+## Output format — MANDATORY
+
+Output the note using EXACTLY the following four section headers, each on its own line, followed by the section content. Do not add any other headers, preamble, or closing text.
+
+SUBJECTIVE:
+<summarise the history of present illness in the patient's own words: chief complaint, onset, character, severity, timing, provocation/palliation, relevant past history, medications, allergies>
+
+OBJECTIVE:
+<list ONLY objective data the patient actually reported — for example, self-measured blood pressure, temperature, or weight; do NOT fabricate physical examination findings that could not have been obtained in a text interview; if no objective data was reported, write exactly: None reported>
+
+ASSESSMENT:
+<your preliminary clinical impression; begin with "Preliminary assessment:" and do NOT state a definitive diagnosis; make clear this assessment requires physician review>
+
+PLAN:
+<actionable recommended plan including self-care, monitoring, when to seek emergency care, and suggested follow-up with a clinician>
+
+## Rules
+
+1. SUBJECTIVE must be drawn directly from what the patient reported during the interview. Do not invent or infer information not explicitly provided.
+2. OBJECTIVE must contain ONLY findings the patient reported themselves (e.g. "states blood pressure 140/90 at home"). Do NOT write findings that would require a physical examination (auscultation, palpation, percussion, inspection). If no such data was provided, write "None reported".
+3. ASSESSMENT must start with "Preliminary assessment:" and must not claim to be a definitive diagnosis. It must note that physician review is required.
+4. PLAN must be safe, actionable, and appropriate for a text-based consultation.
+5. Every section must be present and non-empty.
+6. Use the exact headers shown above (SUBJECTIVE:, OBJECTIVE:, ASSESSMENT:, PLAN:) — no markdown bold, no hash signs, no extra colons or punctuation on the header line itself.`

--- a/backend/internal/agent/soap_drafter_test.go
+++ b/backend/internal/agent/soap_drafter_test.go
@@ -1,0 +1,441 @@
+// Package agent — internal tests for draftSOAPNote and parseSOAPSections
+// (Task 2.2).
+//
+// This file uses "package agent" (not "package agent_test") so it can access
+// the unexported draftSOAPNote and parseSOAPSections symbols. DB-backed tests
+// reuse itTestPool from interview_turn_test.go (same package) and the
+// spyClient/stubNotifierNoop helpers defined there.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/markolonius/housecall/backend/internal/domain"
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// Well-formed SOAP text used across multiple test cases.
+// ---------------------------------------------------------------------------
+
+const wellFormedSOAPText = `SUBJECTIVE:
+Patient reports a throbbing headache on the right side that started two days ago. Rates severity 7/10. Worse with bright light and noise. Lying in a dark room provides partial relief. No prior headaches of this severity. Takes no regular medications. No known drug allergies.
+
+OBJECTIVE:
+None reported.
+
+ASSESSMENT:
+Preliminary assessment: unilateral throbbing headache with photophobia and phonophobia, consistent with migraine headache; requires physician review before any diagnosis is confirmed.
+
+PLAN:
+Rest in a quiet dark room; stay well hydrated; OTC ibuprofen 400 mg every 6 hours as needed for pain; seek emergency care if headache suddenly worsens, vision changes, or neurological symptoms appear; follow up with primary care within 48 hours if no improvement.`
+
+// ---------------------------------------------------------------------------
+// soapDrafterFixture — minimum DB rows for draftSOAPNote testing.
+// A physician / care relationship is NOT required: the agent transition
+// DRAFT→PENDING_REVIEW ignores patient state for licensing.
+// ---------------------------------------------------------------------------
+
+type soapDrafterFixture struct {
+	TenantID store.TenantID
+	Patient  store.Patient
+	Conv     store.Conversation
+}
+
+func setupSOAPDrafterFixture(t *testing.T, s *store.Store) soapDrafterFixture {
+	t.Helper()
+	ctx := context.Background()
+	suffix := uuid.New().String()
+
+	tenant, err := s.CreateTenant(ctx, "dtc", "soap-drafter-test-"+suffix)
+	if err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	tid := store.TenantID(tenant.ID)
+
+	patient, err := s.CreatePatient(ctx, tid, store.Patient{
+		Email:        "patient+" + suffix + "@soap.test",
+		FullName:     "SOAP Test Patient",
+		State:        "CA",
+		PasswordHash: "hash",
+	})
+	if err != nil {
+		t.Fatalf("create patient: %v", err)
+	}
+
+	conv, err := s.CreateConversation(ctx, tid, patient.ID, "soap test conversation")
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	if _, err := s.CreateMessage(ctx, tid, conv.ID, "user", "I have a headache for two days"); err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+
+	return soapDrafterFixture{TenantID: tid, Patient: patient, Conv: conv}
+}
+
+// ---------------------------------------------------------------------------
+// captureNotifier satisfies PhysicianNotifier and records every event sent.
+// ---------------------------------------------------------------------------
+
+type captureNotifier struct {
+	mu     sync.Mutex
+	events [][]byte
+}
+
+func (n *captureNotifier) SendToPhysicians(_ string, event []byte) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	cp := make([]byte, len(event))
+	copy(cp, event)
+	n.events = append(n.events, cp)
+}
+
+func (n *captureNotifier) count() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.events)
+}
+
+func (n *captureNotifier) last() []byte {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.events) == 0 {
+		return nil
+	}
+	return n.events[len(n.events)-1]
+}
+
+// ---------------------------------------------------------------------------
+// Pure unit tests: parseSOAPSections
+// ---------------------------------------------------------------------------
+
+// TestParseSOAPSections_HappyPath verifies that a well-formed four-section
+// model output is parsed into the correct SOAPPayload fields.
+func TestParseSOAPSections_HappyPath(t *testing.T) {
+	p, err := parseSOAPSections(wellFormedSOAPText)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Subjective == "" {
+		t.Error("Subjective is empty")
+	}
+	if p.Objective == "" {
+		t.Error("Objective is empty")
+	}
+	if p.Assessment == "" {
+		t.Error("Assessment is empty")
+	}
+	if p.Plan == "" {
+		t.Error("Plan is empty")
+	}
+}
+
+// TestParseSOAPSections_MissingSectionLabel verifies that output missing at
+// least one label returns a *ParseError and no panic.
+func TestParseSOAPSections_MissingSectionLabel(t *testing.T) {
+	// PLAN section is absent.
+	missing := `SUBJECTIVE:
+Patient reports headache.
+
+OBJECTIVE:
+None reported.
+
+ASSESSMENT:
+Preliminary assessment: tension headache; physician review required.`
+
+	_, err := parseSOAPSections(missing)
+	if err == nil {
+		t.Fatal("expected error for output missing PLAN section, got nil")
+	}
+	var pe *ParseError
+	if !errAsParseError(err, &pe) {
+		t.Errorf("expected *ParseError, got %T: %v", err, err)
+	}
+}
+
+// TestParseSOAPSections_InlineContent verifies that content placed on the same
+// line as the header (after the colon) is correctly extracted.
+func TestParseSOAPSections_InlineContent(t *testing.T) {
+	inline := `SUBJECTIVE: Headache onset two days ago.
+OBJECTIVE: None reported.
+ASSESSMENT: Preliminary assessment: tension headache.
+PLAN: Rest and OTC ibuprofen.`
+
+	p, err := parseSOAPSections(inline)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Subjective != "Headache onset two days ago." {
+		t.Errorf("Subjective = %q, want %q", p.Subjective, "Headache onset two days ago.")
+	}
+	if p.Objective != "None reported." {
+		t.Errorf("Objective = %q, want %q", p.Objective, "None reported.")
+	}
+	if p.Plan != "Rest and OTC ibuprofen." {
+		t.Errorf("Plan = %q, want %q", p.Plan, "Rest and OTC ibuprofen.")
+	}
+}
+
+// TestParseSOAPSections_CaseInsensitiveLabels verifies that lowercase or
+// mixed-case section headers are matched correctly.
+func TestParseSOAPSections_CaseInsensitiveLabels(t *testing.T) {
+	lower := `subjective:
+Patient has a cough.
+
+objective:
+None reported.
+
+assessment:
+Preliminary assessment: viral upper respiratory tract infection.
+
+plan:
+Rest and fluids.`
+
+	p, err := parseSOAPSections(lower)
+	if err != nil {
+		t.Fatalf("unexpected error for lowercase labels: %v", err)
+	}
+	if p.Subjective == "" || p.Objective == "" || p.Assessment == "" || p.Plan == "" {
+		t.Errorf("one or more sections empty with lowercase labels: %+v", p)
+	}
+}
+
+// TestParseSOAPSections_WhitespaceOnlyContent verifies that parseSOAPSections
+// returns an empty string for whitespace-only section content (after TrimSpace)
+// and that the domain validator subsequently rejects it.
+func TestParseSOAPSections_WhitespaceOnlyContent(t *testing.T) {
+	// Subjective section contains only blank lines.
+	ws := `SUBJECTIVE:
+
+
+OBJECTIVE:
+None reported.
+
+ASSESSMENT:
+Preliminary assessment: unknown.
+
+PLAN:
+Follow up with primary care.`
+
+	p, err := parseSOAPSections(ws)
+	if err != nil {
+		t.Fatalf("parseSOAPSections must not error on whitespace-only content: %v", err)
+	}
+	// After TrimSpace the Subjective should be empty string.
+	if p.Subjective != "" {
+		t.Errorf("expected empty Subjective after trimming whitespace, got %q", p.Subjective)
+	}
+	// Validate must reject the whitespace-only section.
+	if err := p.Validate(); err == nil {
+		t.Fatal("expected Validate() to reject whitespace-only Subjective, got nil")
+	}
+}
+
+// errAsParseError is a type-assertion helper for *ParseError.
+func errAsParseError(err error, target **ParseError) bool {
+	if err == nil {
+		return false
+	}
+	pe, ok := err.(*ParseError)
+	if ok && target != nil {
+		*target = pe
+	}
+	return ok
+}
+
+// ---------------------------------------------------------------------------
+// DB-backed integration tests: draftSOAPNote
+// ---------------------------------------------------------------------------
+
+// TestDraftSOAPNote_HappyPath verifies that draftSOAPNote, given a stub client
+// returning well-formed SOAP text, persists exactly one PENDING_REVIEW
+// soap_note recommendation with the correct payload and draft_content, writes
+// an audit event with payload_type in metadata, and emits queue.updated.
+func TestDraftSOAPNote_HappyPath(t *testing.T) {
+	pool := itTestPool(t) // defined in interview_turn_test.go, same package
+	s := store.New(pool)
+	f := setupSOAPDrafterFixture(t, s)
+	ctx := context.Background()
+
+	notifier := &captureNotifier{}
+	// spyClient is defined in interview_turn_test.go (same package).
+	client := &spyClient{text: wellFormedSOAPText}
+	d := NewDrafter(client, s, notifier)
+
+	if err := d.draftSOAPNote(ctx, f.TenantID, f.Conv, f.Patient); err != nil {
+		t.Fatalf("draftSOAPNote: unexpected error: %v", err)
+	}
+
+	// 1. Exactly one PENDING_REVIEW recommendation for this conversation.
+	recs, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
+	if err != nil {
+		t.Fatalf("list recommendations: %v", err)
+	}
+	var found []store.Recommendation
+	for _, r := range recs {
+		if r.ConversationID == f.Conv.ID {
+			found = append(found, r)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected 1 PENDING_REVIEW soap_note recommendation, got %d", len(found))
+	}
+	rec := found[0]
+
+	// 2. payload_type must be soap_note.
+	if rec.PayloadType != domain.PayloadTypeSOAPNote {
+		t.Errorf("payload_type = %q, want %q", rec.PayloadType, domain.PayloadTypeSOAPNote)
+	}
+
+	// 3. Payload must contain all four sections.
+	var sp domain.SOAPPayload
+	if err := json.Unmarshal(rec.Payload, &sp); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if sp.Subjective == "" {
+		t.Error("payload.subjective is empty")
+	}
+	if sp.Objective == "" {
+		t.Error("payload.objective is empty")
+	}
+	if sp.Assessment == "" {
+		t.Error("payload.assessment is empty")
+	}
+	if sp.Plan == "" {
+		t.Error("payload.plan is empty")
+	}
+	if err := sp.Validate(); err != nil {
+		t.Errorf("payload fails domain validation: %v", err)
+	}
+
+	// 4. draft_content must equal the full trimmed model text.
+	wantDraftContent := strings.TrimSpace(wellFormedSOAPText)
+	if rec.DraftContent != wantDraftContent {
+		t.Errorf("draft_content length got=%d, want=%d", len(rec.DraftContent), len(wantDraftContent))
+	}
+
+	// 5. No DRAFT rows must remain (the transition was atomic).
+	drafts, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StateDraft)
+	if err != nil {
+		t.Fatalf("list draft recs: %v", err)
+	}
+	for _, r := range drafts {
+		if r.ConversationID == f.Conv.ID {
+			t.Errorf("unexpected DRAFT recommendation for conversation %s", f.Conv.ID)
+		}
+	}
+
+	// 6. Audit event must include payload_type and identifiers — no PHI.
+	rows, err := pool.Query(ctx,
+		`SELECT metadata
+		   FROM audit_events
+		  WHERE tenant_id = $1
+		    AND event_type = 'recommendation.submitted_for_review'
+		    AND metadata->>'conversation_id' = $2`,
+		f.TenantID.UUID(),
+		f.Conv.ID.String(),
+	)
+	if err != nil {
+		t.Fatalf("query audit events: %v", err)
+	}
+	defer rows.Close()
+
+	var auditCount int
+	for rows.Next() {
+		auditCount++
+		var meta []byte
+		if err := rows.Scan(&meta); err != nil {
+			t.Fatalf("scan audit metadata: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(meta, &m); err != nil {
+			t.Fatalf("unmarshal audit metadata: %v", err)
+		}
+		if got, _ := m["payload_type"].(string); got != domain.PayloadTypeSOAPNote {
+			t.Errorf("audit metadata payload_type = %q, want %q", got, domain.PayloadTypeSOAPNote)
+		}
+		if _, ok := m["recommendation_id"]; !ok {
+			t.Error("audit metadata missing recommendation_id")
+		}
+		if _, ok := m["conversation_id"]; !ok {
+			t.Error("audit metadata missing conversation_id")
+		}
+		// Clinical content must NOT appear in audit metadata.
+		raw := string(meta)
+		for _, forbidden := range []string{"throbbing", "ibuprofen", "headache", "Preliminary"} {
+			if strings.Contains(raw, forbidden) {
+				t.Errorf("audit metadata contains clinical content (found %q) — PHI constraint violation", forbidden)
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows error: %v", err)
+	}
+	if auditCount != 1 {
+		t.Errorf("expected 1 audit event for recommendation.submitted_for_review, got %d", auditCount)
+	}
+
+	// 7. queue.updated must be emitted (draftSOAPNote is synchronous).
+	if notifier.count() == 0 {
+		t.Fatal("queue.updated event not emitted")
+	}
+	var evt map[string]any
+	if err := json.Unmarshal(notifier.last(), &evt); err != nil {
+		t.Fatalf("unmarshal queue.updated event: %v", err)
+	}
+	if evt["type"] != "queue.updated" {
+		t.Errorf("event type = %q, want %q", evt["type"], "queue.updated")
+	}
+}
+
+// TestDraftSOAPNote_MissingSection verifies that when the model output is
+// missing a required section header, draftSOAPNote returns an error and
+// persists no recommendation and emits no queue.updated.
+func TestDraftSOAPNote_MissingSection(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+	f := setupSOAPDrafterFixture(t, s)
+	ctx := context.Background()
+
+	// Model returns text without a PLAN section.
+	malformedText := `SUBJECTIVE:
+Patient reports a cough for three days.
+
+OBJECTIVE:
+None reported.
+
+ASSESSMENT:
+Preliminary assessment: upper respiratory tract infection; physician review required.`
+
+	notifier := &captureNotifier{}
+	d := NewDrafter(&spyClient{text: malformedText}, s, notifier)
+
+	err := d.draftSOAPNote(ctx, f.TenantID, f.Conv, f.Patient)
+	if err == nil {
+		t.Fatal("expected error when model output is missing a SOAP section, got nil")
+	}
+
+	// No recommendation must be persisted.
+	recs, listErr := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
+	if listErr != nil {
+		t.Fatalf("list recommendations: %v", listErr)
+	}
+	for _, r := range recs {
+		if r.ConversationID == f.Conv.ID {
+			t.Errorf("found unexpected PENDING_REVIEW recommendation for conversation %s", f.Conv.ID)
+		}
+	}
+
+	// No queue.updated must be emitted.
+	if notifier.count() != 0 {
+		t.Errorf("expected 0 queue.updated events on parse error, got %d", notifier.count())
+	}
+}

--- a/backend/internal/domain/soap.go
+++ b/backend/internal/domain/soap.go
@@ -1,0 +1,89 @@
+package domain
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// PayloadTypeSOAPNote is the payload_type value for a structured
+// Subjective/Objective/Assessment/Plan recommendation.  It is the only
+// payload type produced by the clinical interview flow and MUST pass through
+// physician review before delivery (the lifecycle machine enforces this).
+const PayloadTypeSOAPNote = "soap_note"
+
+// Section key constants for the soap_note JSON payload.  Using named
+// constants keeps the prompt, the drafter, and the validator in sync.
+const (
+	SOAPKeySubjective  = "subjective"
+	SOAPKeyObjective   = "objective"
+	SOAPKeyAssessment  = "assessment"
+	SOAPKeyPlan        = "plan"
+)
+
+// SOAPPayload is the structured payload for a soap_note recommendation.
+// All four sections are required and must be non-empty strings.
+//
+// Assessment and Plan are the physician-reviewed clinical fields; they must
+// never be delivered to the patient without a state-licensed physician
+// transition (APPROVED or MODIFIED).  The lifecycle machine in
+// recommendation.go enforces this invariant — this struct does not duplicate
+// that logic.
+type SOAPPayload struct {
+	Subjective string `json:"subjective"`
+	Objective  string `json:"objective"`
+	Assessment string `json:"assessment"`
+	Plan       string `json:"plan"`
+}
+
+// Validate returns an error if any of the four required sections is absent or
+// empty.  Call this before persisting a soap_note recommendation to ensure the
+// payload is structurally complete.
+func (s SOAPPayload) Validate() error {
+	var missing []string
+	if s.Subjective == "" {
+		missing = append(missing, SOAPKeySubjective)
+	}
+	if s.Objective == "" {
+		missing = append(missing, SOAPKeyObjective)
+	}
+	if s.Assessment == "" {
+		missing = append(missing, SOAPKeyAssessment)
+	}
+	if s.Plan == "" {
+		missing = append(missing, SOAPKeyPlan)
+	}
+	if len(missing) > 0 {
+		return &SOAPValidationError{Missing: missing}
+	}
+	return nil
+}
+
+// ValidateSOAPPayload decodes raw JSON into a SOAPPayload and validates that
+// all four sections are present and non-empty.  It is the canonical entry
+// point for callers that hold a []byte payload (e.g. the store layer before
+// persisting a soap_note recommendation).
+func ValidateSOAPPayload(payload []byte) error {
+	var sp SOAPPayload
+	if err := json.Unmarshal(payload, &sp); err != nil {
+		return errors.New("domain: soap_note payload is not valid JSON")
+	}
+	return sp.Validate()
+}
+
+// SOAPValidationError is returned by SOAPPayload.Validate / ValidateSOAPPayload
+// when one or more required sections are absent or empty.
+type SOAPValidationError struct {
+	Missing []string
+}
+
+func (e *SOAPValidationError) Error() string {
+	msg := "domain: soap_note payload missing required sections:"
+	for i, s := range e.Missing {
+		if i == 0 {
+			msg += " " + s
+		} else {
+			msg += ", " + s
+		}
+	}
+	return msg
+}

--- a/backend/internal/domain/soap.go
+++ b/backend/internal/domain/soap.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 )
 
 // PayloadTypeSOAPNote is the payload_type value for a structured
@@ -35,21 +36,21 @@ type SOAPPayload struct {
 	Plan       string `json:"plan"`
 }
 
-// Validate returns an error if any of the four required sections is absent or
-// empty.  Call this before persisting a soap_note recommendation to ensure the
-// payload is structurally complete.
+// Validate returns an error if any of the four required sections is absent,
+// empty, or contains only whitespace.  Call this before persisting a soap_note
+// recommendation to ensure the payload is structurally complete.
 func (s SOAPPayload) Validate() error {
 	var missing []string
-	if s.Subjective == "" {
+	if strings.TrimSpace(s.Subjective) == "" {
 		missing = append(missing, SOAPKeySubjective)
 	}
-	if s.Objective == "" {
+	if strings.TrimSpace(s.Objective) == "" {
 		missing = append(missing, SOAPKeyObjective)
 	}
-	if s.Assessment == "" {
+	if strings.TrimSpace(s.Assessment) == "" {
 		missing = append(missing, SOAPKeyAssessment)
 	}
-	if s.Plan == "" {
+	if strings.TrimSpace(s.Plan) == "" {
 		missing = append(missing, SOAPKeyPlan)
 	}
 	if len(missing) > 0 {

--- a/backend/internal/domain/soap_test.go
+++ b/backend/internal/domain/soap_test.go
@@ -1,0 +1,117 @@
+package domain_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/markolonius/housecall/backend/internal/domain"
+)
+
+func TestValidateSOAPPayload_Valid(t *testing.T) {
+	payload := []byte(`{
+		"subjective":  "patient reports headache for 3 days",
+		"objective":   "none reported",
+		"assessment":  "tension headache",
+		"plan":        "rest and ibuprofen"
+	}`)
+	if err := domain.ValidateSOAPPayload(payload); err != nil {
+		t.Fatalf("expected valid payload to pass: %v", err)
+	}
+}
+
+func TestValidateSOAPPayload_InvalidJSON(t *testing.T) {
+	if err := domain.ValidateSOAPPayload([]byte(`not json`)); err == nil {
+		t.Fatal("expected error for non-JSON payload, got nil")
+	}
+}
+
+// TestValidateSOAPPayload_MissingSections uses a table-driven approach to
+// verify that each missing or empty section is caught individually and that
+// the error message names the offending section(s).
+func TestValidateSOAPPayload_MissingSections(t *testing.T) {
+	cases := []struct {
+		name        string
+		payload     []byte
+		wantMissing []string
+	}{
+		{
+			name:        "missing subjective",
+			payload:     []byte(`{"objective":"o","assessment":"a","plan":"p"}`),
+			wantMissing: []string{"subjective"},
+		},
+		{
+			name:        "empty subjective",
+			payload:     []byte(`{"subjective":"","objective":"o","assessment":"a","plan":"p"}`),
+			wantMissing: []string{"subjective"},
+		},
+		{
+			name:        "missing objective",
+			payload:     []byte(`{"subjective":"s","assessment":"a","plan":"p"}`),
+			wantMissing: []string{"objective"},
+		},
+		{
+			name:        "missing assessment",
+			payload:     []byte(`{"subjective":"s","objective":"o","plan":"p"}`),
+			wantMissing: []string{"assessment"},
+		},
+		{
+			name:        "missing plan",
+			payload:     []byte(`{"subjective":"s","objective":"o","assessment":"a"}`),
+			wantMissing: []string{"plan"},
+		},
+		{
+			name:        "missing all four sections",
+			payload:     []byte(`{}`),
+			wantMissing: []string{"subjective", "objective", "assessment", "plan"},
+		},
+		{
+			name:        "missing assessment and plan",
+			payload:     []byte(`{"subjective":"s","objective":"o"}`),
+			wantMissing: []string{"assessment", "plan"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := domain.ValidateSOAPPayload(tc.payload)
+			if err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+			msg := err.Error()
+			for _, section := range tc.wantMissing {
+				if !strings.Contains(msg, section) {
+					t.Errorf("error message %q does not mention missing section %q", msg, section)
+				}
+			}
+		})
+	}
+}
+
+// TestSOAPPayload_Validate exercises the struct method directly (used by
+// callers that already have a decoded struct, e.g. the drafter).
+func TestSOAPPayload_Validate(t *testing.T) {
+	full := domain.SOAPPayload{
+		Subjective: "s",
+		Objective:  "o",
+		Assessment: "a",
+		Plan:       "p",
+	}
+	if err := full.Validate(); err != nil {
+		t.Fatalf("full payload: %v", err)
+	}
+
+	empty := domain.SOAPPayload{}
+	if err := empty.Validate(); err == nil {
+		t.Fatal("empty payload: expected error, got nil")
+	}
+}
+
+// TestPayloadTypeSOAPNote_Constant ensures the constant value matches the
+// database-level payload_type string so prompt + parser + constraint stay
+// in sync.
+func TestPayloadTypeSOAPNote_Constant(t *testing.T) {
+	const want = "soap_note"
+	if domain.PayloadTypeSOAPNote != want {
+		t.Fatalf("PayloadTypeSOAPNote = %q, want %q", domain.PayloadTypeSOAPNote, want)
+	}
+}

--- a/backend/internal/domain/soap_test.go
+++ b/backend/internal/domain/soap_test.go
@@ -106,6 +106,79 @@ func TestSOAPPayload_Validate(t *testing.T) {
 	}
 }
 
+// TestSOAPPayload_Validate_WhitespaceOnly verifies that sections containing
+// only whitespace (spaces, tabs, newlines) are rejected as empty by the
+// validator tightened in task 2.2.
+func TestSOAPPayload_Validate_WhitespaceOnly(t *testing.T) {
+	cases := []struct {
+		name        string
+		payload     domain.SOAPPayload
+		wantMissing string
+	}{
+		{
+			name: "subjective whitespace only",
+			payload: domain.SOAPPayload{
+				Subjective: "   ",
+				Objective:  "o",
+				Assessment: "a",
+				Plan:       "p",
+			},
+			wantMissing: "subjective",
+		},
+		{
+			name: "objective tab only",
+			payload: domain.SOAPPayload{
+				Subjective: "s",
+				Objective:  "\t",
+				Assessment: "a",
+				Plan:       "p",
+			},
+			wantMissing: "objective",
+		},
+		{
+			name: "assessment newline only",
+			payload: domain.SOAPPayload{
+				Subjective: "s",
+				Objective:  "o",
+				Assessment: "\n",
+				Plan:       "p",
+			},
+			wantMissing: "assessment",
+		},
+		{
+			name: "plan spaces and newlines",
+			payload: domain.SOAPPayload{
+				Subjective: "s",
+				Objective:  "o",
+				Assessment: "a",
+				Plan:       "  \n  ",
+			},
+			wantMissing: "plan",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.payload.Validate()
+			if err == nil {
+				t.Fatalf("expected validation error for whitespace-only %q section, got nil", tc.wantMissing)
+			}
+			if !strings.Contains(err.Error(), tc.wantMissing) {
+				t.Errorf("error %q does not mention section %q", err.Error(), tc.wantMissing)
+			}
+		})
+	}
+}
+
+// TestValidateSOAPPayload_WhitespaceOnly verifies the JSON entry point also
+// rejects whitespace-only section values.
+func TestValidateSOAPPayload_WhitespaceOnly(t *testing.T) {
+	payload := []byte(`{"subjective":"   ","objective":"o","assessment":"a","plan":"p"}`)
+	if err := domain.ValidateSOAPPayload(payload); err == nil {
+		t.Fatal("expected error for whitespace-only subjective, got nil")
+	}
+}
+
 // TestPayloadTypeSOAPNote_Constant ensures the constant value matches the
 // database-level payload_type string so prompt + parser + constraint stay
 // in sync.

--- a/backend/internal/store/soap_test.go
+++ b/backend/internal/store/soap_test.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/markolonius/housecall/backend/internal/domain"
+)
+
+// TestCreateRecommendation_SOAPNote verifies that the database accepts a
+// soap_note recommendation with a valid four-section payload (i.e. the
+// migration 0003_soap_note_payload has been applied and the CHECK constraint
+// now includes 'soap_note').
+func TestCreateRecommendation_SOAPNote(t *testing.T) {
+	pool := testPool(t)
+	s := New(pool)
+	f := setupFixture(t, s)
+	ctx := context.Background()
+
+	tid := TenantID(f.A.Tenant.ID)
+
+	soapPayload := domain.SOAPPayload{
+		Subjective: "patient reports headache for 3 days, worse in the morning",
+		Objective:  "none reported (text interview only)",
+		Assessment: "tension-type headache",
+		Plan:       "recommend rest, hydration, and OTC ibuprofen; follow up if no improvement in 48 h",
+	}
+	raw, err := json.Marshal(soapPayload)
+	if err != nil {
+		t.Fatalf("marshal soap payload: %v", err)
+	}
+
+	// Validate the payload before persisting (mirrors what the drafter will do).
+	if err := domain.ValidateSOAPPayload(raw); err != nil {
+		t.Fatalf("soap payload failed domain validation: %v", err)
+	}
+
+	rec, err := s.CreateRecommendation(ctx, tid, Recommendation{
+		ConversationID: f.A.Conversation.ID,
+		PatientID:      f.A.Patient.ID,
+		State:          domain.StateDraft,
+		PayloadType:    domain.PayloadTypeSOAPNote,
+		Payload:        raw,
+		DraftContent:   "Headache note draft",
+	})
+	if err != nil {
+		t.Fatalf("create soap_note recommendation: %v", err)
+	}
+
+	if rec.PayloadType != domain.PayloadTypeSOAPNote {
+		t.Errorf("payload_type = %q, want %q", rec.PayloadType, domain.PayloadTypeSOAPNote)
+	}
+	if rec.State != domain.StateDraft {
+		t.Errorf("state = %q, want %q", rec.State, domain.StateDraft)
+	}
+	if rec.TenantID != tid {
+		t.Errorf("tenant_id mismatch: got %v, want %v", rec.TenantID, tid)
+	}
+
+	// Round-trip: fetch and confirm all four sections survive.
+	fetched, err := s.GetRecommendation(ctx, tid, rec.ID)
+	if err != nil {
+		t.Fatalf("get recommendation: %v", err)
+	}
+	var roundTripped domain.SOAPPayload
+	if err := json.Unmarshal(fetched.Payload, &roundTripped); err != nil {
+		t.Fatalf("unmarshal round-tripped payload: %v", err)
+	}
+	if roundTripped.Subjective != soapPayload.Subjective {
+		t.Errorf("Subjective mismatch: got %q, want %q", roundTripped.Subjective, soapPayload.Subjective)
+	}
+	if roundTripped.Assessment != soapPayload.Assessment {
+		t.Errorf("Assessment mismatch: got %q, want %q", roundTripped.Assessment, soapPayload.Assessment)
+	}
+	if roundTripped.Plan != soapPayload.Plan {
+		t.Errorf("Plan mismatch: got %q, want %q", roundTripped.Plan, soapPayload.Plan)
+	}
+}
+
+// TestCreateRecommendation_SOAPNote_SchemaRejectsInvalidPayloadType confirms
+// that the Postgres CHECK constraint still rejects an unknown payload_type
+// string after the migration (regression guard).
+func TestCreateRecommendation_SOAPNote_SchemaRejectsInvalidPayloadType(t *testing.T) {
+	pool := testPool(t)
+	s := New(pool)
+	f := setupFixture(t, s)
+	ctx := context.Background()
+
+	tid := TenantID(f.A.Tenant.ID)
+
+	_, err := s.CreateRecommendation(ctx, tid, Recommendation{
+		ConversationID: f.A.Conversation.ID,
+		PatientID:      f.A.Patient.ID,
+		State:          domain.StateDraft,
+		PayloadType:    "unknown_type",
+		Payload:        []byte(`{}`),
+		DraftContent:   "should fail",
+	})
+	if err == nil {
+		t.Fatal("expected schema CHECK violation for unknown payload_type, got nil error")
+	}
+}

--- a/backend/internal/store/soap_test.go
+++ b/backend/internal/store/soap_test.go
@@ -70,6 +70,9 @@ func TestCreateRecommendation_SOAPNote(t *testing.T) {
 	if roundTripped.Subjective != soapPayload.Subjective {
 		t.Errorf("Subjective mismatch: got %q, want %q", roundTripped.Subjective, soapPayload.Subjective)
 	}
+	if roundTripped.Objective != soapPayload.Objective {
+		t.Errorf("Objective mismatch: got %q, want %q", roundTripped.Objective, soapPayload.Objective)
+	}
 	if roundTripped.Assessment != soapPayload.Assessment {
 		t.Errorf("Assessment mismatch: got %q, want %q", roundTripped.Assessment, soapPayload.Assessment)
 	}

--- a/backend/migrations/0003_soap_note_payload.sql
+++ b/backend/migrations/0003_soap_note_payload.sql
@@ -1,0 +1,23 @@
+-- 0003_soap_note_payload: extend the recommendations payload_type constraint to
+-- allow 'soap_note' in addition to the four existing types.
+--
+-- Postgres inline CHECK constraints receive a generated name
+-- (recommendations_payload_type_check) that must be dropped before the
+-- replacement can be added.  The new constraint is given the same name so
+-- that re-running this migration on a database where it has already been
+-- applied produces a clear "constraint already exists" error (rather than
+-- silently adding a duplicate), which makes accidental double-application
+-- detectable.
+
+ALTER TABLE recommendations
+    DROP CONSTRAINT recommendations_payload_type_check;
+
+ALTER TABLE recommendations
+    ADD CONSTRAINT recommendations_payload_type_check
+    CHECK (payload_type IN (
+        'guidance',
+        'prescription',
+        'lab_order',
+        'referral',
+        'soap_note'
+    ));

--- a/openspec/changes/add-clinical-soap-review-workflow/tasks.md
+++ b/openspec/changes/add-clinical-soap-review-workflow/tasks.md
@@ -21,7 +21,7 @@ question. Marker handling is server-side only and never patient-visible.
 
 ## Phase 2: SOAP note payload + drafting (backend)
 
-### Task 2.1: Register the soap_note payload type
+### Task 2.1: Register the soap_note payload type  [x]
 Add `soap_note` as a valid recommendation payload type in the domain layer with
 validation that Subjective/Objective/Assessment/Plan are present; extend the
 migration payload-type constraint if one exists. Lifecycle transitions unchanged.

--- a/openspec/changes/add-clinical-soap-review-workflow/tasks.md
+++ b/openspec/changes/add-clinical-soap-review-workflow/tasks.md
@@ -26,7 +26,7 @@ Add `soap_note` as a valid recommendation payload type in the domain layer with
 validation that Subjective/Objective/Assessment/Plan are present; extend the
 migration payload-type constraint if one exists. Lifecycle transitions unchanged.
 
-### Task 2.2: Draft the SOAP note into PENDING_REVIEW
+### Task 2.2: Draft the SOAP note into PENDING_REVIEW  [x]
 On marker detection, draft a `soap_note` recommendation (structured S/O/A/P
 payload + human-readable `draft_content`) using the existing DRAFT→PENDING_REVIEW
 transaction + audit + `queue.updated` pattern. Instruct the model not to


### PR DESCRIPTION
Phase 2 of `add-clinical-soap-review-workflow`: the `soap_note` payload + server-side drafting (additive; entry-point flip is phase 3).

## Tasks
- [x] 2.1 Migration `0003_soap_note_payload.sql` (payload_type CHECK +soap_note) + domain `SOAPPayload`/`PayloadTypeSOAPNote` + validator + tests.
- [x] 2.2 `SOAPDraftSystemPrompt` (4 labeled sections, no fabricated objective findings), `parseSOAPSections`, `Drafter.draftSOAPNote` (DRAFT→PENDING_REVIEW txn + audit + queue.updated, all-or-nothing on failure), validator tightened to TrimSpace + tests.

## Beads closed
HouseCall-8u0 (#151), HouseCall-4dr (#150)

## Invariants (reviewer-confirmed)
Agent only does DRAFT→PENDING_REVIEW (no deliver path); tenant-scoped; no recommendation/queue event on any failure; audit metadata is identifiers + payload_type only (no PHI/model text).

## Test
`make test` (Postgres via colima) green; guidance `draft()`/`DraftAsync` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)