### PR TITLE
add-clinical-soap-review-workflow: Phase 4 — Physician SOAP review UI

### DIFF
--- a/backend/internal/web/templates/queue.html
+++ b/backend/internal/web/templates/queue.html
@@ -79,11 +79,14 @@
             <form method="POST" action="/web/recommendations/{{.ID}}/review">
               <input type="hidden" name="action" value="modify">
               <label style="display:block;font-size:.85rem;margin-bottom:.35rem;">
-                Edited content (required):
+                {{if .SOAP}}Edit Assessment &amp; Plan — confirm or modify the full note (required):{{else}}Edited content (required):{{end}}
               </label>
-              <textarea name="final_content" rows="3"
+              {{/* For soap_note rows, pre-populate with DraftContent so the physician
+                   can review and edit the full note before delivering. DraftContent is
+                   auto-escaped by html/template — template.HTML is never used here. */}}
+              <textarea name="final_content" rows="{{if .SOAP}}8{{else}}3{{end}}"
                 style="width:100%;padding:.4rem;border:1px solid #d1d5db;border-radius:4px;font-size:.85rem;resize:vertical;"
-                placeholder="Enter edited recommendation text…"></textarea>
+                placeholder="Enter edited recommendation text…">{{if .SOAP}}{{.DraftContent}}{{end}}</textarea>
               <button type="submit"
                 style="margin-top:.5rem;background:#1d3557;color:#fff;border:none;padding:.35rem .75rem;border-radius:4px;cursor:pointer;font-size:.85rem;">
                 Deliver Modified

--- a/backend/internal/web/templates/queue.html
+++ b/backend/internal/web/templates/queue.html
@@ -30,7 +30,26 @@
     <tr style="border-top:1px solid #e5e7eb;">
       <td style="padding:.65rem 1rem;font-family:monospace;font-size:.8rem;">{{.ID}}</td>
       <td style="padding:.65rem 1rem;">{{.PayloadType}}</td>
-      <td style="padding:.65rem 1rem;">{{.DraftContent}}</td>
+      <td style="padding:.65rem 1rem;">
+        {{if .SOAP}}
+        {{/* SOAP note: render four sections; Assessment and Plan are
+             the physician's clinical decision focus and are visually
+             distinguished. All content is auto-escaped by html/template —
+             template.HTML is never used on patient or model text. */}}
+        <dl style="margin:0;font-size:.9rem;">
+          <dt style="font-weight:600;color:#374151;margin-top:.25rem;">Subjective</dt>
+          <dd style="margin:.2rem 0 .6rem 1rem;">{{.SOAP.Subjective}}</dd>
+          <dt style="font-weight:600;color:#374151;">Objective</dt>
+          <dd style="margin:.2rem 0 .6rem 1rem;">{{.SOAP.Objective}}</dd>
+          <dt style="font-weight:700;color:#1d3557;margin-top:.5rem;border-top:1px solid #e5e7eb;padding-top:.4rem;">Assessment &#x2605;</dt>
+          <dd style="margin:.2rem 0 .6rem 1rem;font-weight:500;">{{.SOAP.Assessment}}</dd>
+          <dt style="font-weight:700;color:#1d3557;">Plan &#x2605;</dt>
+          <dd style="margin:.2rem 0 0 1rem;font-weight:500;">{{.SOAP.Plan}}</dd>
+        </dl>
+        {{else}}
+        {{.DraftContent}}
+        {{end}}
+      </td>
       <td style="padding:.65rem 1rem;font-size:.85rem;color:#6b7280;">{{.CreatedAt.Format "2006-01-02 15:04"}}</td>
       <td style="padding:.65rem 1rem;">
         {{/* Approve: no edit needed — physician confirms draft content */}}

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -18,6 +18,7 @@ package web
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"errors"
 	"html/template"
 	"log"
@@ -372,8 +373,36 @@ func (h *Handler) handlePanel(w http.ResponseWriter, r *http.Request) {
 
 // ---- queue handler ----
 
+// recommendationView wraps store.Recommendation for template rendering.
+// SOAP is non-nil only when PayloadType == domain.PayloadTypeSOAPNote and the
+// Payload JSON unmarshals successfully; nil causes the template to fall back
+// to DraftContent. PHI in SOAP fields is auto-escaped by html/template —
+// template.HTML must never be used on model or patient content.
+type recommendationView struct {
+	store.Recommendation
+	SOAP *domain.SOAPPayload
+}
+
+// toRecommendationViews converts raw store recommendations into view models.
+// For soap_note rows it attempts to unmarshal the Payload; on any parse error
+// the SOAP field is left nil so DraftContent is used instead.
+func toRecommendationViews(recs []store.Recommendation) []recommendationView {
+	views := make([]recommendationView, len(recs))
+	for i, r := range recs {
+		v := recommendationView{Recommendation: r}
+		if r.PayloadType == domain.PayloadTypeSOAPNote && len(r.Payload) > 0 {
+			var sp domain.SOAPPayload
+			if err := json.Unmarshal(r.Payload, &sp); err == nil {
+				v.SOAP = &sp
+			}
+		}
+		views[i] = v
+	}
+	return views
+}
+
 type queuePageData struct {
-	Recommendations []store.Recommendation
+	Recommendations []recommendationView
 	// Error is shown as a flash banner when a review action fails (e.g.
 	// unlicensed-state rejection). Empty string means no error.
 	Error string
@@ -399,7 +428,7 @@ func (h *Handler) handleQueue(w http.ResponseWriter, r *http.Request) {
 	})
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := h.tmpl("queue").ExecuteTemplate(w, "layout", queuePageData{Recommendations: recs}); err != nil {
+	if err := h.tmpl("queue").ExecuteTemplate(w, "layout", queuePageData{Recommendations: toRecommendationViews(recs)}); err != nil {
 		log.Printf("web: render queue template: %v", err)
 	}
 }
@@ -495,7 +524,7 @@ func (h *Handler) renderQueueWithError(w http.ResponseWriter, r *http.Request, c
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusForbidden)
 	if err := h.tmpl("queue").ExecuteTemplate(w, "layout", queuePageData{
-		Recommendations: recs,
+		Recommendations: toRecommendationViews(recs),
 		Error:           errMsg,
 	}); err != nil {
 		log.Printf("web: render queue error template: %v", err)

--- a/backend/internal/web/web_test.go
+++ b/backend/internal/web/web_test.go
@@ -1233,10 +1233,12 @@ func TestQueue_SOAPNoteRendersSections(t *testing.T) {
 		}
 	}
 
-	// The DraftContent fallback text must NOT appear when SOAP sections are rendered.
-	if strings.Contains(body, "SOAP note draft (fallback)") {
-		t.Error("soap_note queue: DraftContent fallback must not appear when SOAP sections are rendered")
-	}
+	// NOTE (task 4.2): DraftContent now intentionally appears inside the
+	// "Modify & Deliver" textarea so the physician can edit the full note before
+	// delivering.  The draft-display column still shows the structured SOAP
+	// sections (verified above), so the fallback path is not taken.  We no
+	// longer assert DraftContent is absent from the full page body, only that
+	// the four SOAP section labels and their content are present.
 
 	// Review action forms must still be present.
 	if !strings.Contains(body, `value="approve"`) {
@@ -1413,6 +1415,208 @@ func TestReview_ExactlyOneAuditEvent(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("expected exactly 1 recommendation.reviewed audit event, got %d (events: %v)",
 			count, auditEventSummary(fs))
+	}
+}
+
+// ---- SOAP note review action tests (task 4.2) -----------------------------------
+
+// testSOAPDraftContent is the human-readable SOAP note pre-filled in the
+// modify textarea; it represents all four sections as plain text.
+const testSOAPDraftContent = "Subjective: Patient reports headache for 3 days\nObjective: No objective findings reported\nAssessment: Likely tension headache\nPlan: Rest, hydrate, OTC analgesic prn"
+
+// newFakeStoreForSOAPReview returns a fakeStore with a soap_note recommendation
+// in PENDING_REVIEW, structured payload, and human-readable DraftContent, for
+// a physician with the given licensed states and a patient in patientState.
+func newFakeStoreForSOAPReview(physStates []string, patientState string) *fakeStore {
+	soapPayload, _ := json.Marshal(map[string]string{
+		"subjective": "Patient reports headache for 3 days",
+		"objective":  "No objective findings reported",
+		"assessment": "Likely tension headache",
+		"plan":       "Rest, hydrate, OTC analgesic prn",
+	})
+	phys := store.Physician{
+		ID:             testPhysID,
+		TenantID:       testTenantID,
+		Email:          "doc@clinic.example",
+		StatesLicensed: physStates,
+	}
+	patient := store.Patient{
+		ID:       testPatientID,
+		TenantID: testTenantID,
+		State:    patientState,
+	}
+	rec := store.Recommendation{
+		ID:           testRecID,
+		TenantID:     testTenantID,
+		PatientID:    testPatientID,
+		State:        domain.StatePendingReview,
+		PayloadType:  domain.PayloadTypeSOAPNote,
+		Payload:      soapPayload,
+		DraftContent: testSOAPDraftContent,
+	}
+	return &fakeStore{
+		physicians:   map[string]store.Physician{"doc@clinic.example": phys},
+		physByID:     map[uuid.UUID]store.Physician{testPhysID: phys},
+		patientsByID: map[uuid.UUID]store.Patient{testPatientID: patient},
+		recsByID:     map[uuid.UUID]store.Recommendation{testRecID: rec},
+		recsByPhys: map[string][]store.Recommendation{
+			testPhysID.String(): {rec},
+		},
+		updatedStates: make(map[uuid.UUID]string),
+	}
+}
+
+// TestReview_SOAPNote_Approve verifies that a licensed physician can approve a
+// soap_note recommendation: the handler calls review.Execute, the state
+// transitions to DELIVERED, and the queue redirects (303).
+func TestReview_SOAPNote_Approve(t *testing.T) {
+	fs := newFakeStoreForSOAPReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+
+	rec := postReview(t, h, testRecID, domain.ActionApprove, "")
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("soap approve: want 303, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/web/queue" {
+		t.Fatalf("soap approve: want redirect to /web/queue, got %q", loc)
+	}
+	if got := fs.updatedStates[testRecID]; got != domain.StateDelivered {
+		t.Fatalf("soap approve: want state DELIVERED, got %q", got)
+	}
+	assertAuditEvent(t, fs, "recommendation.reviewed", domain.ActionApprove, domain.StateDelivered)
+}
+
+// TestReview_SOAPNote_Modify verifies that a licensed physician can submit a
+// modified Assessment & Plan for a soap_note: the handler passes the edited
+// content through, the state transitions to DELIVERED, and final_content is set.
+func TestReview_SOAPNote_Modify(t *testing.T) {
+	fs := newFakeStoreForSOAPReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+	editedNote := testSOAPDraftContent + "\n[Physician addendum: follow up in 48h if symptoms persist]"
+
+	rec := postReview(t, h, testRecID, domain.ActionModify, editedNote)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("soap modify: want 303, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := fs.updatedStates[testRecID]; got != domain.StateDelivered {
+		t.Fatalf("soap modify: want state DELIVERED, got %q", got)
+	}
+	r := fs.recsByID[testRecID]
+	if r.FinalContent == nil {
+		t.Fatal("soap modify: final_content must be set after delivery")
+	}
+	if *r.FinalContent != editedNote {
+		t.Fatalf("soap modify: final_content = %q, want %q", *r.FinalContent, editedNote)
+	}
+	assertAuditEvent(t, fs, "recommendation.reviewed", domain.ActionModify, domain.StateDelivered)
+}
+
+// TestReview_SOAPNote_Reject verifies that a licensed physician can reject a
+// soap_note recommendation: state transitions to REJECTED, final_content
+// remains nil, and the queue redirects.
+func TestReview_SOAPNote_Reject(t *testing.T) {
+	fs := newFakeStoreForSOAPReview([]string{"CA"}, "CA")
+	h := buildHandler(t, fs)
+
+	rec := postReview(t, h, testRecID, domain.ActionReject, "")
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("soap reject: want 303, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := fs.updatedStates[testRecID]; got != domain.StateRejected {
+		t.Fatalf("soap reject: want state REJECTED, got %q", got)
+	}
+	if r, ok := fs.recsByID[testRecID]; ok && r.FinalContent != nil {
+		t.Error("soap reject: final_content must remain nil for REJECTED recommendations")
+	}
+	assertAuditEvent(t, fs, "recommendation.reviewed", domain.ActionReject, domain.StateRejected)
+}
+
+// TestReview_SOAPNote_UnlicensedPhysician verifies that a physician not
+// licensed in the patient's state receives a 403 with the queue re-rendered
+// showing the error flash, and state is NOT mutated.
+func TestReview_SOAPNote_UnlicensedPhysician(t *testing.T) {
+	// Physician licensed in NY; patient is in CA.
+	fs := newFakeStoreForSOAPReview([]string{"NY"}, "CA")
+	h := buildHandler(t, fs)
+
+	rec := postReview(t, h, testRecID, domain.ActionApprove, "")
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("soap unlicensed: want 403, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	// State must NOT have been mutated.
+	if _, changed := fs.updatedStates[testRecID]; changed {
+		t.Error("soap unlicensed: state must not be mutated when physician is unlicensed")
+	}
+	// Queue must re-render with the physician-facing error banner.
+	body := rec.Body.String()
+	if !strings.Contains(body, "not licensed in the patient") {
+		t.Error("soap unlicensed: response body must contain physician-facing error message")
+	}
+	// A review_rejected audit event with reason=unlicensed_state must be written.
+	found := false
+	for _, e := range fs.auditEvents {
+		if e.EventType == "recommendation.review_rejected" {
+			var meta map[string]any
+			if err := json.Unmarshal(e.Metadata, &meta); err == nil {
+				if meta["reason"] == "unlicensed_state" {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("soap unlicensed: expected recommendation.review_rejected audit event with reason=unlicensed_state")
+	}
+}
+
+// TestQueue_SOAPNote_ModifyTextareaPreFilled verifies that the queue page
+// pre-populates the Modify & Deliver textarea with the SOAP note's DraftContent
+// so the physician can review and edit the full note before delivering.
+func TestQueue_SOAPNote_ModifyTextareaPreFilled(t *testing.T) {
+	soapPayload, _ := json.Marshal(map[string]string{
+		"subjective": "Patient reports headache for 3 days",
+		"objective":  "No objective findings reported",
+		"assessment": "Likely tension headache",
+		"plan":       "Rest, hydrate, OTC analgesic prn",
+	})
+	queueRec := store.Recommendation{
+		ID:           testRecID,
+		TenantID:     testTenantID,
+		PatientID:    testPatientID,
+		State:        domain.StatePendingReview,
+		PayloadType:  domain.PayloadTypeSOAPNote,
+		Payload:      soapPayload,
+		DraftContent: testSOAPDraftContent,
+	}
+	fs := &fakeStore{
+		physicians: map[string]store.Physician{},
+		queueRecs:  []store.Recommendation{queueRec},
+	}
+	h := buildHandler(t, fs)
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/queue", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("soap textarea prefill: want 200, got %d", rw.Code)
+	}
+	body := rw.Body.String()
+
+	// The textarea must contain the DraftContent (auto-escaped; no special chars
+	// in testSOAPDraftContent that would change their HTML-escaped form).
+	if !strings.Contains(body, testSOAPDraftContent) {
+		t.Error("soap textarea prefill: DraftContent must appear inside the modify textarea for soap_note rows")
+	}
+
+	// The label must indicate Assessment & Plan editing (not the generic label).
+	if !strings.Contains(body, "Edit Assessment") {
+		t.Error("soap textarea prefill: label must indicate Assessment &amp; Plan editing for soap_note rows")
 	}
 }
 

--- a/backend/internal/web/web_test.go
+++ b/backend/internal/web/web_test.go
@@ -1173,6 +1173,150 @@ func TestReview_QueueShowsActionForms(t *testing.T) {
 	}
 }
 
+// ---- SOAP note rendering tests (task 4.1) ---------------------------------------
+
+// TestQueue_SOAPNoteRendersSections verifies that a soap_note recommendation in
+// the review queue renders the four SOAP section labels and their content, and
+// that Assessment and Plan are visually distinguished (the template uses a star
+// marker so we can check for the label+marker pair).
+func TestQueue_SOAPNoteRendersSections(t *testing.T) {
+	soapPayload, err := json.Marshal(map[string]string{
+		"subjective": "Patient reports headache for 3 days",
+		"objective":  "No vitals reported",
+		"assessment": "Likely tension headache",
+		"plan":       "Rest, hydrate, OTC analgesic",
+	})
+	if err != nil {
+		t.Fatalf("marshal soap payload: %v", err)
+	}
+	rec := store.Recommendation{
+		ID:           uuid.MustParse("77777777-0000-0000-0000-000000000007"),
+		TenantID:     testTenantID,
+		PatientID:    testPatientID,
+		State:        "PENDING_REVIEW",
+		PayloadType:  "soap_note",
+		Payload:      soapPayload,
+		DraftContent: "SOAP note draft (fallback)",
+	}
+	fs := &fakeStore{
+		physicians: map[string]store.Physician{},
+		queueRecs:  []store.Recommendation{rec},
+	}
+	h := buildHandler(t, fs)
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/queue", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("soap_note queue: want 200, got %d", rw.Code)
+	}
+	body := rw.Body.String()
+
+	// All four section labels must appear.
+	for _, label := range []string{"Subjective", "Objective", "Assessment", "Plan"} {
+		if !strings.Contains(body, label) {
+			t.Errorf("soap_note queue: expected section label %q in rendered HTML", label)
+		}
+	}
+
+	// All four section contents must appear (auto-escaped; no special chars here).
+	for _, content := range []string{
+		"Patient reports headache for 3 days",
+		"No vitals reported",
+		"Likely tension headache",
+		"Rest, hydrate, OTC analgesic",
+	} {
+		if !strings.Contains(body, content) {
+			t.Errorf("soap_note queue: expected section content %q in rendered HTML", content)
+		}
+	}
+
+	// The DraftContent fallback text must NOT appear when SOAP sections are rendered.
+	if strings.Contains(body, "SOAP note draft (fallback)") {
+		t.Error("soap_note queue: DraftContent fallback must not appear when SOAP sections are rendered")
+	}
+
+	// Review action forms must still be present.
+	if !strings.Contains(body, `value="approve"`) {
+		t.Error("soap_note queue: approve action must still be present")
+	}
+	if !strings.Contains(body, `value="reject"`) {
+		t.Error("soap_note queue: reject action must still be present")
+	}
+}
+
+// TestQueue_NonSOAPRowRendersDraftContent verifies that a non-soap_note
+// recommendation still renders its DraftContent (not a SOAP section layout).
+func TestQueue_NonSOAPRowRendersDraftContent(t *testing.T) {
+	rec := store.Recommendation{
+		ID:           uuid.MustParse("88888888-0000-0000-0000-000000000008"),
+		TenantID:     testTenantID,
+		PatientID:    testPatientID,
+		State:        "PENDING_REVIEW",
+		PayloadType:  "guidance",
+		DraftContent: "Drink plenty of water",
+	}
+	fs := &fakeStore{
+		physicians: map[string]store.Physician{},
+		queueRecs:  []store.Recommendation{rec},
+	}
+	h := buildHandler(t, fs)
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/queue", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("non-soap queue: want 200, got %d", rw.Code)
+	}
+	body := rw.Body.String()
+
+	if !strings.Contains(body, "Drink plenty of water") {
+		t.Error("non-soap queue: DraftContent must appear for non-soap_note recommendation")
+	}
+	// SOAP-specific section markers must not appear.
+	for _, label := range []string{"Subjective", "Objective", "Assessment", "Plan"} {
+		if strings.Contains(body, label) {
+			t.Errorf("non-soap queue: SOAP section label %q must not appear for guidance recommendation", label)
+		}
+	}
+}
+
+// TestQueue_SOAPNoteWithBadPayload verifies that a soap_note row whose Payload
+// is malformed JSON falls back gracefully to rendering DraftContent.
+func TestQueue_SOAPNoteWithBadPayload(t *testing.T) {
+	rec := store.Recommendation{
+		ID:           uuid.MustParse("99999999-0000-0000-0000-000000000009"),
+		TenantID:     testTenantID,
+		PatientID:    testPatientID,
+		State:        "PENDING_REVIEW",
+		PayloadType:  "soap_note",
+		Payload:      []byte(`not-valid-json`),
+		DraftContent: "Fallback draft content",
+	}
+	fs := &fakeStore{
+		physicians: map[string]store.Physician{},
+		queueRecs:  []store.Recommendation{rec},
+	}
+	h := buildHandler(t, fs)
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/web/queue", nil)
+	req.AddCookie(makeCookie(t, testTenantID, testPhysID, "physician"))
+	h.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("bad-payload soap_note: want 200, got %d", rw.Code)
+	}
+	body := rw.Body.String()
+	if !strings.Contains(body, "Fallback draft content") {
+		t.Error("bad-payload soap_note: DraftContent must appear when Payload cannot be parsed")
+	}
+}
+
 // assertAuditEvent is a helper that verifies the fakeStore has an audit event
 // of the given type with matching action and new_state metadata fields.
 func assertAuditEvent(t *testing.T, fs *fakeStore, eventType, action, newState string) {

--- a/openspec/changes/add-clinical-soap-review-workflow/tasks.md
+++ b/openspec/changes/add-clinical-soap-review-workflow/tasks.md
@@ -52,7 +52,7 @@ Extend the review template so a `soap_note` recommendation displays the four
 sections clearly, with Assessment and Plan presented as the physician's decision
 focus.
 
-### Task 4.2: Approve / modify / reject the Assessment & Plan
+### Task 4.2: Approve / modify / reject the Assessment & Plan  [x]
 Wire approve (`approve`), edit-then-save (`modify` of A/P), and reject
 (`reject`) using the existing review actions and state-licensing checks. No new
 lifecycle states.

--- a/openspec/changes/add-clinical-soap-review-workflow/tasks.md
+++ b/openspec/changes/add-clinical-soap-review-workflow/tasks.md
@@ -47,7 +47,7 @@ deliver a soap_note.
 
 ## Phase 4: Physician SOAP review UI (physician-web-app)
 
-### Task 4.1: Render the SOAP note in the review queue
+### Task 4.1: Render the SOAP note in the review queue  [x]
 Extend the review template so a `soap_note` recommendation displays the four
 sections clearly, with Assessment and Plan presented as the physician's decision
 focus.


### PR DESCRIPTION
Phase 4 of `add-clinical-soap-review-workflow`: physician web app renders + acts on the SOAP note.

## Tasks
- [x] 4.1 `recommendationView` + `toRecommendationViews`; `queue.html` renders 4 SOAP sections (Assessment/Plan emphasized), falls back to DraftContent; auto-escaped; tests.
- [x] 4.2 Modify textarea pre-filled with the note for A/P editing; soap_note approve/modify/reject + unlicensed-physician tests. Review handler + lifecycle reused unchanged.

## Beads closed
HouseCall-qfd3 (#147), HouseCall-ub5v (#146)

## Notes
Approve/modify deliver the physician-approved note to the patient (DELIVERED); state-licensing enforced; html/template auto-escaping preserved (no XSS via model content). 42 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)