### PR TITLE
add-patient-cloud-auth: Phase 2 — iOS Core API auth client

### DIFF
--- a/HouseCall/Core/Services/Sync/CoreAPIAuthClient.swift
+++ b/HouseCall/Core/Services/Sync/CoreAPIAuthClient.swift
@@ -1,0 +1,212 @@
+//
+//  CoreAPIAuthClient.swift
+//  HouseCall
+//
+//  Pre-authentication REST client for the HouseCall Core API.
+//
+//  Responsibilities:
+//  - POST credentials to /api/auth/login → CoreAPIAuthResult
+//  - POST credentials to /api/auth/register → CoreAPIAuthResult
+//
+//  This client requires NO JWT — these endpoints are the only way to
+//  *obtain* a JWT.  Wiring into AuthenticationService is deferred to
+//  task 3.x; this file is a self-contained testable seam.
+//
+//  HIPAA guardrails:
+//  - Plaintext passwords are sent only in the HTTPS/TLS request body;
+//    they are NEVER logged, printed, or placed in error descriptions.
+//  - TLS is required for any non-localhost base URL (same rule as SyncClient).
+//
+
+import Foundation
+
+// MARK: - Public result type
+
+/// The normalised result returned by both `login` and `register`.
+struct CoreAPIAuthResult {
+    /// JWT to store via `AuthenticationService.storeCoreAPIJWT(_:)`.
+    let token: String
+    /// Server-canonical patient UUID.  Used as the HKDF salt for
+    /// device-local encryption key derivation so encryption identity
+    /// stays stable and purely device-local.
+    let patientId: String
+}
+
+// MARK: - Private response DTOs
+//
+// These mirror the Go JSON field names exactly (snake_case, as declared
+// in auth.go with explicit json struct tags).
+//
+//   loginResponse    → { token, actor_type, actor_id }
+//   registerResponse → { token, actor_type, actor_id, patient_id }
+
+private struct LoginResponseDTO: Decodable {
+    let token: String
+    /// For patient actors actor_id equals the patient UUID.
+    let actor_id: String
+}
+
+private struct RegisterResponseDTO: Decodable {
+    let token: String
+    /// Canonical patient UUID; equal to actor_id for patient registrations.
+    let patient_id: String
+}
+
+// MARK: - CoreAPIAuthClient
+
+/// Dedicated pre-auth REST client.
+///
+/// Inject a custom `URLSession` in tests to avoid live network calls
+/// (see `CoreAPIAuthClientTests`).
+final class CoreAPIAuthClient {
+
+    // MARK: - Dependencies
+
+    private let baseURL: URL
+    private let session: URLSession
+
+    // MARK: - Initialisation
+
+    /// - Parameters:
+    ///   - baseURL: Core API host.  Default: `http://localhost:8080`.
+    ///     Any non-localhost URL **must** use `https://`.
+    ///   - session: URLSession for requests.  Defaults to `URLSession.shared`.
+    ///     Provide a stub session in tests.
+    /// - Throws: `SyncError.insecureBaseURL` if `baseURL` is non-localhost
+    ///   and does not use the `https` scheme.
+    init(
+        baseURL: URL = URL(string: "http://localhost:8080")!,
+        session: URLSession = .shared
+    ) throws {
+        let host = baseURL.host ?? ""
+        let isLocalhost = host == "localhost" || host == "127.0.0.1" || host == "::1"
+        if !isLocalhost && baseURL.scheme != "https" {
+            throw SyncError.insecureBaseURL
+        }
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    // MARK: - Public API
+
+    /// Authenticate an existing patient (or physician) account.
+    ///
+    /// Maps to `POST /api/auth/login`.
+    ///
+    /// - Parameters:
+    ///   - tenantId: Tenant UUID string (from `CoreAPITenantID` config).
+    ///   - email: Account email address.
+    ///   - password: Plaintext password (sent over TLS; never logged).
+    /// - Returns: `CoreAPIAuthResult` containing the JWT and the patient UUID.
+    /// - Throws:
+    ///   - `SyncError.unauthorized` on HTTP 401.
+    ///   - `SyncError.serverError(code)` on other non-2xx responses.
+    ///   - `SyncError.offline(reason)` when the server is unreachable or the
+    ///     transport fails; callers MUST distinguish this from `.unauthorized`
+    ///     to enable the phase-4 offline fallback.
+    func login(
+        tenantId: String,
+        email: String,
+        password: String
+    ) async throws -> CoreAPIAuthResult {
+        let body = try encodeBody(tenantId: tenantId, email: email, password: password)
+        let request = try buildRequest(path: "/api/auth/login", body: body)
+        let dto: LoginResponseDTO = try await perform(request)
+        return CoreAPIAuthResult(token: dto.token, patientId: dto.actor_id)
+    }
+
+    /// Register a new patient account.
+    ///
+    /// Maps to `POST /api/auth/register`.
+    ///
+    /// - Parameters:
+    ///   - tenantId: Tenant UUID string.
+    ///   - email: Desired email address.
+    ///   - password: Plaintext password (sent over TLS; never logged).
+    /// - Returns: `CoreAPIAuthResult` with the JWT and the newly-created
+    ///   patient UUID.  The caller should key local storage on `patientId`
+    ///   immediately so the encryption identity matches the server-canonical id.
+    /// - Throws:
+    ///   - `SyncError.conflict` if the email is already registered for this
+    ///     tenant (HTTP 409 "email already registered").
+    ///   - `SyncError.unauthorized` on HTTP 401.
+    ///   - `SyncError.serverError(code)` on other non-2xx responses.
+    ///   - `SyncError.offline(reason)` when the server is unreachable.
+    func register(
+        tenantId: String,
+        email: String,
+        password: String
+    ) async throws -> CoreAPIAuthResult {
+        let body = try encodeBody(tenantId: tenantId, email: email, password: password)
+        let request = try buildRequest(path: "/api/auth/register", body: body)
+        let dto: RegisterResponseDTO = try await perform(request)
+        return CoreAPIAuthResult(token: dto.token, patientId: dto.patient_id)
+    }
+
+    // MARK: - Private helpers
+
+    /// Encode `{tenant_id, email, password}` as JSON.
+    ///
+    /// The password value is encoded into the request body.
+    /// It must never appear in logs, error strings, or debug output.
+    private func encodeBody(tenantId: String, email: String, password: String) throws -> Data {
+        let dict: [String: String] = [
+            "tenant_id": tenantId,
+            "email": email,
+            "password": password
+        ]
+        return try JSONEncoder().encode(dict)
+    }
+
+    private func buildRequest(path: String, body: Data) throws -> URLRequest {
+        guard let url = URL(string: path, relativeTo: baseURL) else {
+            throw SyncError.offline("invalid path: \(path)")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        return request
+    }
+
+    /// Execute a request and decode the response body into `T`.
+    ///
+    /// Error mapping (mirrors SyncClient.perform for consistent error taxonomy):
+    /// - Transport / URLError          → `SyncError.offline(...)`
+    /// - HTTP 401                      → `SyncError.unauthorized`
+    /// - HTTP 409                      → `SyncError.conflict`
+    /// - Other non-2xx                 → `SyncError.serverError(code)`
+    /// - Decode failure                → `SyncError.decodeFailed(...)`
+    private func perform<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch let urlError as URLError {
+            throw SyncError.offline(urlError.localizedDescription)
+        } catch {
+            throw SyncError.offline(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw SyncError.offline("non-HTTP response")
+        }
+
+        switch http.statusCode {
+        case 200..<300:
+            break
+        case 401:
+            throw SyncError.unauthorized
+        case 409:
+            throw SyncError.conflict
+        default:
+            throw SyncError.serverError(http.statusCode)
+        }
+
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch let decodeError {
+            throw SyncError.decodeFailed(decodeError.localizedDescription)
+        }
+    }
+}

--- a/HouseCall/Core/Services/Sync/SyncClient.swift
+++ b/HouseCall/Core/Services/Sync/SyncClient.swift
@@ -38,6 +38,10 @@ enum SyncError: LocalizedError, Equatable {
     case serverError(Int)
     /// A non-localhost base URL was provided without HTTPS.
     case insecureBaseURL
+    /// The server returned 409 — e.g. the email is already registered for
+    /// this tenant (distinct from a generic server error so callers can
+    /// surface a specific "account already exists" message).
+    case conflict
 
     var errorDescription: String? {
         switch self {
@@ -56,6 +60,8 @@ enum SyncError: LocalizedError, Equatable {
             return "Server error (\(code))."
         case .insecureBaseURL:
             return "Non-localhost base URLs must use https://."
+        case .conflict:
+            return "An account with that email already exists."
         }
     }
 
@@ -66,6 +72,7 @@ enum SyncError: LocalizedError, Equatable {
         case (.decodeFailed(let a), .decodeFailed(let b)): return a == b
         case (.serverError(let a), .serverError(let b)): return a == b
         case (.insecureBaseURL, .insecureBaseURL): return true
+        case (.conflict, .conflict): return true
         default: return false
         }
     }

--- a/HouseCallTests/CoreAPIAuthClientTests.swift
+++ b/HouseCallTests/CoreAPIAuthClientTests.swift
@@ -1,0 +1,288 @@
+//
+//  CoreAPIAuthClientTests.swift
+//  HouseCallTests
+//
+//  Unit tests for CoreAPIAuthClient (Task 2.1).
+//
+//  All network calls are intercepted by SyncMockURLProtocol (defined in
+//  SyncClientTests.swift, internal to the HouseCallTests module).
+//  Tests follow the same Swift Testing (@Suite / @Test / #expect) style
+//  used across HouseCallTests.
+//
+
+import Testing
+import Foundation
+@testable import HouseCall
+
+// MARK: - Body capture helpers
+//
+// URLSession passes the request body to URLProtocol via `httpBodyStream`
+// (not `httpBody`) in many configurations.  These helpers let tests read
+// the body bytes regardless of which property is populated.
+
+/// Thread-safe box for a captured request body.
+/// `@unchecked Sendable` is intentional: the test controls the write-then-read
+/// ordering across the async boundary, so no additional locking is required.
+private final class BodyCapture: @unchecked Sendable {
+    var data: Data?
+}
+
+/// Drain an `InputStream` into `Data`.  The stream is opened and closed here.
+private func readStream(_ stream: InputStream) -> Data {
+    var data = Data()
+    let bufferSize = 4096
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+    stream.open()
+    while stream.hasBytesAvailable {
+        let n = stream.read(buffer, maxLength: bufferSize)
+        if n > 0 { data.append(buffer, count: n) }
+    }
+    stream.close()
+    return data
+}
+
+// MARK: - Session factories
+//
+// Private helpers that mirror the pattern in SyncClientTests.  They must
+// be redeclared here because the originals are file-private.
+
+private func makeAuthStubSession(sessionID: String) -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [SyncMockURLProtocol.self]
+    config.httpAdditionalHeaders = ["X-Test-Session-ID": sessionID]
+    return URLSession(configuration: config)
+}
+
+private func makeAuthOfflineSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [SyncOfflineURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func makeHTTPResponse(url: URL, status: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+}
+
+// MARK: - CoreAPIAuthClient Tests
+
+@Suite("CoreAPIAuthClient Tests")
+@MainActor
+struct CoreAPIAuthClientTests {
+
+    // MARK: - register: success (201)
+
+    @Test("register decodes token and patient_id from 201 response")
+    func testRegisterSuccess() async throws {
+        let sid = UUID().uuidString
+        let session = makeAuthStubSession(sessionID: sid)
+
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/auth/register") { req in
+            let json = """
+            {
+              "token": "jwt.register.tok",
+              "actor_type": "patient",
+              "actor_id": "patient-uuid-abc",
+              "patient_id": "patient-uuid-abc"
+            }
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = try CoreAPIAuthClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session
+        )
+        let result = try await client.register(
+            tenantId: "tenant-1",
+            email: "patient@example.com",
+            password: "TestPassword123!"
+        )
+
+        #expect(result.token == "jwt.register.tok")
+        #expect(result.patientId == "patient-uuid-abc")
+    }
+
+    // MARK: - register: password is sent in the request body
+
+    @Test("register sends password in the request body (not exposed via logs)")
+    func testRegisterPasswordInRequestBody() async throws {
+        let sid = UUID().uuidString
+        let session = makeAuthStubSession(sessionID: sid)
+        let expectedPassword = "SecurePass999!"
+
+        // URLSession hands the body to URLProtocol via httpBodyStream, not
+        // httpBody.  Capture the raw bytes inside the handler where the stream
+        // is still open (and where httpBody may still be set on some runtimes).
+        let bodyCapture = BodyCapture()
+
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/auth/register") { req in
+            if let body = req.httpBody {
+                bodyCapture.data = body
+            } else if let stream = req.httpBodyStream {
+                bodyCapture.data = readStream(stream)
+            }
+            let json = """
+            {"token":"tok","actor_type":"patient","actor_id":"pid","patient_id":"pid"}
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = try CoreAPIAuthClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session
+        )
+        _ = try await client.register(
+            tenantId: "t-1",
+            email: "a@b.com",
+            password: expectedPassword
+        )
+
+        let bodyData = try #require(bodyCapture.data, "Request body was not captured")
+        // Must be a valid JSON dictionary with the password field.
+        let bodyDict = try JSONDecoder().decode([String: String].self, from: bodyData)
+        #expect(bodyDict["password"] == expectedPassword)
+        #expect(bodyDict["email"] == "a@b.com")
+        #expect(bodyDict["tenant_id"] == "t-1")
+    }
+
+    // MARK: - login: success (200)
+
+    @Test("login decodes token and actor_id as patientId from 200 response")
+    func testLoginSuccess() async throws {
+        let sid = UUID().uuidString
+        let session = makeAuthStubSession(sessionID: sid)
+
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/auth/login") { req in
+            let json = """
+            {
+              "token": "jwt.login.tok",
+              "actor_type": "patient",
+              "actor_id": "patient-uuid-xyz"
+            }
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 200))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = try CoreAPIAuthClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session
+        )
+        let result = try await client.login(
+            tenantId: "tenant-1",
+            email: "patient@example.com",
+            password: "TestPassword123!"
+        )
+
+        #expect(result.token == "jwt.login.tok")
+        #expect(result.patientId == "patient-uuid-xyz")
+    }
+
+    // MARK: - 401 → SyncError.unauthorized
+
+    @Test("401 response maps to SyncError.unauthorized")
+    func test401MapsToUnauthorized() async throws {
+        let sid = UUID().uuidString
+        let session = makeAuthStubSession(sessionID: sid)
+
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/auth/login") { req in
+            ("invalid credentials".data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 401))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = try CoreAPIAuthClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session
+        )
+
+        do {
+            _ = try await client.login(
+                tenantId: "t-1",
+                email: "bad@example.com",
+                password: "wrongpw"
+            )
+            Issue.record("Expected SyncError.unauthorized but no error was thrown")
+        } catch let err as SyncError {
+            #expect(err == .unauthorized)
+        }
+    }
+
+    // MARK: - 409 → SyncError.conflict
+
+    @Test("409 response maps to SyncError.conflict")
+    func test409MapsToConflict() async throws {
+        let sid = UUID().uuidString
+        let session = makeAuthStubSession(sessionID: sid)
+
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/auth/register") { req in
+            ("email already registered".data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 409))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let client = try CoreAPIAuthClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session
+        )
+
+        do {
+            _ = try await client.register(
+                tenantId: "t-1",
+                email: "existing@example.com",
+                password: "SomePassword!"
+            )
+            Issue.record("Expected SyncError.conflict but no error was thrown")
+        } catch let err as SyncError {
+            #expect(err == .conflict)
+        }
+    }
+
+    // MARK: - Transport failure → SyncError.offline
+
+    @Test("URLError (unreachable) maps to SyncError.offline — distinct from .unauthorized")
+    func testTransportFailureMapsToOffline() async throws {
+        let session = makeAuthOfflineSession()
+
+        let client = try CoreAPIAuthClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session
+        )
+
+        do {
+            _ = try await client.login(
+                tenantId: "t-1",
+                email: "patient@example.com",
+                password: "SomePassword!"
+            )
+            Issue.record("Expected SyncError.offline but no error was thrown")
+        } catch let err as SyncError {
+            // Must be .offline — NOT .unauthorized.  This distinction is
+            // required for the phase-4 offline fallback to local credentials.
+            if case .offline = err {
+                // Expected — transport layer failure correctly signalled.
+            } else {
+                Issue.record("Expected SyncError.offline, got \(err)")
+            }
+        }
+    }
+
+    // MARK: - Insecure base URL
+
+    @Test("Non-localhost http:// base URL is rejected at init with insecureBaseURL")
+    func testInsecureBaseURLRejected() throws {
+        #expect(throws: SyncError.insecureBaseURL) {
+            try CoreAPIAuthClient(baseURL: URL(string: "http://example.com")!)
+        }
+    }
+
+    // MARK: - HTTPS base URL accepted
+
+    @Test("https:// non-localhost base URL is accepted at init")
+    func testHTTPSBaseURLAccepted() throws {
+        #expect(throws: Never.self) {
+            _ = try CoreAPIAuthClient(baseURL: URL(string: "https://api.example.com")!)
+        }
+    }
+}

--- a/openspec/changes/add-patient-cloud-auth/tasks.md
+++ b/openspec/changes/add-patient-cloud-auth/tasks.md
@@ -16,7 +16,7 @@ authenticates a subsequent `/api/*` request.
 
 ## Phase 2: iOS Core API auth client
 
-### Task 2.1: Core API login/register client
+### Task 2.1: Core API login/register client  [x]
 Add `login(tenantId:email:password:)` and `register(tenantId:email:password:)` to
 the Core API client surface (extend `SyncClient` or a small `CoreAPIAuthClient`
 sharing baseURL + URLSession), returning `{token, patientId}`. Never log the


### PR DESCRIPTION
Phase 2 of `add-patient-cloud-auth`: pre-auth iOS client for Core API login/register.

## Tasks
- [x] 2.1 `CoreAPIAuthClient` (login/register → `{token, patientId}`), TLS/localhost guard, `SyncError.conflict`; error mapping preserves offline≠unauthorized (401→unauthorized, 409→conflict, transport→offline); 8 tests. Password sent only in body, never logged.

## Beads closed
HouseCall-q26q (#172)

## Test
Build + `HouseCallTests` green (known SyncMock/timing flakes excused). No production wiring yet (phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)