### PR TITLE
docs(openspec): add patient-cloud-auth change proposal

### DIFF
--- a/openspec/changes/add-patient-cloud-auth/design.md
+++ b/openspec/changes/add-patient-cloud-auth/design.md
@@ -1,0 +1,101 @@
+# Design: Patient Cloud Authentication
+
+## Existing pieces (reused)
+
+- Core API `POST /api/auth/login` (`internal/api/auth.go::handleLogin`): tries
+  patient-then-physician by email, bcrypt-compares, issues an HMAC JWT
+  (`issueToken`). `requireAuth` validates the Bearer token on `/api/*`.
+- iOS `AuthenticationService.storeCoreAPIJWT(_:)` / `clearCoreAPIJWT()` already
+  write/delete `KeychainManager.Keys.coreAPIJWT` — currently never called by a
+  real Core API login.
+- iOS `EncryptionManager`: device-local AES-256-GCM master key in the Keychain;
+  per-user key = `HKDF(masterKey, salt = userId.uuidString)`.
+- Config-gated `CloudSyncCoordinator` (from the SOAP change) activates only when
+  `CoreAPIBaseURL` is set AND a `coreAPIJWT` exists.
+
+## The hard part: credentials move, encryption stays local
+
+Making Core API authoritative for credentials must NOT change how PHI is
+encrypted at rest, because:
+
+- The master key is device-local and must never leave the device or be derived
+  from a server secret.
+- Existing per-user keys are HKDF-salted by a UUID. The salt identity must remain
+  stable for a given patient or previously-encrypted data becomes unreadable.
+
+**Approach — canonical patient identity = Core API patient UUID.**
+- On Core API login/register, the response carries the patient's Core API UUID.
+- The iOS local user record is keyed by that same UUID, and that UUID is the HKDF
+  salt. So the encryption identity is the Core API patient id from creation
+  onward — consistent across devices' *credential* checks while keys stay local
+  to each device.
+- The device master key remains generated/stored locally on first setup
+  (unchanged). Encryption keys are therefore device-local but salted by a
+  server-canonical id — credentials and keys stay cleanly separated.
+- Pre-launch: no production data to migrate. Existing local-only test accounts
+  may not carry over; that is acceptable and called out in scope.
+
+## Flows
+
+### Registration (iOS SignUp)
+1. iOS calls `POST /api/auth/register {tenant_id, email, password}`.
+2. Core API creates the patient (bcrypt password), audits `patient.registered`
+   (identifiers only), returns `{token, patient_id}` (same shape as login).
+3. iOS creates the local cache user keyed by `patient_id`, sets up the device
+   master key / derived key (encryption identity = `patient_id`), and stores the
+   JWT via `storeCoreAPIJWT`.
+
+### Login (iOS)
+1. iOS calls `POST /api/auth/login {tenant_id, email, password}`.
+2. On success: store JWT, ensure the local cache user exists for `patient_id`,
+   unlock encryption (derive key for `patient_id`), start the session.
+3. On Core API auth failure (401): reject — Core API is authoritative.
+4. On Core API UNREACHABLE (network/timeout): fall back to the cached local
+   credential check so the patient can still open their encrypted local record
+   offline; cloud sync stays inactive (no fresh JWT) until connectivity returns.
+
+### Logout
+- Clear the session, the cached derived key, AND the `coreAPIJWT`
+  (`clearCoreAPIJWT`).
+
+### JWT lifecycle
+- The JWT is short-lived/HMAC. On a `401` from any `SyncClient` call, the
+  coordinator should surface re-auth (silently re-login if a cached credential is
+  available, else require interactive login). MVP: on 401, deactivate cloud sync
+  and prompt re-login; do not loop.
+
+## Backend: register endpoint
+- `POST /api/auth/register` mirrors `handleLogin` validation (tenant_id, email,
+  password required). Reject duplicate email within tenant (409). Hash with
+  bcrypt (same cost as existing physician/patient hashing). Create patient row
+  (tenant-scoped), write `patient.registered` audit (identifiers only — never the
+  password or PHI), issue + return a JWT so the client is logged in immediately.
+- Reuse `issueToken`, the store's patient creation path, and the audit writer.
+
+## iOS: Core API auth client
+- Add login/register to the Core API client surface (extend `SyncClient` or a
+  small dedicated `CoreAPIAuthClient` sharing the base URL + `URLSession`). It is
+  the only component that sends the plaintext password (over TLS) to Core API; it
+  never logs it. Returns `{token, patientId}`.
+- `AuthenticationService.register`/`login` orchestrate: call the client, manage
+  JWT + local cache user + encryption unlock + session, with the offline
+  fallback above.
+
+## Tenant config
+- `CoreAPITenantID` build setting → Info.plist, read alongside `CoreAPIBaseURL`.
+  Empty → cloud auth disabled (pure local mode, current behavior) so the default
+  build still runs without a backend.
+
+## Safety / HIPAA
+- Password sent only to Core API over TLS; never logged on either side.
+- Encryption master key never leaves the device; keys never derived from server
+  secrets; JWT is not an encryption input.
+- Audit: `patient.registered` / login events carry identifiers only.
+- Offline fallback never weakens encryption — it only gates app entry via the
+  cached local credential; the data is still AES-GCM encrypted at rest.
+
+## Alternatives considered
+- **Dual auth (keep local authoritative, add cloud alongside)** — rejected per
+  decision; leaves two drifting credential stores.
+- **Auto-provision on first login** — rejected; muddies the registration audit
+  trail vs an explicit register endpoint.

--- a/openspec/changes/add-patient-cloud-auth/proposal.md
+++ b/openspec/changes/add-patient-cloud-auth/proposal.md
@@ -1,0 +1,60 @@
+# Proposal: Patient Cloud Authentication (Core API as Source of Truth)
+
+## Why
+
+`add-clinical-soap-review-workflow` built the full server-side interview → SOAP →
+physician-approval → delivery loop, but the patient app can't reach it: the iOS
+cloud path requires a Core API JWT (`KeychainManager.Keys.coreAPIJWT`), and the
+patient logs in only against the local Core Data store — no JWT is ever obtained.
+The `CloudSyncCoordinator` therefore stays gated off and the app falls back to
+direct-LLM (tracked as `HouseCall-nre3`).
+
+Core API already exposes `POST /api/auth/login` (patient-or-physician, returns an
+HMAC JWT), but there is no patient registration route and the iOS app never calls
+either endpoint. This change makes the Core API the source of truth for patient
+authentication, adds patient registration, and wires the iOS auth flow to obtain
+and cache the JWT — unblocking the cloud SOAP loop end-to-end.
+
+## What Changes
+
+- **NEW** `POST /api/auth/register` on Core API: creates a tenant-scoped patient
+  (email + bcrypt password), audited, returning the same token shape as login.
+- **Core API as patient auth source of truth.** iOS registration and login go
+  through Core API; the local Core Data user becomes a device-local cache used
+  for offline access and (critically) for PHI encryption-key derivation. On
+  successful Core API login the returned JWT is cached in the Keychain
+  (`storeCoreAPIJWT`, already present) so `SyncClient`/`CloudSyncCoordinator` can
+  authenticate.
+- **Encryption-identity continuity.** PHI encryption stays device-local and
+  unchanged in mechanism: the AES-256-GCM master key remains in the device
+  Keychain and per-user keys are HKDF-derived from a stable canonical patient
+  identity. Credentials move to Core API, but encryption keys are never sent to
+  or derived from the server.
+- **Offline fallback.** When Core API is unreachable, the patient can still
+  unlock the app via the cached local credential (so the encrypted local record
+  remains accessible); Core API remains authoritative when reachable, and cloud
+  sync activates only with a valid JWT.
+- **Tenant configuration.** A single-tenant MVP tenant id is supplied by build
+  config (alongside the existing `CoreAPIBaseURL`).
+- **Cloud activation.** With a JWT present, the existing config-gated
+  `CloudSyncCoordinator` activates, resolving `HouseCall-nre3` and making the
+  patient→interview→SOAP→approval→delivery loop reachable from the app.
+
+## Impact
+
+- **Affected specs**: `core-api` (ADDED patient registration), `authentication`
+  (MODIFIED registration + login to be Core-API-authoritative; ADDED Core API
+  session token handling + offline fallback), `data-security` (ADDED encryption-
+  identity continuity guarantee), `ios-cloud-sync` (ADDED authenticated cloud
+  activation).
+- **Affected code**: backend `internal/api/auth.go` + `router.go` + `store`
+  (CreatePatient/register, audit); iOS `AuthenticationService` (register/login
+  flows, JWT lifecycle), a Core API auth client (extend `SyncClient` or a small
+  `CoreAPIAuthClient`), `EncryptionManager` identity continuity, config
+  (`CoreAPITenantID`), and activation of the existing `CloudSyncCoordinator` gate.
+- **Resolves**: `HouseCall-nre3`. Unblocks `add-clinical-soap-review-workflow`
+  task 6.3 (manual e2e).
+- **Out of scope**: physician registration UI (physicians remain seeded/managed
+  separately); OIDC/Cognito (the `requireAuth` comment notes it plugs in later);
+  password reset / email verification; multi-tenant onboarding; migrating any
+  pre-existing local-only accounts (pre-launch, no production data).

--- a/openspec/changes/add-patient-cloud-auth/specs/authentication/spec.md
+++ b/openspec/changes/add-patient-cloud-auth/specs/authentication/spec.md
@@ -1,0 +1,92 @@
+# authentication (delta)
+
+## MODIFIED Requirements
+
+### Requirement: User Registration with Email and Password
+
+Patient registration SHALL be performed against the Core API as the source of
+truth: the app SHALL register the patient with the Core API (email + password),
+and SHALL create a device-local cache record keyed by the canonical patient
+identity returned by the Core API, used for offline access and PHI encryption-key
+derivation. The plaintext password SHALL be sent only to the Core API over TLS
+and SHALL never be logged.
+
+#### Scenario: Successful patient registration
+
+- **GIVEN** a new patient provides a valid email and a password meeting strength rules
+- **WHEN** registration succeeds against the Core API
+- **THEN** a Core API patient is created and an authentication token is returned
+- **AND** a device-local cache record is created keyed by the canonical patient identity
+- **AND** the authentication token is cached securely for cloud sync
+
+#### Scenario: Registration rejected for an existing account
+
+- **GIVEN** an email already registered in the tenant
+- **WHEN** the patient attempts to register
+- **THEN** registration fails with a conflict and no local cache record is created
+
+### Requirement: User Login with Multiple Authentication Methods
+
+Patient login SHALL authenticate against the Core API as the source of truth.
+On success the app SHALL cache the returned authentication token, ensure the
+device-local cache record for the canonical patient identity exists, unlock PHI
+encryption for that identity, and start a session. When the Core API rejects the
+credentials the login SHALL fail. Biometric unlock SHALL continue to gate access
+to a previously authenticated local session.
+
+#### Scenario: Successful cloud login
+
+- **GIVEN** valid credentials and a reachable Core API
+- **WHEN** the patient logs in
+- **THEN** the Core API returns an authentication token which is cached securely
+- **AND** the session starts and PHI encryption is unlocked for the canonical patient identity
+
+#### Scenario: Invalid credentials are rejected
+
+- **GIVEN** a reachable Core API and incorrect credentials
+- **WHEN** the patient attempts to log in
+- **THEN** login fails and no session is started
+
+## ADDED Requirements
+
+### Requirement: Core API Session Token Lifecycle
+
+The app SHALL cache the Core API authentication token in the Keychain on
+successful registration or login, SHALL clear it on logout, and SHALL deactivate
+cloud sync and require re-login when the Core API reports the token is no longer
+valid. The token SHALL never be logged.
+
+#### Scenario: Token cached and cleared
+
+- **GIVEN** a successful Core API login
+- **WHEN** the token is returned
+- **THEN** it is stored in the Keychain for cloud sync
+- **WHEN** the patient logs out
+- **THEN** the cached token is removed
+
+#### Scenario: Expired token forces re-login
+
+- **GIVEN** a cached token that the Core API rejects as invalid
+- **WHEN** a cloud sync request returns unauthorized
+- **THEN** cloud sync is deactivated and re-login is required, without a retry loop
+
+### Requirement: Offline Authentication Fallback
+
+The app SHALL allow a previously-authenticated patient to unlock their encrypted
+local record via the cached local credential when the Core API is unreachable
+(network failure or timeout, as distinct from a credential rejection), and SHALL
+keep cloud sync inactive until a valid token is obtained.
+
+#### Scenario: Login while Core API unreachable
+
+- **GIVEN** a patient who has previously authenticated on this device
+- **AND** the Core API is unreachable
+- **WHEN** the patient logs in with correct credentials
+- **THEN** the local encrypted record is unlocked for offline use
+- **AND** cloud sync remains inactive until connectivity and a valid token return
+
+#### Scenario: Unreachable is distinguished from rejected
+
+- **GIVEN** the Core API is reachable and rejects the credentials
+- **WHEN** the patient attempts to log in
+- **THEN** login fails and the offline fallback is NOT used

--- a/openspec/changes/add-patient-cloud-auth/specs/core-api/spec.md
+++ b/openspec/changes/add-patient-cloud-auth/specs/core-api/spec.md
@@ -1,0 +1,39 @@
+# core-api (delta)
+
+## ADDED Requirements
+
+### Requirement: Patient Registration
+
+The Core API SHALL provide a registration endpoint that creates a tenant-scoped
+patient from an email and password, storing the password as a bcrypt hash, and
+SHALL return an authentication token so the client is immediately authenticated.
+Registration SHALL reject a duplicate email within the same tenant and SHALL
+write an audit event containing identifiers only.
+
+#### Scenario: New patient registers
+
+- **GIVEN** a valid tenant and an email not yet registered in that tenant
+- **WHEN** the client POSTs the email and password to the registration endpoint
+- **THEN** a patient record is created in that tenant with a bcrypt password hash
+- **AND** an authentication token is returned
+- **AND** a `patient.registered` audit event is written with identifiers only (no password, no PHI)
+
+#### Scenario: Duplicate email is rejected
+
+- **GIVEN** an email already registered within the tenant
+- **WHEN** the client attempts to register that email again
+- **THEN** the request is rejected as a conflict
+- **AND** no second patient record is created
+
+#### Scenario: Missing fields are rejected
+
+- **GIVEN** a registration request missing tenant, email, or password
+- **WHEN** the request is processed
+- **THEN** it is rejected as a bad request
+- **AND** no patient record is created
+
+#### Scenario: Returned token authenticates API access
+
+- **GIVEN** a successful registration
+- **WHEN** the returned token is used as a Bearer token on an authenticated `/api/*` request
+- **THEN** the request is accepted as that patient within the tenant

--- a/openspec/changes/add-patient-cloud-auth/specs/data-security/spec.md
+++ b/openspec/changes/add-patient-cloud-auth/specs/data-security/spec.md
@@ -1,0 +1,26 @@
+# data-security (delta)
+
+## ADDED Requirements
+
+### Requirement: Encryption Identity Continuity Under Cloud Auth
+
+Moving patient credential authority to the Core API SHALL NOT change how PHI is
+encrypted at rest. The AES-256-GCM master key SHALL remain generated and stored
+on the device and SHALL never be transmitted to, or derived from, the Core API or
+the authentication token. Per-user PHI keys SHALL be HKDF-derived using the
+canonical patient identity as the stable salt so that encrypted data remains
+readable across sessions for the same patient.
+
+#### Scenario: Keys stay device-local under cloud auth
+
+- **GIVEN** a patient authenticated via the Core API
+- **WHEN** PHI is encrypted or decrypted on the device
+- **THEN** the master key is read only from the device Keychain
+- **AND** neither the master key nor any derived key is sent to the Core API
+- **AND** the authentication token is not used as key material
+
+#### Scenario: Stable identity keeps data readable
+
+- **GIVEN** PHI previously encrypted for a patient's canonical identity
+- **WHEN** the same patient authenticates again on the same device
+- **THEN** the derived key for that canonical identity reproduces and the PHI decrypts

--- a/openspec/changes/add-patient-cloud-auth/specs/ios-cloud-sync/spec.md
+++ b/openspec/changes/add-patient-cloud-auth/specs/ios-cloud-sync/spec.md
@@ -1,0 +1,25 @@
+# ios-cloud-sync (delta)
+
+## ADDED Requirements
+
+### Requirement: Authenticated Cloud Activation
+
+Cloud sync SHALL activate only when a Core API base URL and tenant are configured
+AND a valid Core API authentication token is present. After a successful patient
+login that yields a token, the client SHALL activate cloud sync so patient
+messages route through the Core API and agent interview questions and delivered
+recommendations arrive over the live connection. Absent configuration or token,
+the client SHALL remain in local-only mode with no regression.
+
+#### Scenario: Cloud activates after authenticated login
+
+- **GIVEN** a configured Core API base URL and tenant
+- **WHEN** the patient logs in and a valid token is cached
+- **THEN** cloud sync activates and patient messages route through the Core API
+- **AND** agent interview questions arrive over the live connection
+
+#### Scenario: Local-only mode without configuration or token
+
+- **GIVEN** no Core API tenant/base URL configured, or no valid token
+- **WHEN** the patient uses the chat
+- **THEN** cloud sync stays inactive and the app operates in local-only mode without error

--- a/openspec/changes/add-patient-cloud-auth/tasks.md
+++ b/openspec/changes/add-patient-cloud-auth/tasks.md
@@ -1,0 +1,74 @@
+# Tasks: Patient Cloud Authentication
+
+## Phase 1: Core API patient registration endpoint
+
+### Task 1.1: Add POST /api/auth/register
+Add a registration handler mirroring `handleLogin` validation (tenant_id, email,
+password required). Create a tenant-scoped patient with a bcrypt password hash,
+reject duplicate email within tenant (409), issue + return a JWT (same response
+shape as login). Wire the route in `router.go`.
+
+### Task 1.2: Audit + store wiring
+Write a `patient.registered` audit event (identifiers only — never password/PHI).
+Add/confirm the store patient-creation path used by registration is tenant-scoped.
+Tests: happy path, duplicate email, missing fields, and that the returned token
+authenticates a subsequent `/api/*` request.
+
+## Phase 2: iOS Core API auth client
+
+### Task 2.1: Core API login/register client
+Add `login(tenantId:email:password:)` and `register(tenantId:email:password:)` to
+the Core API client surface (extend `SyncClient` or a small `CoreAPIAuthClient`
+sharing baseURL + URLSession), returning `{token, patientId}`. Never log the
+password. Unit tests with a stubbed URLSession (success, 401, 409, unreachable).
+
+## Phase 3: Make Core API authoritative in AuthenticationService
+
+### Task 3.1: Registration flow through Core API
+`AuthenticationService.register` calls the Core API register client, then creates
+the local cache user keyed by the returned `patientId`, sets up the device master
+key + derived key (encryption identity = `patientId`), and stores the JWT.
+
+### Task 3.2: Login flow through Core API + encryption-identity continuity
+`AuthenticationService.login` authenticates against Core API; on success stores
+the JWT, ensures the local cache user for `patientId`, unlocks encryption for
+`patientId`, starts the session. Confirm HKDF salt = canonical `patientId` so PHI
+keys stay device-local and stable. 401 → reject.
+
+## Phase 4: Offline fallback + session/JWT lifecycle
+
+### Task 4.1: Offline fallback login
+When Core API is unreachable (network/timeout, not 401), fall back to the cached
+local credential check so the patient can open their encrypted local record;
+cloud sync stays inactive until a JWT is obtained. Distinguish unreachable vs
+rejected.
+
+### Task 4.2: Logout + 401 handling
+Logout clears session, cached derived key, and `coreAPIJWT`. On a `401` from
+`SyncClient`, deactivate cloud sync and require re-login (no retry loop).
+
+## Phase 5: Tenant config + cloud activation
+
+### Task 5.1: CoreAPITenantID config
+Add `CoreAPITenantID` build setting → Info.plist (alongside `CoreAPIBaseURL`),
+read in the auth/coordinator wiring. Empty → cloud auth disabled (pure local
+mode, no regression).
+
+### Task 5.2: Activate cloud sync when authenticated
+With base URL + tenant + JWT present, the existing `CloudSyncCoordinator` gate
+activates after login. Verify a logged-in patient's messages route through Core
+API and agent interview questions arrive over WebSocket (resolves HouseCall-nre3).
+
+## Phase 6: Tests and end-to-end evaluation
+
+### Task 6.1: Backend + iOS auth tests
+Backend: register endpoint tests (phase 1). iOS: AuthenticationService register/
+login through Core API, offline fallback, logout JWT clearing, encryption-
+identity continuity (same patientId → same derived key).
+
+### Task 6.2: Manual end-to-end evaluation
+With Postgres + core-api + agent (Ollama `medgemma:4b`) + physician web app
+running: register a patient in-app, conduct the interview, confirm the SOAP note
+reaches the physician queue, approve it, and confirm the approved plan is
+delivered back to the patient app. Closes HouseCall-nre3 and
+add-clinical-soap-review-workflow task 6.3.


### PR DESCRIPTION
Adds the `add-patient-cloud-auth` OpenSpec change: Core API as patient auth source of truth (new `POST /api/auth/register`, iOS JWT obtain/cache, device-local encryption continuity, offline fallback, cloud activation). Resolves `HouseCall-nre3`.

Spec deltas: `core-api`, `authentication`, `data-security`, `ios-cloud-sync`. Validated with `openspec validate --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)