### PR TITLE
add-patient-cloud-auth: Phase 3 — Core API authoritative auth + encryption continuity

### DIFF
--- a/HouseCall/Core/Persistence/CoreDataUserRepository.swift
+++ b/HouseCall/Core/Persistence/CoreDataUserRepository.swift
@@ -36,14 +36,17 @@ class CoreDataUserRepository: UserRepositoryProtocol {
         password: String?,
         passcode: String?,
         fullName: String,
-        authMethod: AuthMethod
+        authMethod: AuthMethod,
+        id: UUID?
     ) throws -> User {
-        // Create user entity. Use a local `userId` for the derivation/encryption
-        // calls below rather than reading `user.id` back: a force-unwrap of the
-        // managed object's attribute crashes the process if the object's state
-        // is ever disturbed (e.g. a caller misusing the context from another
-        // thread), whereas the local value is always valid.
-        let userId = UUID()
+        // Use the caller-supplied id when provided (e.g. the Core API patient UUID
+        // for encryption-identity continuity) or generate a fresh one otherwise.
+        // Use a local `userId` for the derivation/encryption calls below rather
+        // than reading `user.id` back: a force-unwrap of the managed object's
+        // attribute crashes the process if the object's state is ever disturbed
+        // (e.g. a caller misusing the context from another thread), whereas the
+        // local value is always valid.
+        let userId = id ?? UUID()
         let user = User(context: context)
         user.id = userId
         user.email = email.lowercased()

--- a/HouseCall/Core/Persistence/UserRepository.swift
+++ b/HouseCall/Core/Persistence/UserRepository.swift
@@ -79,13 +79,19 @@ enum AuthMethod: String {
 
 /// Protocol defining user data access operations
 protocol UserRepositoryProtocol {
-    /// Creates a new user account
+    /// Creates a new user account.
+    ///
     /// - Parameters:
     ///   - email: User's email address
     ///   - password: User's password (optional, for password auth)
     ///   - passcode: User's passcode (optional, for passcode auth)
     ///   - fullName: User's full name
     ///   - authMethod: Authentication method (password, passcode, or biometric)
+    ///   - id: Optional caller-supplied UUID to use as the new user's identity.
+    ///     When `nil` the implementation generates a fresh UUID.
+    ///     Pass the Core API `patientId` here so the local user's `id` matches
+    ///     the server-canonical UUID, ensuring HKDF salt continuity for at-rest
+    ///     encryption (see design.md §"encryption-identity continuity").
     /// - Returns: Created User entity
     /// - Throws: UserRepositoryError
     func createUser(
@@ -93,7 +99,8 @@ protocol UserRepositoryProtocol {
         password: String?,
         passcode: String?,
         fullName: String,
-        authMethod: AuthMethod
+        authMethod: AuthMethod,
+        id: UUID?
     ) throws -> User
 
     /// Finds a user by email address
@@ -124,4 +131,25 @@ protocol UserRepositoryProtocol {
     /// - Parameter email: Email address to check
     /// - Returns: true if email exists, false otherwise
     func isEmailRegistered(_ email: String) -> Bool
+}
+
+extension UserRepositoryProtocol {
+    /// Backward-compatible convenience wrapper — passes `id: nil` so existing
+    /// call sites that do not supply an explicit UUID are unchanged.
+    func createUser(
+        email: String,
+        password: String?,
+        passcode: String?,
+        fullName: String,
+        authMethod: AuthMethod
+    ) throws -> User {
+        try createUser(
+            email: email,
+            password: password,
+            passcode: passcode,
+            fullName: fullName,
+            authMethod: authMethod,
+            id: nil
+        )
+    }
 }

--- a/HouseCall/Core/Services/AuthenticationService.swift
+++ b/HouseCall/Core/Services/AuthenticationService.swift
@@ -198,9 +198,11 @@ class AuthenticationService: ObservableObject {
                 throw AuthenticationError.registrationFailed("Email already registered")
             case .unauthorized:
                 throw AuthenticationError.registrationFailed("Registration unauthorised")
-            case .offline(let reason):
+            case .offline:
+                // Do not embed the raw offline reason — system error strings can
+                // carry sensitive context (matches SyncError.offline.errorDescription).
                 throw AuthenticationError.registrationFailed(
-                    "Registration requires network connectivity (\(reason))"
+                    "Registration requires network connectivity"
                 )
             default:
                 throw AuthenticationError.registrationFailed(syncErr.localizedDescription ?? "Server error")

--- a/HouseCall/Core/Services/AuthenticationService.swift
+++ b/HouseCall/Core/Services/AuthenticationService.swift
@@ -245,7 +245,20 @@ class AuthenticationService: ObservableObject {
 
     // MARK: - Login
 
-    /// Logs in a user with credentials
+    /// Logs in a user with credentials.
+    ///
+    /// **Cloud path** (when `coreAuthClient` and `coreAPITenantId` are both set):
+    /// 1. `POST /api/auth/login` → `{token, patientId}`.
+    /// 2. Ensure the local cache user for `patientId` exists; create one keyed by
+    ///    `patientId` if missing (first login on this device).
+    /// 3. Store the JWT via `storeCoreAPIJWT(_:)`.
+    /// 4. Start the session — encryption unlocks for `user.id == patientId`.
+    ///
+    /// Error mapping (cloud path only):
+    /// - 401 (unauthorized) → `loginFailed(...)`. Core API is authoritative; no fallback.
+    /// - Network unreachable → `loginFailed(...)` for now (task 4.1 will add offline fallback).
+    ///
+    /// **Local path** (nil cloud deps): unchanged from the original behaviour.
     @MainActor
     func login(
         email: String,
@@ -253,7 +266,9 @@ class AuthenticationService: ObservableObject {
         authMethod: AuthMethod,
         useBiometric: Bool = false
     ) async throws -> User {
-        // If biometric auth is requested, perform it first
+        // Biometric pre-check (preserved from original behaviour).
+        // Runs regardless of cloud/local path: biometric gates device-local session
+        // access; it does not replace the Core API credential check.
         if useBiometric && authMethod == .biometric {
             let reason = BiometricAuthManager.createAuthenticationReason(for: "login")
             let result = await biometricAuthManager.authenticate(reason: reason)
@@ -264,6 +279,18 @@ class AuthenticationService: ObservableObject {
             }
         }
 
+        // Cloud-enabled path
+        if let authClient = coreAuthClient, let tenantId = coreAPITenantId {
+            return try await loginViaCloudAPI(
+                authClient: authClient,
+                tenantId: tenantId,
+                email: email,
+                credential: credential,
+                authMethod: authMethod
+            )
+        }
+
+        // Local-only path (unchanged)
         do {
             let user = try userRepository.authenticateUser(
                 email: email,
@@ -277,6 +304,79 @@ class AuthenticationService: ObservableObject {
         } catch {
             throw AuthenticationError.loginFailed(error.localizedDescription)
         }
+    }
+
+    /// Cloud login flow.  Separated from the public `login` method so the
+    /// control flow is easy to read and the local path has zero added indentation.
+    @MainActor
+    private func loginViaCloudAPI(
+        authClient: CoreAPIAuthClientProtocol,
+        tenantId: String,
+        email: String,
+        credential: String,
+        authMethod: AuthMethod
+    ) async throws -> User {
+        // Step 1: Authenticate against Core API (Core API is authoritative).
+        let authResult: CoreAPIAuthResult
+        do {
+            authResult = try await authClient.login(
+                tenantId: tenantId,
+                email: email,
+                password: credential
+            )
+        } catch let syncErr as SyncError {
+            switch syncErr {
+            case .unauthorized:
+                // Core API explicitly rejected the credentials — do NOT fall back
+                // to a local credential check; Core API is the single source of truth.
+                throw AuthenticationError.loginFailed("Invalid credentials")
+            case .offline:
+                // TODO: Task 4.1 — offline fallback: when Core API is unreachable,
+                // fall back to the cached local credential check so the patient can
+                // still open their encrypted local record.  For now fail fast.
+                throw AuthenticationError.loginFailed("Unable to reach the server. Please check your connection.")
+            default:
+                throw AuthenticationError.loginFailed(syncErr.localizedDescription ?? "Server error")
+            }
+        } catch {
+            throw AuthenticationError.loginFailed(error.localizedDescription)
+        }
+
+        // Step 2: Parse the server-canonical patient UUID.
+        guard let patientId = UUID(uuidString: authResult.patientId) else {
+            throw AuthenticationError.loginFailed("Invalid patient id from server")
+        }
+
+        // Step 3: Ensure the local cache user exists for the canonical patientId.
+        // On first login on this device the record may not exist yet (e.g., the
+        // patient registered on another device or the local store was cleared).
+        // Creating it here keyed by patientId keeps the HKDF salt stable and equal
+        // to the server-canonical identity — encryption-identity continuity.
+        let user: User
+        if let existingUser = userRepository.findUser(by: patientId) {
+            user = existingUser
+        } else {
+            do {
+                user = try userRepository.createUser(
+                    email: email,
+                    password: authMethod == .password ? credential : nil,
+                    passcode: authMethod == .passcode ? credential : nil,
+                    fullName: "",   // Full name unknown at login; will be populated by sync (task 5.2)
+                    authMethod: authMethod,
+                    id: patientId
+                )
+            } catch {
+                throw AuthenticationError.loginFailed(error.localizedDescription)
+            }
+        }
+
+        // Step 4: Persist the JWT for subsequent authenticated Core API calls.
+        try? storeCoreAPIJWT(authResult.token)
+
+        // Step 5: Start the local session (encryption unlocks via user.id == patientId).
+        try await createSession(for: user, authMethod: authMethod)
+
+        return user
     }
 
     /// Logs in with biometric authentication only

--- a/HouseCall/Core/Services/AuthenticationService.swift
+++ b/HouseCall/Core/Services/AuthenticationService.swift
@@ -67,6 +67,18 @@ class AuthenticationService: ObservableObject {
     private let biometricAuthManager: BiometricAuthManager
     private let auditLogger: AuditLogger
 
+    // MARK: - Cloud Auth (Task 3.1)
+
+    /// Optional Core API auth client.  When non-nil (together with
+    /// `coreAPITenantId`), registration and login route through Core API.
+    /// `nil` preserves the original local-only behaviour — no existing call
+    /// sites or tests are affected.  Production wiring is finalised in phase 5.
+    private let coreAuthClient: CoreAPIAuthClientProtocol?
+
+    /// Tenant identifier passed to Core API auth calls.  Must be non-nil
+    /// alongside `coreAuthClient` for cloud auth to activate.
+    private let coreAPITenantId: String?
+
     /// Injected after login so timeout and logout both stop the WebSocket
     /// subscription and prevent PHI from being delivered to an expired session.
     /// Set this to the active `CloudSyncCoordinator` once the coordinator is
@@ -80,12 +92,16 @@ class AuthenticationService: ObservableObject {
         userRepository: UserRepositoryProtocol = CoreDataUserRepository(),
         keychainManager: KeychainManager = .shared,
         biometricAuthManager: BiometricAuthManager = .shared,
-        auditLogger: AuditLogger = .shared
+        auditLogger: AuditLogger = .shared,
+        coreAuthClient: CoreAPIAuthClientProtocol? = nil,
+        coreAPITenantId: String? = nil
     ) {
         self.userRepository = userRepository
         self.keychainManager = keychainManager
         self.biometricAuthManager = biometricAuthManager
         self.auditLogger = auditLogger
+        self.coreAuthClient = coreAuthClient
+        self.coreAPITenantId = coreAPITenantId
 
         // Restore session on init
         restoreSession()
@@ -96,7 +112,21 @@ class AuthenticationService: ObservableObject {
 
     // MARK: - Registration
 
-    /// Registers a new user
+    /// Registers a new user.
+    ///
+    /// **Cloud path** (when `coreAuthClient` and `coreAPITenantId` are both set):
+    /// 1. `POST /api/auth/register` → `{token, patientId}`.
+    /// 2. Create the local cache user keyed by `patientId` so the HKDF salt
+    ///    equals the server-canonical identity (encryption-identity continuity).
+    /// 3. Store the JWT via `storeCoreAPIJWT(_:)`.
+    /// 4. Start the session as usual.
+    ///
+    /// Error mapping (cloud path only):
+    /// - 409 conflict → `registrationFailed("Email already registered")`
+    /// - Network unreachable → `registrationFailed("Registration requires…")`
+    /// - 401 → `registrationFailed("Registration unauthorised")`
+    ///
+    /// **Local path** (nil cloud deps): unchanged from the original behaviour.
     @MainActor
     func register(
         email: String,
@@ -105,6 +135,20 @@ class AuthenticationService: ObservableObject {
         fullName: String,
         authMethod: AuthMethod
     ) async throws -> User {
+        // Cloud-enabled path
+        if let authClient = coreAuthClient, let tenantId = coreAPITenantId {
+            return try await registerViaCloudAPI(
+                authClient: authClient,
+                tenantId: tenantId,
+                email: email,
+                password: password,
+                passcode: passcode,
+                fullName: fullName,
+                authMethod: authMethod
+            )
+        }
+
+        // Local-only path (unchanged)
         do {
             let user = try userRepository.createUser(
                 email: email,
@@ -121,6 +165,80 @@ class AuthenticationService: ObservableObject {
         } catch {
             throw AuthenticationError.registrationFailed(error.localizedDescription)
         }
+    }
+
+    /// Cloud registration flow.  Separated from the public `register` method so
+    /// the control flow is easy to read and the local path has zero added
+    /// indentation.
+    @MainActor
+    private func registerViaCloudAPI(
+        authClient: CoreAPIAuthClientProtocol,
+        tenantId: String,
+        email: String,
+        password: String?,
+        passcode: String?,
+        fullName: String,
+        authMethod: AuthMethod
+    ) async throws -> User {
+        // Step 1: Obtain the server-canonical patient UUID and JWT.
+        // Registration requires connectivity — offline is a hard failure here.
+        // (Offline login fallback is handled in task 4.1.)
+        let authResult: CoreAPIAuthResult
+        do {
+            // Core API register requires a password credential.
+            let pw = password ?? ""
+            authResult = try await authClient.register(
+                tenantId: tenantId,
+                email: email,
+                password: pw
+            )
+        } catch let syncErr as SyncError {
+            switch syncErr {
+            case .conflict:
+                throw AuthenticationError.registrationFailed("Email already registered")
+            case .unauthorized:
+                throw AuthenticationError.registrationFailed("Registration unauthorised")
+            case .offline(let reason):
+                throw AuthenticationError.registrationFailed(
+                    "Registration requires network connectivity (\(reason))"
+                )
+            default:
+                throw AuthenticationError.registrationFailed(syncErr.localizedDescription ?? "Server error")
+            }
+        } catch {
+            throw AuthenticationError.registrationFailed(error.localizedDescription)
+        }
+
+        // Step 2: Parse the server-canonical patient UUID.
+        guard let patientId = UUID(uuidString: authResult.patientId) else {
+            throw AuthenticationError.registrationFailed("Invalid patient id from server")
+        }
+
+        // Step 3: Create the local cache user keyed by patientId so that
+        // EncryptionManager.getDerivedKey(for: user.id) uses the canonical salt.
+        let user: User
+        do {
+            user = try userRepository.createUser(
+                email: email,
+                password: password,
+                passcode: passcode,
+                fullName: fullName,
+                authMethod: authMethod,
+                id: patientId
+            )
+        } catch {
+            throw AuthenticationError.registrationFailed(error.localizedDescription)
+        }
+
+        // Step 4: Persist the JWT for subsequent authenticated Core API calls.
+        // Errors here are non-fatal for the registration itself but unusual —
+        // cloud sync will remain inactive until the next login refreshes the JWT.
+        try? storeCoreAPIJWT(authResult.token)
+
+        // Step 5: Start the local session (encryption unlocks via user.id == patientId).
+        try await createSession(for: user, authMethod: authMethod)
+
+        return user
     }
 
     // MARK: - Login

--- a/HouseCall/Core/Services/Sync/CoreAPIAuthClient.swift
+++ b/HouseCall/Core/Services/Sync/CoreAPIAuthClient.swift
@@ -52,13 +52,28 @@ private struct RegisterResponseDTO: Decodable {
     let patient_id: String
 }
 
+// MARK: - CoreAPIAuthClientProtocol
+
+/// Testable seam for the Core API auth client.
+///
+/// Inject a conforming stub in unit tests to avoid live network calls.
+/// `CoreAPIAuthClient` is the production conformer; tests use
+/// `StubCoreAPIAuthClient` (defined in HouseCallTests).
+protocol CoreAPIAuthClientProtocol {
+    /// Authenticate an existing patient account.
+    func login(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult
+
+    /// Register a new patient account.
+    func register(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult
+}
+
 // MARK: - CoreAPIAuthClient
 
 /// Dedicated pre-auth REST client.
 ///
 /// Inject a custom `URLSession` in tests to avoid live network calls
 /// (see `CoreAPIAuthClientTests`).
-final class CoreAPIAuthClient {
+final class CoreAPIAuthClient: CoreAPIAuthClientProtocol {
 
     // MARK: - Dependencies
 

--- a/HouseCallTests/CloudLoginTests.swift
+++ b/HouseCallTests/CloudLoginTests.swift
@@ -1,0 +1,331 @@
+//
+//  CloudLoginTests.swift
+//  HouseCallTests
+//
+//  Unit tests for Task 3.2 — login flow through Core API +
+//  encryption-identity continuity.
+//
+//  Coverage:
+//  - Cloud login success (existing local user for patientId) → session created,
+//    JWT stored, encryption unlocks for the canonical patientId.
+//  - Cloud login success when NO local user yet (first device login) → local
+//    cache user created keyed by patientId, then session/JWT.
+//  - Encryption continuity across register→login: PHI encrypted after register
+//    decrypts correctly after login (same HKDF salt = patientId).
+//  - Unauthorized (401) → loginFailed thrown, no session, no JWT.
+//  - Cloud disabled (nil deps) → unchanged local-only login works.
+//
+
+import Testing
+import CoreData
+import CryptoKit
+@testable import HouseCall
+
+// MARK: - Stub
+
+/// Configurable stub satisfying `CoreAPIAuthClientProtocol` for login tests.
+/// File-private so it can shadow the private stub in CloudRegistrationTests.swift
+/// without any name conflict (each is visible only within its own file).
+private final class StubCoreAPIAuthClient: CoreAPIAuthClientProtocol, @unchecked Sendable {
+    enum Behaviour {
+        case success(token: String, patientId: String)
+        case conflict
+        case unauthorized
+        case offline(String)
+    }
+
+    var registerBehaviour: Behaviour
+    var loginBehaviour: Behaviour
+
+    /// Convenience init with `loginBehaviour` as the primary parameter.
+    init(loginBehaviour: Behaviour, registerBehaviour: Behaviour = .unauthorized) {
+        self.loginBehaviour = loginBehaviour
+        self.registerBehaviour = registerBehaviour
+    }
+
+    func login(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult {
+        try resolve(loginBehaviour)
+    }
+
+    func register(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult {
+        try resolve(registerBehaviour)
+    }
+
+    private func resolve(_ behaviour: Behaviour) throws -> CoreAPIAuthResult {
+        switch behaviour {
+        case .success(let token, let patientId):
+            return CoreAPIAuthResult(token: token, patientId: patientId)
+        case .conflict:
+            throw SyncError.conflict
+        case .unauthorized:
+            throw SyncError.unauthorized
+        case .offline(let reason):
+            throw SyncError.offline(reason)
+        }
+    }
+}
+
+// MARK: - CloudLoginTests
+
+@Suite("Cloud Login Tests")
+@MainActor
+struct CloudLoginTests {
+
+    // MARK: - Helpers
+
+    private func makeContext() -> NSManagedObjectContext {
+        let container = NSPersistentContainer(
+            name: "HouseCall",
+            managedObjectModel: TestCoreDataModel.shared
+        )
+        let desc = NSPersistentStoreDescription()
+        desc.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [desc]
+        container.loadPersistentStores { _, error in
+            if let error { fatalError("In-memory store failed: \(error)") }
+        }
+        return container.viewContext
+    }
+
+    private func makeService(
+        context: NSManagedObjectContext,
+        keychain: InMemoryKeychainManager,
+        stubClient: CoreAPIAuthClientProtocol?,
+        tenantId: String?
+    ) -> AuthenticationService {
+        AuthenticationService(
+            userRepository: CoreDataUserRepository(
+                context: context,
+                encryptionManager: EncryptionManager.shared,
+                passwordHasher: PasswordHasher.shared,
+                auditLogger: AuditLogger(context: context)
+            ),
+            keychainManager: keychain,
+            biometricAuthManager: .shared,
+            auditLogger: AuditLogger(context: context),
+            coreAuthClient: stubClient,
+            coreAPITenantId: tenantId
+        )
+    }
+
+    private func makeRepo(context: NSManagedObjectContext) -> CoreDataUserRepository {
+        CoreDataUserRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            passwordHasher: PasswordHasher.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+    }
+
+    // MARK: - Cloud login success: existing local user
+
+    @Test("Cloud login success — existing local user, session created and JWT stored")
+    func testCloudLoginExistingLocalUser() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let patientId = UUID()
+
+        // Pre-create the local cache user keyed by patientId (simulates a prior
+        // registration or a previous login on this device).
+        let repo = makeRepo(context: context)
+        _ = try repo.createUser(
+            email: "patient@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Jane Smith",
+            authMethod: .password,
+            id: patientId
+        )
+
+        let stub = StubCoreAPIAuthClient(
+            loginBehaviour: .success(token: "login.jwt.123", patientId: patientId.uuidString)
+        )
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        let user = try await service.login(
+            email: "patient@example.com",
+            credential: "SecurePassword123!",
+            authMethod: .password
+        )
+
+        // User identity must match the canonical patientId.
+        let userId = try #require(user.id)
+        #expect(userId == patientId,
+                "Logged-in user.id must equal the Core API patientId")
+
+        // JWT must be stored.
+        let storedJWT = try keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == "login.jwt.123",
+                "Core API JWT must be written to keychain after successful cloud login")
+
+        // Session must be active.
+        await Task.yield()
+        #expect(service.isAuthenticated == true,
+                "Session must be active after successful cloud login")
+    }
+
+    // MARK: - Cloud login success: no local user yet (first device login)
+
+    @Test("Cloud login success — no local user, cache user created keyed by patientId")
+    func testCloudLoginFirstDevice() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let patientId = UUID()
+
+        // No local user exists before login (first login on this device).
+        let repo = makeRepo(context: context)
+        #expect(repo.findUser(by: patientId) == nil,
+                "Precondition: no local user should exist before first-device login")
+
+        let stub = StubCoreAPIAuthClient(
+            loginBehaviour: .success(token: "first.jwt", patientId: patientId.uuidString)
+        )
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        let user = try await service.login(
+            email: "new@example.com",
+            credential: "SecurePassword123!",
+            authMethod: .password
+        )
+
+        // User must be created keyed by the canonical patientId.
+        let userId = try #require(user.id)
+        #expect(userId == patientId,
+                "Cache user created on first-device login must be keyed by patientId")
+
+        // Local user must now exist in the store.
+        #expect(repo.findUser(by: patientId) != nil,
+                "A local cache user must exist after first-device cloud login")
+
+        // JWT and session must be established.
+        let storedJWT = try keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == "first.jwt")
+
+        await Task.yield()
+        #expect(service.isAuthenticated == true)
+    }
+
+    // MARK: - Encryption continuity: register then login
+
+    @Test("Encryption continuity — PHI encrypted after register decrypts after login")
+    func testEncryptionContinuityRegisterThenLogin() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let patientId = UUID()
+        let stub = StubCoreAPIAuthClient(
+            loginBehaviour: .success(token: "login.jwt", patientId: patientId.uuidString),
+            registerBehaviour: .success(token: "reg.jwt", patientId: patientId.uuidString)
+        )
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        // Register — creates local user keyed by patientId.
+        let registeredUser = try await service.register(
+            email: "cont@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Continuity Patient",
+            authMethod: .password
+        )
+        let registeredId = try #require(registeredUser.id)
+        #expect(registeredId == patientId)
+
+        // Encrypt a PHI value using the registered user's identity.
+        let plaintext = "blood pressure: 120/80"
+        let encryptedPHI = try EncryptionManager.shared.encryptString(plaintext, for: registeredId)
+
+        // Log out so we start a fresh login.
+        try await service.logout()
+
+        // Login — must resolve to the same local user (or re-create with the
+        // same patientId) and derive the same encryption key.
+        let loggedInUser = try await service.login(
+            email: "cont@example.com",
+            credential: "SecurePassword123!",
+            authMethod: .password
+        )
+        let loggedInId = try #require(loggedInUser.id)
+        #expect(loggedInId == patientId,
+                "Login must resolve to the same canonical patientId as registration")
+
+        // PHI encrypted under the registered identity must decrypt under login identity.
+        let decrypted = try EncryptionManager.shared.decryptString(encryptedPHI, for: loggedInId)
+        #expect(decrypted == plaintext,
+                "PHI written after registration must be readable after login (same HKDF salt)")
+    }
+
+    // MARK: - Unauthorized (401) → loginFailed
+
+    @Test("Cloud 401 — loginFailed thrown, no session, no JWT")
+    func testCloudUnauthorized() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let stub = StubCoreAPIAuthClient(loginBehaviour: .unauthorized)
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        var caughtLoginFailed = false
+        do {
+            _ = try await service.login(
+                email: "bad@example.com",
+                credential: "WrongPassword123!",
+                authMethod: .password
+            )
+            Issue.record("Expected loginFailed to be thrown for a 401 response")
+        } catch let err as AuthenticationError {
+            if case .loginFailed = err {
+                caughtLoginFailed = true
+            } else {
+                Issue.record("Expected .loginFailed, got \(err)")
+            }
+        }
+        #expect(caughtLoginFailed, "401 from Core API must produce loginFailed")
+
+        // No JWT stored.
+        let storedJWT = try? keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == nil, "No JWT must be stored when login is rejected with 401")
+
+        // No active session.
+        await Task.yield()
+        #expect(service.isAuthenticated == false,
+                "No session must be started when Core API rejects credentials")
+    }
+
+    // MARK: - Cloud disabled (nil deps) → local-only login
+
+    @Test("Cloud disabled — local-only login works unchanged")
+    func testLocalOnlyLogin() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        // nil client + nil tenantId → local-only path
+        let service = makeService(context: context, keychain: keychain, stubClient: nil, tenantId: nil)
+
+        // Pre-create a local user (local-only registration).
+        let repo = makeRepo(context: context)
+        let localUser = try repo.createUser(
+            email: "local@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Local Patient",
+            authMethod: .password
+        )
+        let localId = try #require(localUser.id)
+
+        let loggedIn = try await service.login(
+            email: "local@example.com",
+            credential: "SecurePassword123!",
+            authMethod: .password
+        )
+
+        let loggedInId = try #require(loggedIn.id)
+        #expect(loggedInId == localId,
+                "Local-only login must return the pre-existing local user")
+
+        // No JWT should be stored.
+        let storedJWT = try? keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == nil, "Local-only login must NOT store a Core API JWT")
+
+        // Session must be active.
+        await Task.yield()
+        #expect(service.isAuthenticated == true,
+                "Session must be active after successful local-only login")
+    }
+}

--- a/HouseCallTests/CloudRegistrationTests.swift
+++ b/HouseCallTests/CloudRegistrationTests.swift
@@ -1,0 +1,343 @@
+//
+//  CloudRegistrationTests.swift
+//  HouseCallTests
+//
+//  Unit tests for Task 3.1 — registration flow through Core API.
+//
+//  Coverage:
+//  - Cloud register success: local user id equals server-canonical patientId.
+//  - JWT stored in keychain after cloud registration.
+//  - Session created (isAuthenticated) after cloud registration.
+//  - Encryption-identity continuity: getDerivedKey(user.id) == getDerivedKey(patientId)
+//    and PHI round-trips correctly.
+//  - Cloud disabled (nil deps): unchanged local-only registration path.
+//  - 409 conflict: registrationFailed error thrown, no local user created, no JWT stored.
+//  - Network offline: registrationFailed error with connectivity description.
+//
+
+import Testing
+import CoreData
+import CryptoKit
+@testable import HouseCall
+
+// MARK: - StubCoreAPIAuthClient
+
+/// Configurable stub satisfying `CoreAPIAuthClientProtocol`.
+/// Never touches the network; returns or throws a caller-specified result.
+private final class StubCoreAPIAuthClient: CoreAPIAuthClientProtocol, @unchecked Sendable {
+    enum Behaviour {
+        case success(token: String, patientId: String)
+        case conflict
+        case unauthorized
+        case offline(String)
+    }
+
+    var registerBehaviour: Behaviour
+    var loginBehaviour: Behaviour
+
+    init(registerBehaviour: Behaviour, loginBehaviour: Behaviour = .unauthorized) {
+        self.registerBehaviour = registerBehaviour
+        self.loginBehaviour = loginBehaviour
+    }
+
+    func register(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult {
+        try resolve(registerBehaviour)
+    }
+
+    func login(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult {
+        try resolve(loginBehaviour)
+    }
+
+    private func resolve(_ behaviour: Behaviour) throws -> CoreAPIAuthResult {
+        switch behaviour {
+        case .success(let token, let patientId):
+            return CoreAPIAuthResult(token: token, patientId: patientId)
+        case .conflict:
+            throw SyncError.conflict
+        case .unauthorized:
+            throw SyncError.unauthorized
+        case .offline(let reason):
+            throw SyncError.offline(reason)
+        }
+    }
+}
+
+// MARK: - CloudRegistrationTests
+
+@Suite("Cloud Registration Tests")
+@MainActor
+struct CloudRegistrationTests {
+
+    // MARK: - Helpers
+
+    private func makeContext() -> NSManagedObjectContext {
+        let container = NSPersistentContainer(
+            name: "HouseCall",
+            managedObjectModel: TestCoreDataModel.shared
+        )
+        let desc = NSPersistentStoreDescription()
+        desc.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [desc]
+        container.loadPersistentStores { _, error in
+            if let error { fatalError("In-memory store failed: \(error)") }
+        }
+        return container.viewContext
+    }
+
+    private func makeService(
+        context: NSManagedObjectContext,
+        keychain: InMemoryKeychainManager,
+        stubClient: CoreAPIAuthClientProtocol?,
+        tenantId: String?
+    ) -> AuthenticationService {
+        AuthenticationService(
+            userRepository: CoreDataUserRepository(
+                context: context,
+                encryptionManager: EncryptionManager.shared,
+                passwordHasher: PasswordHasher.shared,
+                auditLogger: AuditLogger(context: context)
+            ),
+            keychainManager: keychain,
+            biometricAuthManager: .shared,
+            auditLogger: AuditLogger(context: context),
+            coreAuthClient: stubClient,
+            coreAPITenantId: tenantId
+        )
+    }
+
+    // MARK: - Cloud register success: user.id == patientId
+
+    @Test("Cloud register success — local user.id equals server-canonical patientId")
+    func testCloudRegisterUserKeyedByPatientId() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let canonicalPatientId = UUID()
+        let stub = StubCoreAPIAuthClient(
+            registerBehaviour: .success(token: "tok", patientId: canonicalPatientId.uuidString)
+        )
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        let user = try await service.register(
+            email: "patient@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Jane Smith",
+            authMethod: .password
+        )
+
+        let userId = try #require(user.id, "User must have an id")
+        #expect(userId == canonicalPatientId,
+                "local user.id must equal the Core API patientId for encryption-identity continuity")
+    }
+
+    // MARK: - Cloud register success: JWT stored
+
+    @Test("Cloud register success — JWT persisted to keychain")
+    func testCloudRegisterJWTStored() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let stub = StubCoreAPIAuthClient(
+            registerBehaviour: .success(token: "jwt.abc.123", patientId: UUID().uuidString)
+        )
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        _ = try await service.register(
+            email: "jwt@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "JWT Patient",
+            authMethod: .password
+        )
+
+        let storedJWT = try keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == "jwt.abc.123",
+                "Core API JWT must be written to keychain after successful cloud registration")
+    }
+
+    // MARK: - Cloud register success: session created
+
+    @Test("Cloud register success — session is active after registration")
+    func testCloudRegisterSessionCreated() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let stub = StubCoreAPIAuthClient(
+            registerBehaviour: .success(token: "tok", patientId: UUID().uuidString)
+        )
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        _ = try await service.register(
+            email: "session@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Session Patient",
+            authMethod: .password
+        )
+
+        // createSession defers @Published updates to the next run-loop cycle.
+        await Task.yield()
+        #expect(service.isAuthenticated == true,
+                "Session must be active immediately after cloud registration")
+    }
+
+    // MARK: - Encryption-identity continuity
+
+    @Test("Encryption continuity — getDerivedKey(user.id) equals getDerivedKey(patientId)")
+    func testEncryptionKeyIdentity() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let patientId = UUID()
+        let stub = StubCoreAPIAuthClient(
+            registerBehaviour: .success(token: "tok", patientId: patientId.uuidString)
+        )
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        let user = try await service.register(
+            email: "enc@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Enc Patient",
+            authMethod: .password
+        )
+
+        let userId = try #require(user.id)
+
+        // Both calls use the same UUID (userId == patientId) → must derive identical keys.
+        let keyA = try EncryptionManager.shared.getDerivedKey(for: userId)
+        let keyB = try EncryptionManager.shared.getDerivedKey(for: patientId)
+
+        // SymmetricKey is not Equatable; compare raw bytes.
+        let bytesA = keyA.withUnsafeBytes { Data($0) }
+        let bytesB = keyB.withUnsafeBytes { Data($0) }
+        #expect(bytesA == bytesB,
+                "HKDF-derived key must be identical when user.id == patientId")
+    }
+
+    @Test("Encryption continuity — PHI encrypted for user.id decrypts under patientId")
+    func testPHIRoundTrip() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let patientId = UUID()
+        let stub = StubCoreAPIAuthClient(
+            registerBehaviour: .success(token: "tok", patientId: patientId.uuidString)
+        )
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        let user = try await service.register(
+            email: "phi@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "PHI Patient",
+            authMethod: .password
+        )
+
+        let userId = try #require(user.id)
+        let plaintext = "sensitive health information"
+        let encrypted = try EncryptionManager.shared.encryptString(plaintext, for: userId)
+        let decrypted = try EncryptionManager.shared.decryptString(encrypted, for: patientId)
+        #expect(decrypted == plaintext,
+                "PHI encrypted under user.id must round-trip correctly under the canonical patientId")
+    }
+
+    // MARK: - Cloud disabled (nil deps) — local path unchanged
+
+    @Test("Cloud disabled — local-only registration creates user with a generated id")
+    func testLocalOnlyRegistration() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        // nil client + nil tenantId → local-only path
+        let service = makeService(context: context, keychain: keychain, stubClient: nil, tenantId: nil)
+
+        let user = try await service.register(
+            email: "local@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Local Patient",
+            authMethod: .password
+        )
+
+        #expect(user.email == "local@example.com")
+        #expect(user.id != nil, "Local user must still receive a generated id")
+
+        // No JWT must be stored for a local-only registration.
+        let storedJWT = try? keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == nil, "Local-only registration must NOT store a Core API JWT")
+    }
+
+    // MARK: - 409 conflict
+
+    @Test("Cloud 409 conflict — registrationFailed error, no local user, no JWT")
+    func testCloudConflict() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let stub = StubCoreAPIAuthClient(registerBehaviour: .conflict)
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        var caughtRegistrationFailed = false
+        do {
+            _ = try await service.register(
+                email: "dup@example.com",
+                password: "SecurePassword123!",
+                passcode: nil,
+                fullName: "Duplicate",
+                authMethod: .password
+            )
+            Issue.record("Expected registrationFailed to be thrown for a 409 conflict")
+        } catch let err as AuthenticationError {
+            if case .registrationFailed(let reason) = err {
+                caughtRegistrationFailed = true
+                // Error description must reference email (duplicate account concept).
+                #expect(reason.lowercased().contains("email") || reason.lowercased().contains("registered"),
+                        "registrationFailed reason should mention duplicate email; got: \(reason)")
+            } else {
+                Issue.record("Expected .registrationFailed, got \(err)")
+            }
+        }
+        #expect(caughtRegistrationFailed)
+
+        // Verify no local user was persisted.
+        let repo = CoreDataUserRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            passwordHasher: PasswordHasher.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        #expect(repo.findUser(by: "dup@example.com") == nil,
+                "No local user must be created when Core API returns 409")
+
+        // Verify no JWT was stored.
+        let storedJWT = try? keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == nil, "No JWT must be stored when registration fails with 409")
+    }
+
+    // MARK: - Network offline
+
+    @Test("Cloud offline — registrationFailed error with connectivity description")
+    func testCloudOffline() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let stub = StubCoreAPIAuthClient(registerBehaviour: .offline("no route to host"))
+        let service = makeService(context: context, keychain: keychain, stubClient: stub, tenantId: "t-1")
+
+        var caughtRegistrationFailed = false
+        do {
+            _ = try await service.register(
+                email: "offline@example.com",
+                password: "SecurePassword123!",
+                passcode: nil,
+                fullName: "Offline Patient",
+                authMethod: .password
+            )
+            Issue.record("Expected registrationFailed to be thrown when server is unreachable")
+        } catch let err as AuthenticationError {
+            if case .registrationFailed(let reason) = err {
+                caughtRegistrationFailed = true
+                let lower = reason.lowercased()
+                #expect(lower.contains("connectivity") || lower.contains("network") || lower.contains("offline"),
+                        "registrationFailed reason should indicate network issue; got: \(reason)")
+            } else {
+                Issue.record("Expected .registrationFailed, got \(err)")
+            }
+        }
+        #expect(caughtRegistrationFailed)
+    }
+}

--- a/openspec/changes/add-patient-cloud-auth/tasks.md
+++ b/openspec/changes/add-patient-cloud-auth/tasks.md
@@ -24,7 +24,7 @@ password. Unit tests with a stubbed URLSession (success, 401, 409, unreachable).
 
 ## Phase 3: Make Core API authoritative in AuthenticationService
 
-### Task 3.1: Registration flow through Core API
+### Task 3.1: Registration flow through Core API  [x]
 `AuthenticationService.register` calls the Core API register client, then creates
 the local cache user keyed by the returned `patientId`, sets up the device master
 key + derived key (encryption identity = `patientId`), and stores the JWT.

--- a/openspec/changes/add-patient-cloud-auth/tasks.md
+++ b/openspec/changes/add-patient-cloud-auth/tasks.md
@@ -29,7 +29,7 @@ password. Unit tests with a stubbed URLSession (success, 401, 409, unreachable).
 the local cache user keyed by the returned `patientId`, sets up the device master
 key + derived key (encryption identity = `patientId`), and stores the JWT.
 
-### Task 3.2: Login flow through Core API + encryption-identity continuity
+### Task 3.2: Login flow through Core API + encryption-identity continuity  [x]
 `AuthenticationService.login` authenticates against Core API; on success stores
 the JWT, ensures the local cache user for `patientId`, unlocks encryption for
 `patientId`, starts the session. Confirm HKDF salt = canonical `patientId` so PHI


### PR DESCRIPTION
Phase 3 of `add-patient-cloud-auth`: AuthenticationService routes through Core API; PHI encryption identity preserved.

## Tasks
- [x] 3.1 Cloud registration: `createUser` keyed by canonical `patientId` (encryption identity = patientId), JWT stored, 409/offline mapped; local-only fallback unchanged.
- [x] 3.2 Cloud login: Core API authoritative, first-device cache user keyed by `patientId`, JWT stored, 401/offline fail closed (offline branch staged for 4.1), biometric pre-check preserved.

## Encryption-identity continuity (reviewer-verified)
Local `User.id == Core API patientId` → `getDerivedKey(for: user.id)` salted by the canonical identity; device master key unchanged and never sent to the server. Tests assert derived-key equality + register→login PHI round-trip.

## Beads closed
HouseCall-l1y4 (#171), HouseCall-nl6n (#170)

## Test
Build + `HouseCallTests` green (CloudRegistration/CloudLogin suites pass; known SyncMock/timing flakes excused). Default (nil cloud deps) = unchanged local-only auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)