### PR TITLE
add-clinical-soap-review-workflow: Phase 3 — Agent→patient interview channel + carve-out

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -101,11 +101,12 @@ func runServe(dsn, addr string) error {
 	// 1. Build Router with no drafter yet.
 	rt := api.New(s, secret)
 
-	// 2. Build Drafter pointing at the Router (which satisfies
-	//    agent.PhysicianNotifier via rt.SendToPhysicians).
+	// 2. Build Drafter pointing at the Router, which satisfies both
+	//    agent.PhysicianNotifier (via rt.SendToPhysicians) and
+	//    agent.PatientNotifier (via rt.SendToPatient).
 	agentCfg := agent.ClientConfigFromEnv()
 	log.Printf("agent: model config %s", agentCfg)
-	drafter := agent.NewDrafter(agent.NewClient(agentCfg, nil), s, rt)
+	drafter := agent.NewDrafter(agent.NewClient(agentCfg, nil), s, rt, rt)
 
 	// 3. Wire the drafter into the Router before the server starts accepting
 	//    requests.

--- a/backend/internal/agent/carveout_test.go
+++ b/backend/internal/agent/carveout_test.go
@@ -1,0 +1,389 @@
+// Package agent — internal tests asserting the delivery carve-out (Task 3.2).
+//
+// The carve-out is the security-sensitive invariant that separates the two
+// classes of agent output:
+//
+//   - Interview questions (non-clinical, direct): delivered to the patient as
+//     assistant messages via deliverInterviewQuestion. No recommendation row is
+//     ever created for these turns.
+//   - SOAP notes (clinical, review-gated): created exclusively via draftSOAPNote
+//     as a soap_note recommendation in PENDING_REVIEW. The patient is NEVER
+//     notified by the agent when a SOAP note is drafted.
+//
+// The agent has no code path that transitions a recommendation to APPROVED,
+// MODIFIED, or DELIVERED — those transitions are physician-only.
+//
+// Uses "package agent" to access the unexported runInterviewTurn symbol.
+// DB-backed tests reuse itTestPool from interview_turn_test.go (same package).
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/markolonius/housecall/backend/internal/domain"
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// sequentialClient: stub that returns a pre-programmed sequence of responses.
+// Used when runInterviewTurn makes two model calls (interview turn + SOAP draft).
+// ---------------------------------------------------------------------------
+
+type sequentialClient struct {
+	mu        sync.Mutex
+	responses []struct {
+		text string
+		err  error
+	}
+	idx int
+}
+
+func (s *sequentialClient) Complete(_ context.Context, _ []Message) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.idx >= len(s.responses) {
+		return "", &ParseError{Detail: "sequentialClient: no more responses"}
+	}
+	r := s.responses[s.idx]
+	s.idx++
+	return r.text, r.err
+}
+
+// ---------------------------------------------------------------------------
+// carveoutFixture — minimum DB rows for carve-out testing: one tenant, one
+// patient with a CA physician-linked care relationship, and one conversation
+// with one user message.
+// ---------------------------------------------------------------------------
+
+type carveoutFixture struct {
+	TenantID store.TenantID
+	Patient  store.Patient
+	Conv     store.Conversation
+}
+
+func setupCarveoutFixture(t *testing.T, s *store.Store) carveoutFixture {
+	t.Helper()
+	ctx := context.Background()
+	suffix := uuid.New().String()
+
+	tenant, err := s.CreateTenant(ctx, "dtc", "carveout-test-"+suffix)
+	if err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	tid := store.TenantID(tenant.ID)
+
+	patient, err := s.CreatePatient(ctx, tid, store.Patient{
+		Email:        "patient+" + suffix + "@carveout.test",
+		FullName:     "Carveout Test Patient",
+		State:        "CA",
+		PasswordHash: "hash",
+	})
+	if err != nil {
+		t.Fatalf("create patient: %v", err)
+	}
+
+	// A physician is required for DRAFT→PENDING_REVIEW via domain.Transition
+	// (the agent actor path skips state-licensing but the care relationship
+	// must exist for downstream physician review tests).
+	physician, err := s.CreatePhysician(ctx, tid, store.Physician{
+		Email:          "doc+" + suffix + "@carveout.test",
+		FullName:       "Carveout Doc",
+		StatesLicensed: []string{"CA"},
+		PasswordHash:   "hash",
+	})
+	if err != nil {
+		t.Fatalf("create physician: %v", err)
+	}
+	if _, err := s.CreateCareRelationship(ctx, tid, patient.ID, physician.ID); err != nil {
+		t.Fatalf("create care relationship: %v", err)
+	}
+
+	conv, err := s.CreateConversation(ctx, tid, patient.ID, "carveout test conversation")
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	if _, err := s.CreateMessage(ctx, tid, conv.ID, "user", "I have a headache"); err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+
+	return carveoutFixture{TenantID: tid, Patient: patient, Conv: conv}
+}
+
+// ---------------------------------------------------------------------------
+// spyPhysicianNotifier records SendToPhysicians calls.
+// ---------------------------------------------------------------------------
+
+type spyPhysicianNotifier struct {
+	mu     sync.Mutex
+	events [][]byte
+}
+
+func (n *spyPhysicianNotifier) SendToPhysicians(_ string, event []byte) {
+	cp := make([]byte, len(event))
+	copy(cp, event)
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.events = append(n.events, cp)
+}
+
+func (n *spyPhysicianNotifier) count() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.events)
+}
+
+// ---------------------------------------------------------------------------
+// spyPatientNotifierCarveout records SendToPatient calls.
+// (Named distinctly from the one in deliver_question_test.go to avoid
+// redeclaration — both live in "package agent".)
+// ---------------------------------------------------------------------------
+
+type spyPatientNotifierCarveout struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (n *spyPatientNotifierCarveout) SendToPatient(_, _ string, _ []byte) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.calls++
+}
+
+func (n *spyPatientNotifierCarveout) count() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.calls
+}
+
+// ---------------------------------------------------------------------------
+// Test: question turn — patient notified, no recommendation created.
+// ---------------------------------------------------------------------------
+
+// TestRunInterviewTurn_Question_PatientNotified_NoRecommendation asserts the
+// carve-out for the interview-continues branch of runInterviewTurn:
+//
+//   - When decideInterviewAction yields a question (no marker, cap not reached),
+//     runInterviewTurn MUST persist the question as an assistant message and
+//     call the patient notifier exactly once.
+//   - runInterviewTurn MUST NOT create any recommendation row.
+//   - The physician notifier MUST NOT be called (no queue.updated event).
+func TestRunInterviewTurn_Question_PatientNotified_NoRecommendation(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+	f := setupCarveoutFixture(t, s)
+	ctx := context.Background()
+
+	// A plain interview question — no ReadyForNoteMarker.
+	const question = "Can you describe the character of the pain — is it sharp, dull, or throbbing?"
+
+	physSpy := &spyPhysicianNotifier{}
+	patSpy := &spyPatientNotifierCarveout{}
+	d := NewDrafter(&spyClient{text: question}, s, physSpy, patSpy)
+
+	if err := d.runInterviewTurn(ctx, f.TenantID, f.Conv, f.Patient); err != nil {
+		t.Fatalf("runInterviewTurn: unexpected error: %v", err)
+	}
+
+	// 1. No recommendation must be created.
+	recs, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
+	if err != nil {
+		t.Fatalf("list PENDING_REVIEW recs: %v", err)
+	}
+	for _, r := range recs {
+		if r.ConversationID == f.Conv.ID {
+			t.Errorf("interview question turn must not create a recommendation (found payload_type=%q)", r.PayloadType)
+		}
+	}
+	drafts, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StateDraft)
+	if err != nil {
+		t.Fatalf("list DRAFT recs: %v", err)
+	}
+	for _, r := range drafts {
+		if r.ConversationID == f.Conv.ID {
+			t.Errorf("unexpected DRAFT recommendation for conversation %s", f.Conv.ID)
+		}
+	}
+
+	// 2. An assistant message carrying the question must be persisted.
+	msgs, err := s.ListMessagesByConversation(ctx, f.TenantID, f.Conv.ID)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	var assistantMsgs []store.Message
+	for _, m := range msgs {
+		if m.Role == "assistant" {
+			assistantMsgs = append(assistantMsgs, m)
+		}
+	}
+	if len(assistantMsgs) != 1 {
+		t.Fatalf("expected 1 assistant message (interview question), got %d", len(assistantMsgs))
+	}
+	if assistantMsgs[0].Content != question {
+		t.Errorf("assistant message content = %q, want %q", assistantMsgs[0].Content, question)
+	}
+
+	// 3. Patient notifier must be called exactly once.
+	if patSpy.count() != 1 {
+		t.Errorf("patient notifier called %d times, want 1", patSpy.count())
+	}
+
+	// 4. Physician notifier must NOT be called.
+	if physSpy.count() != 0 {
+		t.Errorf("physician notifier called %d times for an interview-question turn, want 0", physSpy.count())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: ReadyForNote turn — soap_note in PENDING_REVIEW, patient NOT notified.
+// ---------------------------------------------------------------------------
+
+// TestRunInterviewTurn_ReadyForNote_SOAPNoteInPendingReview_PatientNotNotified
+// asserts the carve-out for the SOAP note branch of runInterviewTurn:
+//
+//   - When decideInterviewAction yields ReadyForNote (marker detected), the agent
+//     runtime MUST draft a soap_note recommendation → PENDING_REVIEW.
+//   - The physician notifier MUST receive a queue.updated event.
+//   - The patient notifier MUST NOT be called (clinical A/P is never delivered
+//     by the agent — only by a physician's APPROVE/MODIFY→DELIVER transition).
+func TestRunInterviewTurn_ReadyForNote_SOAPNoteInPendingReview_PatientNotNotified(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+	f := setupCarveoutFixture(t, s)
+	ctx := context.Background()
+
+	// Call 1 (generateInterviewTurn): model emits ReadyForNoteMarker.
+	// Call 2 (draftSOAPNote): model returns a well-formed SOAP note.
+	client := &sequentialClient{
+		responses: []struct {
+			text string
+			err  error
+		}{
+			{text: ReadyForNoteMarker},
+			{text: wellFormedSOAPText}, // from soap_drafter_test.go (same package)
+		},
+	}
+
+	physSpy := &spyPhysicianNotifier{}
+	patSpy := &spyPatientNotifierCarveout{}
+	d := NewDrafter(client, s, physSpy, patSpy)
+
+	if err := d.runInterviewTurn(ctx, f.TenantID, f.Conv, f.Patient); err != nil {
+		t.Fatalf("runInterviewTurn: unexpected error: %v", err)
+	}
+
+	// 1. Exactly one soap_note recommendation in PENDING_REVIEW.
+	recs, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
+	if err != nil {
+		t.Fatalf("list PENDING_REVIEW recs: %v", err)
+	}
+	var found []store.Recommendation
+	for _, r := range recs {
+		if r.ConversationID == f.Conv.ID {
+			found = append(found, r)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected 1 soap_note PENDING_REVIEW recommendation, got %d", len(found))
+	}
+	rec := found[0]
+	if rec.PayloadType != domain.PayloadTypeSOAPNote {
+		t.Errorf("payload_type = %q, want %q", rec.PayloadType, domain.PayloadTypeSOAPNote)
+	}
+
+	// 2. Payload must be parseable as a valid SOAPPayload.
+	var sp domain.SOAPPayload
+	if err := json.Unmarshal(rec.Payload, &sp); err != nil {
+		t.Fatalf("unmarshal soap payload: %v", err)
+	}
+	if err := sp.Validate(); err != nil {
+		t.Errorf("soap payload fails validation: %v", err)
+	}
+
+	// 3. No DRAFT rows must remain (DRAFT→PENDING_REVIEW was atomic).
+	drafts, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StateDraft)
+	if err != nil {
+		t.Fatalf("list DRAFT recs: %v", err)
+	}
+	for _, r := range drafts {
+		if r.ConversationID == f.Conv.ID {
+			t.Errorf("unexpected DRAFT recommendation — DRAFT→PENDING_REVIEW must be atomic")
+		}
+	}
+
+	// 4. Physician notifier must receive a queue.updated event.
+	if physSpy.count() == 0 {
+		t.Fatal("physician notifier not called — queue.updated must be emitted when soap_note is drafted")
+	}
+
+	// 5. Patient notifier MUST NOT be called. This is the core of the carve-out:
+	//    clinical content (Assessment & Plan) never reaches the patient via the
+	//    agent — only via the physician lifecycle (APPROVE/MODIFY → DELIVER).
+	if patSpy.count() != 0 {
+		t.Errorf("patient notifier called %d times during soap_note drafting — CARVE-OUT VIOLATED: "+
+			"clinical content must not be delivered to the patient by the agent", patSpy.count())
+	}
+
+	// 6. No assistant message must be persisted for the SOAP-note turn —
+	//    the note goes into the recommendation row, not the message history.
+	msgs, err := s.ListMessagesByConversation(ctx, f.TenantID, f.Conv.ID)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	for _, m := range msgs {
+		if m.Role == "assistant" {
+			t.Errorf("unexpected assistant message during SOAP-note turn: role=%q content-length=%d "+
+				"— SOAP content must not be written to the message history by the agent",
+				m.Role, len(m.Content))
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Guard test: the agent actor has NO domain transition to APPROVED, MODIFIED,
+// or DELIVERED. These transitions are physician-only.
+// ---------------------------------------------------------------------------
+
+// TestAgentHasNoDeliveryTransition asserts that domain.Transition rejects any
+// attempt by an agent actor to move a recommendation to APPROVED, MODIFIED, or
+// DELIVERED. This is a compile-and-logic guard: even if runInterviewTurn were
+// accidentally extended to call domain.Transition with those actions, the domain
+// layer would reject it.
+func TestAgentHasNoDeliveryTransition(t *testing.T) {
+	agentActor := domain.Actor{Type: domain.ActorAgent, ID: uuid.Nil}
+	const patientState = "CA"
+
+	// The agent CAN go DRAFT → PENDING_REVIEW (its only permitted transition).
+	_, err := domain.Transition(domain.StateDraft, domain.ActionSubmitForReview, agentActor, patientState)
+	if err != nil {
+		t.Errorf("agent DRAFT→PENDING_REVIEW must be permitted, got error: %v", err)
+	}
+
+	// The agent MUST NOT be able to Approve.
+	_, err = domain.Transition(domain.StatePendingReview, domain.ActionApprove, agentActor, patientState)
+	if err == nil {
+		t.Error("agent must not be permitted to Approve a recommendation — CARVE-OUT VIOLATED")
+	}
+
+	// The agent MUST NOT be able to Modify.
+	_, err = domain.Transition(domain.StatePendingReview, domain.ActionModify, agentActor, patientState)
+	if err == nil {
+		t.Error("agent must not be permitted to Modify a recommendation — CARVE-OUT VIOLATED")
+	}
+
+	// The agent MUST NOT be able to Deliver.
+	_, err = domain.Transition(domain.StateApproved, domain.ActionDeliver, agentActor, patientState)
+	if err == nil {
+		t.Error("agent must not be permitted to Deliver a recommendation — CARVE-OUT VIOLATED")
+	}
+
+	// The agent MUST NOT be able to Reject.
+	_, err = domain.Transition(domain.StatePendingReview, domain.ActionReject, agentActor, patientState)
+	if err == nil {
+		t.Error("agent must not be permitted to Reject a recommendation — CARVE-OUT VIOLATED")
+	}
+}

--- a/backend/internal/agent/deliver_question_test.go
+++ b/backend/internal/agent/deliver_question_test.go
@@ -1,0 +1,363 @@
+// Package agent — internal tests for deliverInterviewQuestion (Task 3.1).
+//
+// Uses "package agent" to access the unexported deliverInterviewQuestion symbol.
+// DB-backed tests reuse itTestPool from interview_turn_test.go (same package).
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// spyPatientNotifier records every SendToPatient call for assertions.
+// ---------------------------------------------------------------------------
+
+type spyPatientNotifier struct {
+	mu     sync.Mutex
+	calls  []patientCall
+}
+
+type patientCall struct {
+	tenantID  string
+	patientID string
+	event     []byte
+}
+
+func (n *spyPatientNotifier) SendToPatient(tenantID, patientID string, event []byte) {
+	cp := make([]byte, len(event))
+	copy(cp, event)
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.calls = append(n.calls, patientCall{tenantID: tenantID, patientID: patientID, event: cp})
+}
+
+func (n *spyPatientNotifier) count() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.calls)
+}
+
+func (n *spyPatientNotifier) last() patientCall {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.calls) == 0 {
+		return patientCall{}
+	}
+	return n.calls[len(n.calls)-1]
+}
+
+// ---------------------------------------------------------------------------
+// dqFixture — minimum DB rows for deliverInterviewQuestion testing.
+// ---------------------------------------------------------------------------
+
+type dqFixture struct {
+	TenantID store.TenantID
+	Patient  store.Patient
+	Conv     store.Conversation
+}
+
+func setupDQFixture(t *testing.T, s *store.Store) dqFixture {
+	t.Helper()
+	ctx := context.Background()
+	suffix := uuid.New().String()
+
+	tenant, err := s.CreateTenant(ctx, "dtc", "dq-test-"+suffix)
+	if err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	tid := store.TenantID(tenant.ID)
+
+	patient, err := s.CreatePatient(ctx, tid, store.Patient{
+		Email:        "patient+" + suffix + "@dq.test",
+		FullName:     "DQ Test Patient",
+		State:        "CA",
+		PasswordHash: "hash",
+	})
+	if err != nil {
+		t.Fatalf("create patient: %v", err)
+	}
+
+	conv, err := s.CreateConversation(ctx, tid, patient.ID, "dq test conversation")
+	if err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+
+	// Seed one user message so the conversation exists in a realistic state.
+	if _, err := s.CreateMessage(ctx, tid, conv.ID, "user", "I have a headache"); err != nil {
+		t.Fatalf("create message: %v", err)
+	}
+
+	return dqFixture{TenantID: tid, Patient: patient, Conv: conv}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: deliverInterviewQuestion
+// ---------------------------------------------------------------------------
+
+// TestDeliverInterviewQuestion_PersistsAssistantMessage asserts that
+// deliverInterviewQuestion stores exactly one assistant-role message with the
+// supplied question content in the given conversation.
+func TestDeliverInterviewQuestion_PersistsAssistantMessage(t *testing.T) {
+	pool := itTestPool(t) // defined in interview_turn_test.go, same package
+	s := store.New(pool)
+	f := setupDQFixture(t, s)
+	ctx := context.Background()
+
+	const question = "Can you describe where the pain is located?"
+
+	spy := &spyPatientNotifier{}
+	d := NewDrafter(&spyClient{text: ""}, s, stubNotifierNoop{}, spy)
+
+	if err := d.deliverInterviewQuestion(ctx, f.TenantID, f.Conv, f.Patient, question); err != nil {
+		t.Fatalf("deliverInterviewQuestion: unexpected error: %v", err)
+	}
+
+	// Retrieve all messages for this conversation and find the assistant turn.
+	msgs, err := s.ListMessagesByConversation(ctx, f.TenantID, f.Conv.ID)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+
+	var assistantMsgs []store.Message
+	for _, m := range msgs {
+		if m.Role == "assistant" {
+			assistantMsgs = append(assistantMsgs, m)
+		}
+	}
+
+	if len(assistantMsgs) != 1 {
+		t.Fatalf("expected 1 assistant message, got %d", len(assistantMsgs))
+	}
+	if assistantMsgs[0].Content != question {
+		t.Errorf("message content = %q, want %q", assistantMsgs[0].Content, question)
+	}
+	if assistantMsgs[0].ConversationID != f.Conv.ID {
+		t.Error("message conversation_id mismatch")
+	}
+}
+
+// TestDeliverInterviewQuestion_WritesAuditEventWithIDsOnly asserts that
+// deliverInterviewQuestion writes exactly one audit event of type
+// "agent.interview_question" whose metadata contains conversation_id and
+// message_id but NOT the question text or any other PHI.
+func TestDeliverInterviewQuestion_WritesAuditEventWithIDsOnly(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+	f := setupDQFixture(t, s)
+	ctx := context.Background()
+
+	const question = "How long have you had this symptom?"
+
+	spy := &spyPatientNotifier{}
+	d := NewDrafter(&spyClient{text: ""}, s, stubNotifierNoop{}, spy)
+
+	if err := d.deliverInterviewQuestion(ctx, f.TenantID, f.Conv, f.Patient, question); err != nil {
+		t.Fatalf("deliverInterviewQuestion: unexpected error: %v", err)
+	}
+
+	// Query audit_events directly (tenant-scoped).
+	rows, err := pool.Query(ctx,
+		`SELECT event_type, metadata
+		   FROM audit_events
+		  WHERE tenant_id = $1 AND event_type = 'agent.interview_question'`,
+		f.TenantID.UUID(),
+	)
+	if err != nil {
+		t.Fatalf("query audit events: %v", err)
+	}
+	defer rows.Close()
+
+	var count int
+	for rows.Next() {
+		var eventType string
+		var meta []byte
+		if err := rows.Scan(&eventType, &meta); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+
+		// Metadata must contain conversation_id and message_id.
+		var m map[string]any
+		if err := json.Unmarshal(meta, &m); err != nil {
+			t.Fatalf("unmarshal metadata: %v", err)
+		}
+		if _, ok := m["conversation_id"]; !ok {
+			t.Error("audit metadata missing conversation_id")
+		}
+		if _, ok := m["message_id"]; !ok {
+			t.Error("audit metadata missing message_id")
+		}
+
+		// Question content must NOT appear in the audit metadata.
+		if string(meta) == question {
+			t.Error("audit metadata contains raw question text (PHI leak)")
+		}
+		// Check that the question string is not embedded anywhere in the JSON.
+		var allValues []byte
+		allValues, _ = json.Marshal(m)
+		for k, v := range m {
+			if str, ok := v.(string); ok && str == question {
+				t.Errorf("audit metadata field %q contains question text (PHI leak)", k)
+			}
+		}
+		_ = allValues
+
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 agent.interview_question audit event, got %d", count)
+	}
+}
+
+// TestDeliverInterviewQuestion_NotifiesPatientWithIDsOnly asserts that
+// deliverInterviewQuestion calls the PatientNotifier exactly once with an
+// event of type "message.created" containing only conversation_id and
+// message_id — never the question content.
+func TestDeliverInterviewQuestion_NotifiesPatientWithIDsOnly(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+	f := setupDQFixture(t, s)
+	ctx := context.Background()
+
+	const question = "Do you have any allergies to medications?"
+
+	spy := &spyPatientNotifier{}
+	d := NewDrafter(&spyClient{text: ""}, s, stubNotifierNoop{}, spy)
+
+	if err := d.deliverInterviewQuestion(ctx, f.TenantID, f.Conv, f.Patient, question); err != nil {
+		t.Fatalf("deliverInterviewQuestion: unexpected error: %v", err)
+	}
+
+	if spy.count() != 1 {
+		t.Fatalf("expected 1 patient notification, got %d", spy.count())
+	}
+
+	call := spy.last()
+
+	// The tenantID and patientID routed to the notifier must match the fixture.
+	if call.tenantID != f.TenantID.String() {
+		t.Errorf("notifier tenantID = %q, want %q", call.tenantID, f.TenantID.String())
+	}
+	if call.patientID != f.Patient.ID.String() {
+		t.Errorf("notifier patientID = %q, want %q", call.patientID, f.Patient.ID.String())
+	}
+
+	// Event must be valid JSON with type "message.created" and a data object
+	// containing conversation_id and message_id only.
+	var evt map[string]any
+	if err := json.Unmarshal(call.event, &evt); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if evt["type"] != "message.created" {
+		t.Errorf("event type = %q, want %q", evt["type"], "message.created")
+	}
+	data, ok := evt["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("event.data is not an object: %T", evt["data"])
+	}
+	if _, ok := data["conversation_id"]; !ok {
+		t.Error("event.data missing conversation_id")
+	}
+	if _, ok := data["message_id"]; !ok {
+		t.Error("event.data missing message_id")
+	}
+
+	// Question text must not appear anywhere in the event payload.
+	for k, v := range data {
+		if str, ok := v.(string); ok && str == question {
+			t.Errorf("event.data field %q contains question text (PHI leak)", k)
+		}
+	}
+}
+
+// TestDeliverInterviewQuestion_PersistBeforeNotify asserts that the message
+// referenced in the patient notification event actually exists in the DB when
+// the notifier is called (persist-before-notify ordering guarantee).
+func TestDeliverInterviewQuestion_PersistBeforeNotify(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+	f := setupDQFixture(t, s)
+	ctx := context.Background()
+
+	const question = "On a scale of 1-10, how severe is your pain?"
+
+	var verifyErr error
+
+	// intercept the notification and immediately verify the DB row exists.
+	verifyNotifier := &verifyingPatientNotifier{
+		ctx:   ctx,
+		pool:  pool,
+		store: s,
+		tid:   f.TenantID,
+		convID: f.Conv.ID,
+		onCall: func(msgID uuid.UUID) {
+			msgs, err := s.ListMessagesByConversation(ctx, f.TenantID, f.Conv.ID)
+			if err != nil {
+				verifyErr = err
+				return
+			}
+			found := false
+			for _, m := range msgs {
+				if m.ID == msgID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				verifyErr = &messageNotFoundError{id: msgID}
+			}
+		},
+	}
+
+	d := NewDrafter(&spyClient{text: ""}, s, stubNotifierNoop{}, verifyNotifier)
+
+	if err := d.deliverInterviewQuestion(ctx, f.TenantID, f.Conv, f.Patient, question); err != nil {
+		t.Fatalf("deliverInterviewQuestion: unexpected error: %v", err)
+	}
+	if verifyErr != nil {
+		t.Fatalf("persist-before-notify violated: message not found in DB when notifier fired: %v", verifyErr)
+	}
+}
+
+// verifyingPatientNotifier extracts the message_id from the event JSON and
+// calls onCall so the test can assert the row is already in the DB.
+type verifyingPatientNotifier struct {
+	ctx    context.Context
+	pool   interface{} // unused; kept for import avoidance
+	store  *store.Store
+	tid    store.TenantID
+	convID uuid.UUID
+	onCall func(msgID uuid.UUID)
+}
+
+func (v *verifyingPatientNotifier) SendToPatient(_, _ string, event []byte) {
+	var evt struct {
+		Data struct {
+			MessageID string `json:"message_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(event, &evt); err != nil {
+		return
+	}
+	id, err := uuid.Parse(evt.Data.MessageID)
+	if err != nil {
+		return
+	}
+	v.onCall(id)
+}
+
+// messageNotFoundError is a sentinel error for the persist-before-notify test.
+type messageNotFoundError struct{ id uuid.UUID }
+
+func (e *messageNotFoundError) Error() string {
+	return "message " + e.id.String() + " not found in DB at notification time"
+}

--- a/backend/internal/agent/drafter.go
+++ b/backend/internal/agent/drafter.go
@@ -38,6 +38,15 @@ type PhysicianNotifier interface {
 	SendToPhysicians(tenantID string, event []byte)
 }
 
+// PatientNotifier is the narrow interface the Drafter needs to push
+// message.created events to the patient who owns the conversation. The
+// event payload carries identifiers only (conversation_id, message_id) —
+// never message content (PHI). The iOS client fetches content via its
+// authenticated REST channel after receiving the event.
+type PatientNotifier interface {
+	SendToPatient(tenantID, patientID string, event []byte)
+}
+
 // Drafter listens for persisted patient messages and drives the
 // DRAFT → PENDING_REVIEW lifecycle for guidance recommendations.
 //
@@ -47,15 +56,16 @@ type PhysicianNotifier interface {
 // request is NOT propagated — drafting must complete even if the patient
 // disconnects. The goroutine uses a background context derived from the store.
 type Drafter struct {
-	client     ModelClient
-	store      *store.Store
-	notifier   PhysicianNotifier
-	onComplete func() // optional; called (via defer) when the goroutine exits — tests use this for synchronisation
+	client          ModelClient
+	store           *store.Store
+	notifier        PhysicianNotifier
+	patientNotifier PatientNotifier
+	onComplete      func() // optional; called (via defer) when the goroutine exits — tests use this for synchronisation
 }
 
-// NewDrafter constructs a Drafter. All three arguments are required.
-func NewDrafter(client ModelClient, s *store.Store, notifier PhysicianNotifier) *Drafter {
-	return &Drafter{client: client, store: s, notifier: notifier}
+// NewDrafter constructs a Drafter. All four arguments are required.
+func NewDrafter(client ModelClient, s *store.Store, notifier PhysicianNotifier, patientNotifier PatientNotifier) *Drafter {
+	return &Drafter{client: client, store: s, notifier: notifier, patientNotifier: patientNotifier}
 }
 
 // WithOnComplete returns a shallow copy of d with the onComplete hook set.
@@ -524,6 +534,57 @@ func (d *Drafter) draftSOAPNote(ctx context.Context, tenantID store.TenantID, co
 		"data": map[string]any{
 			"recommendation_id": recID.String(),
 			"conversation_id":   conv.ID.String(),
+		},
+	}))
+
+	return nil
+}
+
+// deliverInterviewQuestion persists an agent interview question as an
+// assistant-role message, writes an audit event with identifiers only (no
+// PHI), and emits a WebSocket event to the patient carrying only IDs so the
+// iOS client can fetch the content over its authenticated REST channel.
+//
+// Order guarantee: the message is committed and audited before the patient
+// notifier fires, so the client can never receive a reference to a message
+// that does not yet exist in the database.
+//
+// PHI discipline: question content is stored in the message row only. Audit
+// metadata and the patient WebSocket event contain conversation_id and
+// message_id exclusively — never the question text.
+func (d *Drafter) deliverInterviewQuestion(ctx context.Context, tenantID store.TenantID, conv store.Conversation, patient store.Patient, question string) error {
+	// Step 1: persist the question as an assistant-role message so the iOS
+	// client can retrieve it via GET /api/conversations/{id}/messages.
+	msg, err := d.store.CreateMessage(ctx, tenantID, conv.ID, "assistant", question)
+	if err != nil {
+		return err
+	}
+
+	// Step 2: write the audit event. Metadata contains identifiers only —
+	// no PHI, no message content.
+	if _, auditErr := d.store.CreateAuditEvent(ctx, tenantID, store.AuditEvent{
+		ActorType: string(domain.ActorAgent),
+		ActorID:   nil, // agent has no user UUID
+		EventType: "agent.interview_question",
+		Metadata: mustMarshalJSON(map[string]any{
+			"conversation_id": conv.ID.String(),
+			"message_id":      msg.ID.String(),
+		}),
+	}); auditErr != nil {
+		// A failed audit write must not prevent the message from being
+		// delivered — log the error type only (never the value, which could
+		// echo PHI) and continue.
+		log.Printf("agent: audit write failed conversation_id=%s: %T", conv.ID, auditErr)
+	}
+
+	// Step 3: emit a WebSocket event to the patient. The payload is IDs only
+	// so no PHI crosses the notification channel. The client fetches message
+	// content via its authenticated REST endpoint after receiving the event.
+	d.patientNotifier.SendToPatient(tenantID.String(), patient.ID.String(), mustMarshalJSON(map[string]any{
+		"type": "message.created",
+		"data": map[string]any{
+			"conversation_id": conv.ID.String(),
+			"message_id":      msg.ID.String(),
 		},
 	}))
 

--- a/backend/internal/agent/drafter.go
+++ b/backend/internal/agent/drafter.go
@@ -81,9 +81,12 @@ func (d *Drafter) WithOnComplete(fn func()) *Drafter {
 	return &cp
 }
 
-// DraftAsync spawns a goroutine that assembles the conversation context,
-// calls the model, and persists a PENDING_REVIEW recommendation. It is
-// fire-and-forget: errors are logged but never returned to the caller.
+// DraftAsync spawns a goroutine that runs one step of the clinical interview
+// per patient message: either delivers the next interview question directly to
+// the patient, or — when the interview is judged complete — drafts a soap_note
+// recommendation into PENDING_REVIEW for physician review. It is fire-and-
+// forget: errors are logged but never returned to the caller.
+//
 // The caller must not pass a request-scoped context — use context.Background()
 // or a long-lived server context so the goroutine is not cancelled when the
 // HTTP handler returns.
@@ -96,10 +99,10 @@ func (d *Drafter) DraftAsync(tenantID store.TenantID, conv store.Conversation, p
 			defer d.onComplete()
 		}
 
-		// Recover from any panic inside draft() (nil-deref, driver bug, etc.)
-		// so a single drafting failure cannot crash the server process.
-		// middleware.Recoverer only protects HTTP handler goroutines; fire-and-
-		// forget goroutines must manage their own recovery.
+		// Recover from any panic inside runInterviewTurn (nil-deref, driver
+		// bug, etc.) so a single drafting failure cannot crash the server
+		// process. middleware.Recoverer only protects HTTP handler goroutines;
+		// fire-and-forget goroutines must manage their own recovery.
 		// Log type only — never the recovered value itself, which may echo
 		// request content or PHI.
 		defer func() {
@@ -109,7 +112,7 @@ func (d *Drafter) DraftAsync(tenantID store.TenantID, conv store.Conversation, p
 		}()
 
 		ctx := context.Background()
-		if err := d.draft(ctx, tenantID, conv, patient); err != nil {
+		if err := d.runInterviewTurn(ctx, tenantID, conv, patient); err != nil {
 			// Log type only — never the error message or body, which may echo
 			// request content or PHI (see ModelError.Body HIPAA note in
 			// client.go).
@@ -138,108 +141,58 @@ func (d *Drafter) DraftAsync(tenantID store.TenantID, conv store.Conversation, p
 	}()
 }
 
-// draft is the synchronous drafting logic, separated for testability.
-func (d *Drafter) draft(ctx context.Context, tenantID store.TenantID, conv store.Conversation, patient store.Patient) error {
-	// Assemble tenant-scoped conversation context. The query includes
-	// tenant_id in the WHERE clause so messages from other tenants are
-	// never mixed in, even if two tenants share a conversation UUID by
-	// some extreme coincidence.
-	msgs, err := d.store.ListMessagesByConversation(ctx, tenantID, conv.ID)
+// runInterviewTurn is the synchronous orchestration logic called by DraftAsync
+// per patient message. It runs one step of the clinical interview:
+//
+//   - Generates the next turn from the tenant-scoped conversation history using
+//     the clinical interview system prompt.
+//   - Loads the prior messages (tenant-scoped) to check the turn cap.
+//   - Decides whether the interview is complete (marker detected or cap reached).
+//   - If complete: drafts a soap_note recommendation → PENDING_REVIEW and emits
+//     queue.updated to the physician. The patient is NOT notified here — clinical
+//     Assessment & Plan require physician review before reaching the patient.
+//   - If continuing: delivers the interview question to the patient as an
+//     assistant message (persisted + WebSocket notification). No recommendation
+//     is created for interview questions (non-clinical data collection only).
+//
+// Delivery carve-out guarantee: interview questions (non-clinical) are the ONLY
+// agent output delivered directly to the patient. The soap_note (clinical A/P)
+// never reaches the patient without a physician lifecycle transition — enforced
+// by this branching logic. There is no code path in this function (or in
+// deliverInterviewQuestion) that creates a recommendation or delivers clinical
+// content directly.
+func (d *Drafter) runInterviewTurn(ctx context.Context, tenantID store.TenantID, conv store.Conversation, patient store.Patient) error {
+	// Generate the next interview turn. The model is called with the clinical
+	// interview system prompt followed by the full tenant-scoped conversation
+	// history. Content never enters logs or audit (PHI constraint).
+	raw, err := d.generateInterviewTurn(ctx, tenantID, conv)
 	if err != nil {
 		return err
 	}
 
-	// Build the model message slice: a brief system prompt followed by the
-	// conversation history. Content goes into the model call only — it is
-	// never written to audit logs.
-	modelMsgs := make([]Message, 0, len(msgs)+1)
-	modelMsgs = append(modelMsgs, Message{
-		Role:    "system",
-		Content: "You are a medical assistant. Provide concise clinical guidance based on the conversation.",
-	})
-	for _, m := range msgs {
-		modelMsgs = append(modelMsgs, Message{
-			Role:    m.Role,
-			Content: m.Content,
-		})
-	}
-
-	text, err := d.client.Complete(ctx, modelMsgs)
-	if err != nil {
-		// Non-nil error means no valid model output — do NOT persist as
-		// clinical content (failure contract from client.go). Task 4.3
-		// handles this branch fully.
-		return err
-	}
-
-	// Build the guidance payload. Only the model text goes here — no
-	// audit metadata, no PHI from other sources.
-	payload, err := json.Marshal(map[string]string{"text": text})
+	// Load prior messages for the turn-cap check. Tenant-scoped query ensures
+	// cross-tenant bleed is impossible. These are the messages present before
+	// any assistant response is persisted — correct for decideInterviewAction's
+	// "priorMsgs" contract (assistant-role count before this turn).
+	priorMsgs, err := d.store.ListMessagesByConversation(ctx, tenantID, conv.ID)
 	if err != nil {
 		return err
 	}
 
-	agentActor := domain.Actor{Type: domain.ActorAgent, ID: uuid.Nil}
+	outcome := decideInterviewAction(raw, priorMsgs, DefaultMaxInterviewTurns)
 
-	// Persist DRAFT → PENDING_REVIEW + audit event atomically. The
-	// two-step pattern (create DRAFT then transition to PENDING_REVIEW
-	// within the same Txn) mirrors the Phase 3 physician review pattern
-	// so there is never a DRAFT row visible outside the transaction.
-	var recID uuid.UUID
-	if err := d.store.Txn(ctx, func(tx *store.TxStore) error {
-		// Step 1: insert at DRAFT.
-		rec, err := tx.CreateRecommendation(ctx, tenantID, store.Recommendation{
-			ConversationID: conv.ID,
-			PatientID:      patient.ID,
-			State:          domain.StateDraft,
-			PayloadType:    "guidance",
-			Payload:        payload,
-			DraftContent:   text,
-		})
-		if err != nil {
-			return err
-		}
-		recID = rec.ID
-
-		// Step 2: pure state-machine transition DRAFT → PENDING_REVIEW.
-		// The agent actor has no path beyond this single transition.
-		nextState, err := domain.Transition(rec.State, domain.ActionSubmitForReview, agentActor, patient.State)
-		if err != nil {
-			return err
-		}
-
-		// Step 3: persist the new state within the same transaction.
-		if err := tx.UpdateRecommendationState(ctx, tenantID, rec.ID, nextState, nil, nil); err != nil {
-			return err
-		}
-
-		// Step 4: write the audit event. Metadata contains identifiers only
-		// — no PHI, no model output.
-		return tx.CreateAuditEvent(ctx, tenantID, store.AuditEvent{
-			ActorType: string(domain.ActorAgent),
-			ActorID:   nil, // agent has no user UUID
-			EventType: "recommendation.submitted_for_review",
-			Metadata: mustMarshalJSON(map[string]any{
-				"recommendation_id": recID.String(),
-				"conversation_id":   conv.ID.String(),
-				"new_state":         nextState,
-			}),
-		})
-	}); err != nil {
-		return err
+	if outcome.ReadyForNote {
+		// Interview complete: draft the SOAP note through DRAFT→PENDING_REVIEW.
+		// Physicians receive a queue.updated event; the patient receives nothing
+		// from the agent at this point. Clinical content (Assessment & Plan) will
+		// reach the patient only after a physician transitions the recommendation
+		// to APPROVED/MODIFIED and it is delivered via the standard lifecycle.
+		return d.draftSOAPNote(ctx, tenantID, conv, patient)
 	}
 
-	// Emit queue.updated AFTER the successful commit so physicians only
-	// receive the event when the row is durably visible.
-	d.notifier.SendToPhysicians(tenantID.String(), mustMarshalJSON(map[string]any{
-		"type": "queue.updated",
-		"data": map[string]any{
-			"recommendation_id": recID.String(),
-			"conversation_id":   conv.ID.String(),
-		},
-	}))
-
-	return nil
+	// Interview continues: deliver the next question to the patient. No
+	// recommendation row is created; this is non-clinical data collection.
+	return d.deliverInterviewQuestion(ctx, tenantID, conv, patient, outcome.Question)
 }
 
 // generateInterviewTurn assembles the full tenant-scoped conversation history

--- a/backend/internal/agent/drafter.go
+++ b/backend/internal/agent/drafter.go
@@ -48,7 +48,7 @@ type PatientNotifier interface {
 }
 
 // Drafter listens for persisted patient messages and drives the
-// DRAFT → PENDING_REVIEW lifecycle for guidance recommendations.
+// DRAFT → PENDING_REVIEW lifecycle for soap_note recommendations.
 //
 // Threading: DraftAsync dispatches the work to a goroutine so the patient's
 // HTTP response is returned immediately; the model call (which may take up to
@@ -200,7 +200,7 @@ func (d *Drafter) runInterviewTurn(ctx context.Context, tenantID store.TenantID,
 // message in the model call is always InterviewSystemPrompt (system role) so
 // the model stays in interview mode; the rest is the raw conversation history.
 //
-// Error discipline mirrors draft(): a non-nil error means no usable model
+// Error discipline mirrors runInterviewTurn's contract: a non-nil error means no usable model
 // output was obtained — the caller must not treat the returned string as
 // clinical content. Message content is never logged (PHI constraint). The
 // error type carries enough coarse information for draftFailureReason to
@@ -380,9 +380,9 @@ func parseSOAPSections(raw string) (domain.SOAPPayload, error) {
 // draftSOAPNote assembles the conversation history, calls the model with
 // SOAPDraftSystemPrompt, parses the four SOAP sections, validates them, and
 // atomically persists a soap_note recommendation at PENDING_REVIEW — mirroring
-// the DRAFT→PENDING_REVIEW transaction pattern in draft().
+// the DRAFT→PENDING_REVIEW transaction pattern used across the agent.
 //
-// Error discipline is identical to draft(): a non-nil return means no
+// Error discipline is identical to the rest of the agent: a non-nil return means no
 // recommendation was persisted; the caller (DraftAsync or the phase-3 entry
 // point) is responsible for writing the ai_interaction_failed audit event.
 // No model output is logged (PHI constraint).

--- a/backend/internal/agent/drafter_test.go
+++ b/backend/internal/agent/drafter_test.go
@@ -140,6 +140,36 @@ type stubPatientNotifier struct{}
 
 func (stubPatientNotifier) SendToPatient(_, _ string, _ []byte) {}
 
+// recordingPatientNotifier captures every SendToPatient call so tests can
+// assert the patient was (or was not) notified.
+type recordingPatientNotifier struct {
+	mu    sync.Mutex
+	calls [][]byte
+}
+
+func (n *recordingPatientNotifier) SendToPatient(_, _ string, event []byte) {
+	cp := make([]byte, len(event))
+	copy(cp, event)
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.calls = append(n.calls, cp)
+}
+
+func (n *recordingPatientNotifier) count() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.calls)
+}
+
+func (n *recordingPatientNotifier) last() []byte {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.calls) == 0 {
+		return nil
+	}
+	return n.calls[len(n.calls)-1]
+}
+
 // ---------------------------------------------------------------------------
 // setupDrafterFixture creates one tenant, patient, physician, care relationship,
 // conversation, and one user message, then returns everything needed to test the
@@ -207,89 +237,98 @@ func setupDrafterFixture(t *testing.T, s *store.Store) drafterFixture {
 // Tests
 // ---------------------------------------------------------------------------
 
-// TestDraft_HappyPath verifies that a patient message produces exactly one
-// PENDING_REVIEW recommendation with payload_type='guidance', an audit event,
-// and a queue.updated notification to physicians.
+// TestDraft_HappyPath verifies that a patient message during an ongoing
+// interview produces an assistant interview question: exactly one assistant-role
+// message persisted, one patient notification (message.created), one
+// agent.interview_question audit event, and NO recommendation row and NO
+// queue.updated event sent to physicians.
+//
+// The stub client returns plain text without ReadyForNoteMarker, so
+// decideInterviewAction classifies the turn as a continuing interview question.
 func TestDraft_HappyPath(t *testing.T) {
 	pool := testPool(t)
 	s := store.New(pool)
 	f := setupDrafterFixture(t, s)
 	ctx := context.Background()
 
-	const wantText = "Take ibuprofen and rest. Consult a physician if symptoms worsen."
+	// A normal interview question — no ReadyForNoteMarker present.
+	const wantText = "Can you describe where the pain is located?"
 
-	notifier := &stubNotifier{}
+	physNotifier := &stubNotifier{}
+	patNotifier := &recordingPatientNotifier{}
 	// newDrafterWithWait registers a t.Cleanup that blocks until the goroutine
 	// has exited, preventing races with shared-DB teardown across tests.
-	d, _ := newDrafterWithWait(t, &stubClient{text: wantText}, s, notifier, stubPatientNotifier{})
+	d, wg := newDrafterWithWait(t, &stubClient{text: wantText}, s, physNotifier, patNotifier)
 
-	// DraftAsync is fire-and-forget; we detect completion via the
-	// queue.updated notification (which fires only after a successful commit).
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
-	// Poll until the notifier receives the event (max 5 s — the stub client
-	// returns instantly so this should be near-zero in practice).
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) && notifier.count() == 0 {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if notifier.count() == 0 {
-		t.Fatal("queue.updated event never received — drafting may have failed")
-	}
+	// Block until the goroutine has fully exited (onComplete hook fires on
+	// success, failure, or panic so this is always safe).
+	wg.Wait()
 
-	// --- Assert exactly one PENDING_REVIEW recommendation ---
+	// --- Assert NO recommendation was created (interview question, not note) ---
 	recs, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
 	if err != nil {
-		t.Fatalf("list recommendations: %v", err)
+		t.Fatalf("list PENDING_REVIEW recs: %v", err)
 	}
-	if len(recs) != 1 {
-		t.Fatalf("expected 1 PENDING_REVIEW recommendation, got %d", len(recs))
+	for _, r := range recs {
+		if r.ConversationID == f.Conv.ID {
+			t.Errorf("unexpected PENDING_REVIEW recommendation for conversation %s — interview questions must not create recommendations", f.Conv.ID)
+		}
 	}
-	rec := recs[0]
-
-	if rec.PayloadType != "guidance" {
-		t.Errorf("payload_type = %q, want %q", rec.PayloadType, "guidance")
-	}
-	if rec.ConversationID != f.Conv.ID {
-		t.Errorf("conversation_id mismatch")
-	}
-	if rec.PatientID != f.Patient.ID {
-		t.Errorf("patient_id mismatch")
-	}
-
-	// Verify payload contains the model output text.
-	var payload map[string]string
-	if err := json.Unmarshal(rec.Payload, &payload); err != nil {
-		t.Fatalf("unmarshal payload: %v", err)
-	}
-	if payload["text"] != wantText {
-		t.Errorf("payload[text] = %q, want %q", payload["text"], wantText)
-	}
-
-	// draft_content should also carry the model text.
-	if rec.DraftContent != wantText {
-		t.Errorf("draft_content = %q, want %q", rec.DraftContent, wantText)
-	}
-
-	// --- Assert no DRAFT rows remain (the DRAFT → PENDING_REVIEW transition
-	// was atomic: the DRAFT state should never be observable outside the Txn) ---
 	drafts, err := s.ListRecommendationsByState(ctx, f.TenantID, domain.StateDraft)
 	if err != nil {
-		t.Fatalf("list draft recommendations: %v", err)
+		t.Fatalf("list DRAFT recs: %v", err)
 	}
-	if len(drafts) != 0 {
-		t.Errorf("expected 0 DRAFT recommendations, got %d", len(drafts))
+	for _, r := range drafts {
+		if r.ConversationID == f.Conv.ID {
+			t.Errorf("unexpected DRAFT recommendation for conversation %s", f.Conv.ID)
+		}
 	}
 
-	// --- Assert audit event exists ---
-	// We query audit_events directly because the store's read path is
-	// tenant-scoped; the event_type must not contain PHI.
-	pool2 := pool // same pool, we re-use it
-	rows, err := pool2.Query(ctx,
-		`SELECT event_type, metadata
+	// --- Assert the interview question was persisted as an assistant message ---
+	msgs, err := s.ListMessagesByConversation(ctx, f.TenantID, f.Conv.ID)
+	if err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+	var assistantMsgs []store.Message
+	for _, m := range msgs {
+		if m.Role == "assistant" {
+			assistantMsgs = append(assistantMsgs, m)
+		}
+	}
+	if len(assistantMsgs) != 1 {
+		t.Fatalf("expected 1 assistant message, got %d", len(assistantMsgs))
+	}
+	if assistantMsgs[0].Content != wantText {
+		t.Errorf("assistant message content = %q, want %q", assistantMsgs[0].Content, wantText)
+	}
+
+	// --- Assert patient was notified (message.created event with IDs only) ---
+	if patNotifier.count() != 1 {
+		t.Fatalf("expected 1 patient notification, got %d", patNotifier.count())
+	}
+	var patEvt map[string]any
+	if err := json.Unmarshal(patNotifier.last(), &patEvt); err != nil {
+		t.Fatalf("unmarshal patient event: %v", err)
+	}
+	if patEvt["type"] != "message.created" {
+		t.Errorf("patient event type = %q, want %q", patEvt["type"], "message.created")
+	}
+
+	// --- Assert NO queue.updated event was emitted to physicians ---
+	if physNotifier.count() != 0 {
+		t.Errorf("expected 0 physician queue.updated events for an interview question turn, got %d", physNotifier.count())
+	}
+
+	// --- Assert audit event exists with identifiers only (no PHI) ---
+	rows, err := pool.Query(ctx,
+		`SELECT metadata
 		   FROM audit_events
-		  WHERE tenant_id = $1 AND event_type = 'recommendation.submitted_for_review'`,
+		  WHERE tenant_id = $1 AND event_type = 'agent.interview_question'
+		    AND metadata->>'conversation_id' = $2`,
 		f.TenantID.UUID(),
+		f.Conv.ID.String(),
 	)
 	if err != nil {
 		t.Fatalf("query audit events: %v", err)
@@ -298,30 +337,24 @@ func TestDraft_HappyPath(t *testing.T) {
 
 	var auditCount int
 	for rows.Next() {
-		var eventType string
 		var meta []byte
-		if err := rows.Scan(&eventType, &meta); err != nil {
+		if err := rows.Scan(&meta); err != nil {
 			t.Fatalf("scan audit row: %v", err)
 		}
-		// Metadata must contain recommendation_id and conversation_id but NOT
-		// the model text or any PHI.
 		var m map[string]any
 		if err := json.Unmarshal(meta, &m); err != nil {
 			t.Fatalf("unmarshal audit metadata: %v", err)
 		}
-		if _, ok := m["recommendation_id"]; !ok {
-			t.Errorf("audit metadata missing recommendation_id")
-		}
 		if _, ok := m["conversation_id"]; !ok {
 			t.Errorf("audit metadata missing conversation_id")
 		}
-		// Model output must NOT appear in audit metadata.
-		raw := string(meta)
-		if raw == wantText || (len(wantText) > 10 && len(raw) > 10) {
-			// Check by looking for the model text literally.
-			if json.Valid([]byte(wantText)) {
-				// model text happens to be JSON — unlikely in practice but skip
-				// this assertion to avoid false positives.
+		if _, ok := m["message_id"]; !ok {
+			t.Errorf("audit metadata missing message_id")
+		}
+		// Question content must NOT appear in audit metadata (PHI constraint).
+		for _, field := range []string{"content", "text", "question"} {
+			if v, ok := m[field]; ok {
+				t.Errorf("audit metadata must not contain field %q (PHI leak): value = %v", field, v)
 			}
 		}
 		auditCount++
@@ -330,26 +363,14 @@ func TestDraft_HappyPath(t *testing.T) {
 		t.Fatalf("rows error: %v", err)
 	}
 	if auditCount != 1 {
-		t.Errorf("expected 1 audit event for recommendation.submitted_for_review, got %d", auditCount)
-	}
-
-	// --- Assert queue.updated event was emitted ---
-	lastEvent := notifier.last()
-	if lastEvent == nil {
-		t.Fatal("no queue.updated event emitted")
-	}
-	var evt map[string]any
-	if err := json.Unmarshal(lastEvent, &evt); err != nil {
-		t.Fatalf("unmarshal queue.updated event: %v", err)
-	}
-	if evt["type"] != "queue.updated" {
-		t.Errorf("event type = %q, want %q", evt["type"], "queue.updated")
+		t.Errorf("expected 1 audit event for agent.interview_question, got %d", auditCount)
 	}
 }
 
-// TestDraft_TenantScoping verifies that the drafter only reads messages that
-// belong to the target conversation/tenant and never bleeds into another
-// tenant's data.
+// TestDraft_TenantScoping verifies that the drafter only reads and writes data
+// scoped to the target tenant and never bleeds into another tenant's data. Under
+// the interview flow, a normal question turn persists an assistant message in the
+// target tenant's conversation and must NOT touch any other tenant's data.
 func TestDraft_TenantScoping(t *testing.T) {
 	pool := testPool(t)
 	s := store.New(pool)
@@ -382,18 +403,18 @@ func TestDraft_TenantScoping(t *testing.T) {
 		t.Fatalf("create message B: %v", err)
 	}
 
-	// Run drafter for tenant A only.
-	const wantText = "Guidance for A only."
-	notifier := &stubNotifier{}
-	d, _ := newDrafterWithWait(t, &stubClient{text: wantText}, s, notifier, stubPatientNotifier{})
+	// Run drafter for tenant A only. Stub returns a plain interview question
+	// (no marker), so the turn delivers a question and creates no recommendation.
+	const wantText = "Interview question for A only."
+	physNotifier := &stubNotifier{}
+	patNotifier := &recordingPatientNotifier{}
+	d, wg := newDrafterWithWait(t, &stubClient{text: wantText}, s, physNotifier, patNotifier)
 	d.DraftAsync(fA.TenantID, fA.Conv, fA.Patient)
 
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) && notifier.count() == 0 {
-		time.Sleep(10 * time.Millisecond)
-	}
+	// Block until the goroutine exits before making DB assertions.
+	wg.Wait()
 
-	// Tenant B must have zero recommendations.
+	// --- Neither tenant must have any recommendation (interview question turn) ---
 	recsB, err := s.ListRecommendationsByState(ctx, tidB, domain.StatePendingReview)
 	if err != nil {
 		t.Fatalf("list B recs: %v", err)
@@ -401,14 +422,40 @@ func TestDraft_TenantScoping(t *testing.T) {
 	if len(recsB) != 0 {
 		t.Errorf("tenant B has %d recommendations after drafting for tenant A — tenant leak!", len(recsB))
 	}
-
-	// Tenant A must have exactly one.
 	recsA, err := s.ListRecommendationsByState(ctx, fA.TenantID, domain.StatePendingReview)
 	if err != nil {
 		t.Fatalf("list A recs: %v", err)
 	}
-	if len(recsA) != 1 {
-		t.Errorf("tenant A has %d PENDING_REVIEW recommendations, want 1", len(recsA))
+	if len(recsA) != 0 {
+		t.Errorf("tenant A has %d PENDING_REVIEW recommendations for an interview-question turn, want 0", len(recsA))
+	}
+
+	// --- Tenant A's conversation must have the interview question as an assistant
+	// message; tenant B's conversation must have only its original user message. ---
+	msgsA, err := s.ListMessagesByConversation(ctx, fA.TenantID, fA.Conv.ID)
+	if err != nil {
+		t.Fatalf("list tenant A messages: %v", err)
+	}
+	var assistantA []store.Message
+	for _, m := range msgsA {
+		if m.Role == "assistant" {
+			assistantA = append(assistantA, m)
+		}
+	}
+	if len(assistantA) != 1 {
+		t.Errorf("tenant A: expected 1 assistant message (interview question), got %d", len(assistantA))
+	} else if assistantA[0].Content != wantText {
+		t.Errorf("tenant A assistant message content = %q, want %q", assistantA[0].Content, wantText)
+	}
+
+	msgsB, err := s.ListMessagesByConversation(ctx, tidB, convB.ID)
+	if err != nil {
+		t.Fatalf("list tenant B messages: %v", err)
+	}
+	for _, m := range msgsB {
+		if m.Role == "assistant" {
+			t.Errorf("tenant B has unexpected assistant message — cross-tenant bleed: content=%q", m.Content)
+		}
 	}
 }
 

--- a/backend/internal/agent/drafter_test.go
+++ b/backend/internal/agent/drafter_test.go
@@ -94,11 +94,11 @@ func (p *panicClient) Complete(_ context.Context, _ []agent.Message) (string, er
 // sync.WaitGroup when it exits (success, failure, or panic). Call wg.Wait()
 // (or register it in t.Cleanup) to ensure no goroutine outlives the test.
 // This is test-only; production callers use agent.NewDrafter directly.
-func newDrafterWithWait(t *testing.T, client agent.ModelClient, s *store.Store, notifier *stubNotifier) (*agent.Drafter, *sync.WaitGroup) {
+func newDrafterWithWait(t *testing.T, client agent.ModelClient, s *store.Store, notifier *stubNotifier, patientNotifier agent.PatientNotifier) (*agent.Drafter, *sync.WaitGroup) {
 	t.Helper()
 	var wg sync.WaitGroup
 	wg.Add(1)
-	d := agent.NewDrafter(client, s, notifier).WithOnComplete(wg.Done)
+	d := agent.NewDrafter(client, s, notifier, patientNotifier).WithOnComplete(wg.Done)
 	t.Cleanup(func() {
 		// Block until the goroutine has fully exited so no in-flight DB writes
 		// can race with test teardown or the store package's TRUNCATE.
@@ -133,6 +133,12 @@ func (n *stubNotifier) last() []byte {
 	}
 	return n.events[len(n.events)-1]
 }
+
+// stubPatientNotifier is a no-op agent.PatientNotifier for tests that only
+// exercise the physician-notification path.
+type stubPatientNotifier struct{}
+
+func (stubPatientNotifier) SendToPatient(_, _ string, _ []byte) {}
 
 // ---------------------------------------------------------------------------
 // setupDrafterFixture creates one tenant, patient, physician, care relationship,
@@ -215,7 +221,7 @@ func TestDraft_HappyPath(t *testing.T) {
 	notifier := &stubNotifier{}
 	// newDrafterWithWait registers a t.Cleanup that blocks until the goroutine
 	// has exited, preventing races with shared-DB teardown across tests.
-	d, _ := newDrafterWithWait(t, &stubClient{text: wantText}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{text: wantText}, s, notifier, stubPatientNotifier{})
 
 	// DraftAsync is fire-and-forget; we detect completion via the
 	// queue.updated notification (which fires only after a successful commit).
@@ -379,7 +385,7 @@ func TestDraft_TenantScoping(t *testing.T) {
 	// Run drafter for tenant A only.
 	const wantText = "Guidance for A only."
 	notifier := &stubNotifier{}
-	d, _ := newDrafterWithWait(t, &stubClient{text: wantText}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{text: wantText}, s, notifier, stubPatientNotifier{})
 	d.DraftAsync(fA.TenantID, fA.Conv, fA.Patient)
 
 	deadline := time.Now().Add(5 * time.Second)
@@ -528,7 +534,7 @@ func TestDraft_FailurePath_TransportError(t *testing.T) {
 	// a connection-refused error.
 	transportErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
 	notifier := &stubNotifier{}
-	d, _ := newDrafterWithWait(t, &stubClient{err: transportErr}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{err: transportErr}, s, notifier, stubPatientNotifier{})
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
 	assertFailurePath(t, pool, s, f, notifier, "model_unavailable")
@@ -544,7 +550,7 @@ func TestDraft_FailurePath_ModelError(t *testing.T) {
 
 	modelErr := &agent.ModelError{StatusCode: 503}
 	notifier := &stubNotifier{}
-	d, _ := newDrafterWithWait(t, &stubClient{err: modelErr}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{err: modelErr}, s, notifier, stubPatientNotifier{})
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
 	assertFailurePath(t, pool, s, f, notifier, "model_error")
@@ -561,7 +567,7 @@ func TestDraft_FailurePath_ParseError(t *testing.T) {
 
 	parseErr := &agent.ParseError{Detail: "response contained no choices"}
 	notifier := &stubNotifier{}
-	d, _ := newDrafterWithWait(t, &stubClient{err: parseErr}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{err: parseErr}, s, notifier, stubPatientNotifier{})
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
 	assertFailurePath(t, pool, s, f, notifier, "parse_error")
@@ -576,7 +582,7 @@ func TestDraft_FailurePath_Timeout(t *testing.T) {
 	f := setupDrafterFixture(t, s)
 
 	notifier := &stubNotifier{}
-	d, _ := newDrafterWithWait(t, &stubClient{err: context.DeadlineExceeded}, s, notifier)
+	d, _ := newDrafterWithWait(t, &stubClient{err: context.DeadlineExceeded}, s, notifier, stubPatientNotifier{})
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
 	assertFailurePath(t, pool, s, f, notifier, "timeout")
@@ -610,7 +616,7 @@ func TestDraft_ErrorPath_StructuredForTask43(t *testing.T) {
 
 	modelErr := &agent.ModelError{StatusCode: 503}
 	notifier := &stubNotifier{}
-	d, wg := newDrafterWithWait(t, &stubClient{err: modelErr}, s, notifier)
+	d, wg := newDrafterWithWait(t, &stubClient{err: modelErr}, s, notifier, stubPatientNotifier{})
 	d.DraftAsync(f.TenantID, f.Conv, f.Patient)
 
 	// Wait for the goroutine to finish before asserting; newDrafterWithWait
@@ -650,7 +656,7 @@ func TestDraft_PanicRecovery(t *testing.T) {
 	ctx := context.Background()
 
 	notifier := &stubNotifier{}
-	d, wg := newDrafterWithWait(t, &panicClient{}, s, notifier)
+	d, wg := newDrafterWithWait(t, &panicClient{}, s, notifier, stubPatientNotifier{})
 
 	// DraftAsync must return without panicking — if the goroutine's panic
 	// propagates the test binary itself will crash here.

--- a/backend/internal/agent/interview_turn_test.go
+++ b/backend/internal/agent/interview_turn_test.go
@@ -124,10 +124,12 @@ func itSetupConversation(t *testing.T, s *store.Store, messages []struct{ Role, 
 	return itFixture{TenantID: tid, Conv: conv}
 }
 
-// stubNotifierNoop satisfies PhysicianNotifier for Drafter construction.
+// stubNotifierNoop satisfies PhysicianNotifier and PatientNotifier for Drafter
+// construction in tests that do not exercise notification paths.
 type stubNotifierNoop struct{}
 
 func (stubNotifierNoop) SendToPhysicians(_ string, _ []byte) {}
+func (stubNotifierNoop) SendToPatient(_, _ string, _ []byte) {}
 
 // ---------------------------------------------------------------------------
 // Tests: generateInterviewTurn
@@ -146,7 +148,7 @@ func TestGenerateInterviewTurn_LeadingSystemPrompt(t *testing.T) {
 	f := itSetupConversation(t, s, msgs)
 
 	spy := &spyClient{text: "When did it start?"}
-	d := NewDrafter(spy, s, stubNotifierNoop{})
+	d := NewDrafter(spy, s, stubNotifierNoop{}, stubNotifierNoop{})
 
 	_, err := d.generateInterviewTurn(context.Background(), f.TenantID, f.Conv)
 	if err != nil {
@@ -185,7 +187,7 @@ func TestGenerateInterviewTurn_ConversationHistory(t *testing.T) {
 	f := itSetupConversation(t, s, seedMsgs)
 
 	spy := &spyClient{text: "How would you rate the pain on a scale of 0-10?"}
-	d := NewDrafter(spy, s, stubNotifierNoop{})
+	d := NewDrafter(spy, s, stubNotifierNoop{}, stubNotifierNoop{})
 
 	_, err := d.generateInterviewTurn(context.Background(), f.TenantID, f.Conv)
 	if err != nil {
@@ -232,7 +234,7 @@ func TestGenerateInterviewTurn_ReturnsModelText(t *testing.T) {
 
 	const wantText = "I'm sorry to hear that. Can you point to where the pain is located?"
 	spy := &spyClient{text: wantText}
-	d := NewDrafter(spy, s, stubNotifierNoop{})
+	d := NewDrafter(spy, s, stubNotifierNoop{}, stubNotifierNoop{})
 
 	got, err := d.generateInterviewTurn(context.Background(), f.TenantID, f.Conv)
 	if err != nil {
@@ -255,7 +257,7 @@ func TestGenerateInterviewTurn_PropagatesModelError(t *testing.T) {
 
 	wantErr := &ModelError{StatusCode: 503}
 	spy := &spyClient{err: wantErr}
-	d := NewDrafter(spy, s, stubNotifierNoop{})
+	d := NewDrafter(spy, s, stubNotifierNoop{}, stubNotifierNoop{})
 
 	text, err := d.generateInterviewTurn(context.Background(), f.TenantID, f.Conv)
 	if err == nil {

--- a/backend/internal/agent/soap_drafter_test.go
+++ b/backend/internal/agent/soap_drafter_test.go
@@ -82,7 +82,9 @@ func setupSOAPDrafterFixture(t *testing.T, s *store.Store) soapDrafterFixture {
 }
 
 // ---------------------------------------------------------------------------
-// captureNotifier satisfies PhysicianNotifier and records every event sent.
+// captureNotifier satisfies PhysicianNotifier and PatientNotifier, recording
+// every physician event sent. Patient events are discarded (not exercised in
+// SOAP drafter tests).
 // ---------------------------------------------------------------------------
 
 type captureNotifier struct {
@@ -97,6 +99,8 @@ func (n *captureNotifier) SendToPhysicians(_ string, event []byte) {
 	copy(cp, event)
 	n.events = append(n.events, cp)
 }
+
+func (n *captureNotifier) SendToPatient(_, _ string, _ []byte) {}
 
 func (n *captureNotifier) count() int {
 	n.mu.Lock()
@@ -268,7 +272,7 @@ func TestDraftSOAPNote_HappyPath(t *testing.T) {
 	notifier := &captureNotifier{}
 	// spyClient is defined in interview_turn_test.go (same package).
 	client := &spyClient{text: wellFormedSOAPText}
-	d := NewDrafter(client, s, notifier)
+	d := NewDrafter(client, s, notifier, notifier)
 
 	if err := d.draftSOAPNote(ctx, f.TenantID, f.Conv, f.Patient); err != nil {
 		t.Fatalf("draftSOAPNote: unexpected error: %v", err)
@@ -416,7 +420,7 @@ ASSESSMENT:
 Preliminary assessment: upper respiratory tract infection; physician review required.`
 
 	notifier := &captureNotifier{}
-	d := NewDrafter(&spyClient{text: malformedText}, s, notifier)
+	d := NewDrafter(&spyClient{text: malformedText}, s, notifier, notifier)
 
 	err := d.draftSOAPNote(ctx, f.TenantID, f.Conv, f.Patient)
 	if err == nil {

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -38,6 +38,15 @@ func (rt *Router) SendToPhysicians(tenantID string, event []byte) {
 	rt.hub.SendToPhysicians(tenantID, event)
 }
 
+// SendToPatient delivers event to the patient identified by patientID in the
+// given tenant. It implements agent.PatientNotifier so the Router can be
+// passed directly to agent.NewDrafter in cmd/server. The caller is
+// responsible for ensuring the event payload contains only identifiers — never
+// message content or other PHI.
+func (rt *Router) SendToPatient(tenantID, patientID string, event []byte) {
+	rt.hub.SendToPatient(tenantID, patientID, event)
+}
+
 // SetDrafter wires the AI Agent Runtime drafter after construction. This
 // breaks the circular dependency between Router (which needs the Drafter) and
 // the Drafter (which needs the Router as a PhysicianNotifier): construct the

--- a/openspec/changes/add-clinical-soap-review-workflow/tasks.md
+++ b/openspec/changes/add-clinical-soap-review-workflow/tasks.md
@@ -39,7 +39,7 @@ Add a patient WebSocket notifier (analogue of PhysicianNotifier); persist each
 agent interview question as an assistant message on the conversation and push it
 to the patient's live socket. Audit with identifiers + event type only.
 
-### Task 3.2: Enforce the delivery carve-out
+### Task 3.2: Enforce the delivery carve-out  [x]
 Ensure interview questions (non-clinical) are the ONLY agent output delivered
 directly; the SOAP note (clinical A/P) is never delivered by the agent — only via
 the physician lifecycle. Add a guard/test asserting the agent has no code path to

--- a/openspec/changes/add-clinical-soap-review-workflow/tasks.md
+++ b/openspec/changes/add-clinical-soap-review-workflow/tasks.md
@@ -34,7 +34,7 @@ fabricate objective exam findings.
 
 ## Phase 3: Direct agent→patient interview channel (core-api + delivery)
 
-### Task 3.1: Add a patient notifier + persist agent questions
+### Task 3.1: Add a patient notifier + persist agent questions  [x]
 Add a patient WebSocket notifier (analogue of PhysicianNotifier); persist each
 agent interview question as an assistant message on the conversation and push it
 to the patient's live socket. Audit with identifiers + event type only.


### PR DESCRIPTION
Phase 3 of `add-clinical-soap-review-workflow`: the interview flow goes LIVE.

## Tasks
- [x] 3.1 `PatientNotifier` (Router.SendToPatient via hub) + `deliverInterviewQuestion` (persist assistant msg, ids-only audit+WS, persist-before-notify).
- [x] 3.2 Flip `DraftAsync` → `runInterviewTurn` (generate turn → decide → deliver interview question OR `draftSOAPNote` to PENDING_REVIEW); retire the guidance path; carve-out guard tests.

## Beads closed
HouseCall-piof (#149), HouseCall-u99e (#148)

## Compliance carve-out (reviewer-verified, security-critical)
- Interview **questions** → patient directly (non-clinical, ids-only WS + authenticated fetch).
- **SOAP note (Assessment/Plan)** → only DRAFT→PENDING_REVIEW; the agent never notifies the patient with clinical content and has no transition to APPROVED/MODIFIED/DELIVERED (domain guard test).
- Turn cap forces a SOAP draft (no unbounded interview); patient still receives no clinical content on cap.
- Tenant-scoped; no PHI in logs/audit/WS (ids + coarse reasons only).

## Test
`make test` (Postgres via colima) + `go vet` green; api/messages tests updated to interview behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)