### PR TITLE
add-patient-cloud-auth: Phase 4 — Offline fallback + JWT/401 lifecycle

### DIFF
--- a/HouseCall/Core/Security/EncryptionManager.swift
+++ b/HouseCall/Core/Security/EncryptionManager.swift
@@ -122,6 +122,17 @@ class EncryptionManager {
         return newKey
     }
 
+    /// Clears the in-memory key caches (master key + derived keys) on logout or
+    /// session timeout. This does NOT delete the master key from the Keychain —
+    /// at-rest PHI must remain decryptable after the next login; it only evicts
+    /// the cached copies from memory so a stale session holds no key material.
+    func clearCachedKeys() {
+        cacheLock.lock()
+        masterKey = nil
+        derivedKeyCache.removeAll()
+        cacheLock.unlock()
+    }
+
     // MARK: - Key Derivation
 
     /// Derives a user-specific encryption key using HKDF

--- a/HouseCall/Core/Services/AuthenticationService.swift
+++ b/HouseCall/Core/Services/AuthenticationService.swift
@@ -331,10 +331,33 @@ class AuthenticationService: ObservableObject {
                 // to a local credential check; Core API is the single source of truth.
                 throw AuthenticationError.loginFailed("Invalid credentials")
             case .offline:
-                // TODO: Task 4.1 — offline fallback: when Core API is unreachable,
-                // fall back to the cached local credential check so the patient can
-                // still open their encrypted local record.  For now fail fast.
-                throw AuthenticationError.loginFailed("Unable to reach the server. Please check your connection.")
+                // Core API is unreachable (network failure / timeout) — attempt the
+                // cached local-credential check so a previously-authenticated patient
+                // can open their encrypted local record for offline use.
+                //
+                // IMPORTANT: this fallback applies ONLY to .offline (transport
+                // unreachable).  .unauthorized (server rejected the credentials)
+                // stays above and NEVER reaches this branch — Core API is the
+                // single source of truth for credential validity.
+                //
+                // No JWT is obtained; cloud sync stays inactive until a subsequent
+                // online login succeeds and a fresh token is stored.
+                do {
+                    let localUser = try userRepository.authenticateUser(
+                        email: email,
+                        credential: credential,
+                        authMethod: authMethod
+                    )
+                    // Local check succeeded: start a session from the cached record.
+                    try await createSession(for: localUser, authMethod: authMethod)
+                    return localUser
+                } catch {
+                    // No cached user for this email, or credential mismatch —
+                    // offline access cannot be granted without a valid local record.
+                    throw AuthenticationError.loginFailed(
+                        "Unable to reach the server. Please check your connection."
+                    )
+                }
             default:
                 throw AuthenticationError.loginFailed(syncErr.localizedDescription ?? "Server error")
             }

--- a/HouseCall/Core/Services/AuthenticationService.swift
+++ b/HouseCall/Core/Services/AuthenticationService.swift
@@ -452,6 +452,11 @@ class AuthenticationService: ObservableObject {
         try keychainManager.deleteSessionToken()
         clearCoreAPIJWT()
 
+        // Evict in-memory encryption keys so a logged-out session retains no
+        // key material. The Keychain master key is preserved so at-rest PHI
+        // remains decryptable after the next login.
+        EncryptionManager.shared.clearCachedKeys()
+
         // Stop cloud sync so the WebSocket subscription is cancelled and no
         // further PHI events can be delivered or persisted after logout.
         syncCoordinator?.stop()
@@ -615,6 +620,9 @@ class AuthenticationService: ObservableObject {
         try? invalidateSession()
         try? keychainManager.deleteSessionToken()
         clearCoreAPIJWT()
+
+        // Evict in-memory encryption keys (Keychain master key preserved).
+        EncryptionManager.shared.clearCachedKeys()
 
         // Stop cloud sync — cancel the WebSocket subscription and prevent any
         // in-flight recommendation.delivered events from persisting PHI.

--- a/HouseCall/Core/Services/Sync/CloudSyncCoordinator.swift
+++ b/HouseCall/Core/Services/Sync/CloudSyncCoordinator.swift
@@ -66,6 +66,11 @@ final class CloudSyncCoordinator: ObservableObject {
     /// Non-nil while a pending-message replay is in progress.
     @Published private(set) var isReplaying: Bool = false
 
+    /// Set when the Core API rejects the cached token (401). The app observes
+    /// this to require re-login. Cloud sync is deactivated when it flips true;
+    /// there is no automatic retry loop.
+    @Published private(set) var requiresReauth: Bool = false
+
     // MARK: - Dependencies
 
     private let syncClient: SyncClient
@@ -118,6 +123,18 @@ final class CloudSyncCoordinator: ObservableObject {
         wsSubscription = nil
         foregroundSubscription?.cancel()
         foregroundSubscription = nil
+    }
+
+    /// Deactivates cloud sync after the Core API rejects the cached token (401).
+    /// Stops the connection, clears the stale JWT so the activation gate will not
+    /// re-arm with a dead token, and flips `requiresReauth` so the app prompts a
+    /// fresh login. Idempotent and loop-free: once `requiresReauth` is set, no
+    /// further work is done, so repeated 401s do not retry or re-trigger.
+    private func handleUnauthorized() {
+        guard !requiresReauth else { return }
+        stop()
+        try? KeychainManager.shared.delete(key: KeychainManager.Keys.coreAPIJWT)
+        requiresReauth = true
     }
 
     // MARK: - Message send (called by AIConversationService)
@@ -179,6 +196,10 @@ final class CloudSyncCoordinator: ObservableObject {
                     "syncState": "synced"
                 ])
             )
+        } catch SyncError.unauthorized {
+            // Cached token rejected — deactivate cloud sync and require re-login.
+            // Leave the message pending; it replays after re-auth.
+            handleUnauthorized()
         } catch SyncError.offline {
             // Transient: leave message pending so replay picks it up.
             // No state change, no rethrow.
@@ -334,6 +355,9 @@ final class CloudSyncCoordinator: ObservableObject {
                     "recommendationId": dto.ID
                 ])
             )
+        } catch SyncError.unauthorized {
+            // Cached token rejected — deactivate cloud sync, require re-login.
+            handleUnauthorized()
         } catch SyncError.serverError(404) {
             // Recommendation not yet DELIVERED — server returned 404; ignore.
             return
@@ -421,6 +445,9 @@ final class CloudSyncCoordinator: ObservableObject {
                 syncedMessageCount += insertedCount
             }
 
+        } catch SyncError.unauthorized {
+            // Cached token rejected — deactivate cloud sync, require re-login.
+            handleUnauthorized()
         } catch SyncError.offline {
             // Transient; the event will be reprocessed on reconnect.
         } catch {

--- a/HouseCallTests/CloudOfflineFallbackTests.swift
+++ b/HouseCallTests/CloudOfflineFallbackTests.swift
@@ -1,0 +1,395 @@
+//
+//  CloudOfflineFallbackTests.swift
+//  HouseCallTests
+//
+//  Unit tests for Task 4.1 — offline fallback login.
+//
+//  Coverage:
+//  - offline + pre-existing local user, correct credential
+//      → local session created, isAuthenticated == true, NO JWT stored.
+//  - offline + pre-existing local user, wrong credential
+//      → loginFailed, no session.
+//  - offline + NO local user
+//      → loginFailed, no session.
+//  - 401 (unauthorized) with a pre-existing local user whose credential matches
+//      → loginFailed, no session, offline fallback NOT consulted.
+//      (If the fallback were incorrectly triggered on 401 the login would succeed;
+//       a loginFailed result proves Core API rejection still fails closed.)
+//  - Confirm unreachable (.offline) vs rejected (.unauthorized) is the deciding
+//    factor.
+//
+
+import Testing
+import CoreData
+@testable import HouseCall
+
+// MARK: - CloudOfflineFallbackTests
+
+@Suite("Cloud Offline Fallback Tests")
+@MainActor
+struct CloudOfflineFallbackTests {
+
+    // MARK: - Helpers
+
+    private func makeContext() -> NSManagedObjectContext {
+        let container = NSPersistentContainer(
+            name: "HouseCall",
+            managedObjectModel: TestCoreDataModel.shared
+        )
+        let desc = NSPersistentStoreDescription()
+        desc.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [desc]
+        container.loadPersistentStores { _, error in
+            if let error { fatalError("In-memory store failed: \(error)") }
+        }
+        return container.viewContext
+    }
+
+    private func makeRepo(context: NSManagedObjectContext) -> CoreDataUserRepository {
+        CoreDataUserRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            passwordHasher: PasswordHasher.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+    }
+
+    private func makeService(
+        context: NSManagedObjectContext,
+        keychain: InMemoryKeychainManager,
+        stubBehaviour: StubOfflineAuthClient.Behaviour
+    ) -> AuthenticationService {
+        let stub = StubOfflineAuthClient(loginBehaviour: stubBehaviour)
+        return AuthenticationService(
+            userRepository: makeRepo(context: context),
+            keychainManager: keychain,
+            biometricAuthManager: .shared,
+            auditLogger: AuditLogger(context: context),
+            coreAuthClient: stub,
+            coreAPITenantId: "tenant-offline-test"
+        )
+    }
+
+    // MARK: - Offline + correct credential → local session
+
+    @Test("Offline + existing user, correct credential — local session created, no JWT")
+    func testOfflineLogin_existingUser_correctCredential() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let patientId = UUID()
+
+        // Pre-create a cached local user (simulates a prior successful cloud login).
+        let repo = makeRepo(context: context)
+        _ = try repo.createUser(
+            email: "offline@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Offline Patient",
+            authMethod: .password,
+            id: patientId
+        )
+
+        let service = makeService(context: context, keychain: keychain, stubBehaviour: .offline("no route"))
+
+        let user = try await service.login(
+            email: "offline@example.com",
+            credential: "SecurePassword123!",
+            authMethod: .password
+        )
+
+        // Must resolve to the cached local user.
+        let userId = try #require(user.id)
+        #expect(userId == patientId,
+                "Offline fallback must return the cached local user keyed by patientId")
+
+        // NO JWT must be stored — none was obtained from the server.
+        let storedJWT = try? keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == nil,
+                "No JWT must be stored when login succeeds via offline fallback")
+
+        // Session must be active (encryption unlocked for the local record).
+        await Task.yield()
+        #expect(service.isAuthenticated == true,
+                "isAuthenticated must be true after successful offline fallback login")
+    }
+
+    // MARK: - Offline + correct credential → encryption identity preserved
+
+    @Test("Offline + existing user — encryption identity (user.id) matches cached local user")
+    func testOfflineLogin_encryptionIdentityPreserved() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let patientId = UUID()
+
+        let repo = makeRepo(context: context)
+        _ = try repo.createUser(
+            email: "eid@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "EID Patient",
+            authMethod: .password,
+            id: patientId
+        )
+
+        // Encrypt a PHI value under the local user's identity.
+        let plaintext = "temperature: 37.2 C"
+        let encryptedPHI = try EncryptionManager.shared.encryptString(plaintext, for: patientId)
+
+        let service = makeService(context: context, keychain: keychain, stubBehaviour: .offline("timeout"))
+
+        let user = try await service.login(
+            email: "eid@example.com",
+            credential: "SecurePassword123!",
+            authMethod: .password
+        )
+
+        let userId = try #require(user.id)
+        // The returned user.id must equal patientId so the caller can derive the
+        // same encryption key — no new identity must be created offline.
+        #expect(userId == patientId,
+                "Offline login must return the same user.id as the cached local record")
+
+        // PHI encrypted before the offline login must still be readable.
+        let decrypted = try EncryptionManager.shared.decryptString(encryptedPHI, for: userId)
+        #expect(decrypted == plaintext,
+                "PHI encrypted under the cached identity must remain readable after offline login")
+    }
+
+    // MARK: - Offline + wrong credential → loginFailed
+
+    @Test("Offline + existing user, wrong credential — loginFailed, no session")
+    func testOfflineLogin_existingUser_wrongCredential() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let patientId = UUID()
+
+        let repo = makeRepo(context: context)
+        _ = try repo.createUser(
+            email: "offline2@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Offline Patient 2",
+            authMethod: .password,
+            id: patientId
+        )
+
+        let service = makeService(context: context, keychain: keychain, stubBehaviour: .offline("no route"))
+
+        var caughtLoginFailed = false
+        do {
+            _ = try await service.login(
+                email: "offline2@example.com",
+                credential: "WrongPassword999!",     // wrong credential
+                authMethod: .password
+            )
+            Issue.record("Expected loginFailed to be thrown for wrong offline credential")
+        } catch let err as AuthenticationError {
+            if case .loginFailed = err {
+                caughtLoginFailed = true
+            } else {
+                Issue.record("Expected .loginFailed, got \(err)")
+            }
+        }
+        #expect(caughtLoginFailed,
+                "Wrong credential during offline fallback must produce loginFailed")
+
+        // No JWT stored.
+        let storedJWT = try? keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == nil)
+
+        // No session.
+        await Task.yield()
+        #expect(service.isAuthenticated == false,
+                "No session must be started when offline credential check fails")
+    }
+
+    // MARK: - Offline + no local user → loginFailed
+
+    @Test("Offline + no local user — loginFailed, no session")
+    func testOfflineLogin_noLocalUser() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+
+        // No local user exists (e.g. first-ever login on this device while offline).
+        let service = makeService(context: context, keychain: keychain, stubBehaviour: .offline("unreachable"))
+
+        var caughtLoginFailed = false
+        do {
+            _ = try await service.login(
+                email: "nobody@example.com",
+                credential: "SecurePassword123!",
+                authMethod: .password
+            )
+            Issue.record("Expected loginFailed when offline with no cached local user")
+        } catch let err as AuthenticationError {
+            if case .loginFailed = err {
+                caughtLoginFailed = true
+            } else {
+                Issue.record("Expected .loginFailed, got \(err)")
+            }
+        }
+        #expect(caughtLoginFailed,
+                "Offline with no cached local user must produce loginFailed")
+
+        let storedJWT = try? keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == nil)
+
+        await Task.yield()
+        #expect(service.isAuthenticated == false)
+    }
+
+    // MARK: - 401 (unauthorized) — no offline fallback, fails closed
+
+    @Test("401 unauthorized — loginFailed, offline fallback NOT used even with a valid local cache user")
+    func testUnauthorized_noOfflineFallback() async throws {
+        let context = makeContext()
+        let keychain = InMemoryKeychainManager()
+        let patientId = UUID()
+
+        // Pre-create a local user whose credential MATCHES what we'll pass to login.
+        // If the offline fallback were incorrectly triggered on a 401, the login
+        // would succeed (because the local credential is correct).  A loginFailed
+        // result proves the fallback is NOT consulted for 401.
+        let repo = makeRepo(context: context)
+        _ = try repo.createUser(
+            email: "rejected@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Rejected Patient",
+            authMethod: .password,
+            id: patientId
+        )
+
+        let service = makeService(context: context, keychain: keychain, stubBehaviour: .unauthorized)
+
+        var caughtLoginFailed = false
+        do {
+            _ = try await service.login(
+                email: "rejected@example.com",
+                credential: "SecurePassword123!",   // correct locally, but server says 401
+                authMethod: .password
+            )
+            Issue.record("Expected loginFailed for a 401 response")
+        } catch let err as AuthenticationError {
+            if case .loginFailed = err {
+                caughtLoginFailed = true
+            } else {
+                Issue.record("Expected .loginFailed, got \(err)")
+            }
+        }
+
+        #expect(caughtLoginFailed,
+                "Core API 401 must produce loginFailed — offline fallback must NOT be used")
+
+        // No JWT stored.
+        let storedJWT = try? keychain.get(key: KeychainManager.Keys.coreAPIJWT)
+        #expect(storedJWT == nil,
+                "No JWT must be stored when Core API rejects with 401")
+
+        // No session — fail closed regardless of local credential state.
+        await Task.yield()
+        #expect(service.isAuthenticated == false,
+                "No session must be started when Core API explicitly rejects credentials")
+    }
+
+    // MARK: - Unreachable-vs-rejected is the deciding factor
+
+    @Test("Unreachable vs rejected — only .offline triggers fallback; .unauthorized does not")
+    func testOfflineVsUnauthorizedDistinction() async throws {
+        let context = makeContext()
+        let keychain1 = InMemoryKeychainManager()
+        let keychain2 = InMemoryKeychainManager()
+        let patientId = UUID()
+
+        // Pre-create identical local users in two separate in-memory stores.
+        let repo1 = makeRepo(context: context)
+        _ = try repo1.createUser(
+            email: "test@example.com",
+            password: "SecurePassword123!",
+            passcode: nil,
+            fullName: "Test Patient",
+            authMethod: .password,
+            id: patientId
+        )
+
+        // Service A — Core API unreachable (.offline).
+        let serviceOffline = makeService(
+            context: context,
+            keychain: keychain1,
+            stubBehaviour: .offline("timeout")
+        )
+
+        // Service B — Core API reachable but rejects credentials (.unauthorized).
+        let serviceUnauthorized = makeService(
+            context: context,
+            keychain: keychain2,
+            stubBehaviour: .unauthorized
+        )
+
+        // Offline path: should succeed via local fallback.
+        let offlineUser = try await serviceOffline.login(
+            email: "test@example.com",
+            credential: "SecurePassword123!",
+            authMethod: .password
+        )
+        await Task.yield()
+        #expect(serviceOffline.isAuthenticated == true,
+                ".offline must allow login via local fallback when credential matches")
+        let offlineId = try #require(offlineUser.id)
+        #expect(offlineId == patientId)
+
+        // Unauthorized path: should fail closed.
+        var unauthorizedFailed = false
+        do {
+            _ = try await serviceUnauthorized.login(
+                email: "test@example.com",
+                credential: "SecurePassword123!",
+                authMethod: .password
+            )
+            Issue.record("Expected loginFailed for .unauthorized")
+        } catch let err as AuthenticationError {
+            if case .loginFailed = err { unauthorizedFailed = true }
+        }
+        await Task.yield()
+        #expect(unauthorizedFailed,
+                ".unauthorized must fail closed regardless of local credential state")
+        #expect(serviceUnauthorized.isAuthenticated == false,
+                "No session must be started when Core API explicitly rejects credentials")
+
+        // Confirm the distinction: .offline succeeded, .unauthorized failed.
+        #expect(serviceOffline.isAuthenticated == true)
+        #expect(serviceUnauthorized.isAuthenticated == false)
+    }
+}
+
+// MARK: - Stub
+
+/// File-private stub for offline fallback tests.
+/// Configurable to throw .offline or .unauthorized to exercise the
+/// unreachable-vs-rejected distinction without live network access.
+private final class StubOfflineAuthClient: CoreAPIAuthClientProtocol, @unchecked Sendable {
+    enum Behaviour {
+        case offline(String)
+        case unauthorized
+    }
+
+    let loginBehaviour: Behaviour
+
+    init(loginBehaviour: Behaviour) {
+        self.loginBehaviour = loginBehaviour
+    }
+
+    func login(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult {
+        switch loginBehaviour {
+        case .offline(let reason):
+            throw SyncError.offline(reason)
+        case .unauthorized:
+            throw SyncError.unauthorized
+        }
+    }
+
+    func register(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult {
+        // Registration is not exercised in these tests.
+        throw SyncError.offline("not implemented in offline stub")
+    }
+}

--- a/HouseCallTests/CloudSyncTests.swift
+++ b/HouseCallTests/CloudSyncTests.swift
@@ -1450,4 +1450,80 @@ struct CloudSyncTests {
         #expect(assistantMessages.first?.serverId == serverMsgId,
                 "The single persisted message must carry the correct serverId")
     }
+
+    // MARK: - 401 deactivation (task 4.2)
+
+    @Test("A 401 from a sync POST deactivates cloud sync and requires re-auth, without looping")
+    func testUnauthorizedDeactivatesCloudSync() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let context = makeInMemoryContext()
+        let userId = UUID()
+        let conversation = try seedConversation(in: context, userId: userId)
+        let convLocalId = conversation.id!
+        let convServerId = conversation.serverId!
+
+        // Stub POST → 401 (cached token rejected). Count calls to prove no retry loop.
+        let callCount = Counter()
+        SyncMockURLProtocol.register(
+            sessionID: sid,
+            path: "/api/conversations/\(convServerId)/messages"
+        ) { req in
+            callCount.increment()
+            return ("{\"error\":\"unauthorized\"}".data(using: .utf8)!,
+                    makeHTTPResponse(url: req.url!, status: 401))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let syncClient = try SyncClient(
+            baseURL: URL(string: "http://localhost:8080")!,
+            session: session,
+            keychainManager: kc
+        )
+        let messageRepo = CoreDataMessageRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let conversationRepo = CoreDataConversationRepository(
+            context: context,
+            encryptionManager: EncryptionManager.shared,
+            auditLogger: AuditLogger(context: context)
+        )
+        let coordinator = CloudSyncCoordinator(
+            syncClient: syncClient,
+            messageRepository: messageRepo,
+            conversationRepository: conversationRepo,
+            auditLogger: AuditLogger(context: context),
+            context: context
+        )
+        let service = AIConversationService(
+            userId: userId,
+            conversationRepository: conversationRepo,
+            messageRepository: messageRepo,
+            auditLogger: AuditLogger(context: context),
+            syncCoordinator: coordinator
+        )
+
+        try await service.loadConversation(convLocalId)
+
+        #expect(coordinator.requiresReauth == false, "should start without re-auth required")
+
+        // First send hits a 401 → deactivate.
+        try await service.sendMessage(conversationId: convLocalId, content: "hi")
+        #expect(coordinator.requiresReauth == true, "401 must flip requiresReauth")
+
+        // A subsequent send must not loop or reset the flag.
+        try await service.sendMessage(conversationId: convLocalId, content: "again")
+        #expect(coordinator.requiresReauth == true, "requiresReauth stays set (no reset)")
+    }
+}
+
+/// Minimal thread-safe counter for asserting call counts in async stubs.
+private final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+    func increment() { lock.lock(); value += 1; lock.unlock() }
+    var count: Int { lock.lock(); defer { lock.unlock() }; return value }
 }

--- a/HouseCallTests/CloudSyncTests.swift
+++ b/HouseCallTests/CloudSyncTests.swift
@@ -1517,6 +1517,9 @@ struct CloudSyncTests {
         // A subsequent send must not loop or reset the flag.
         try await service.sendMessage(conversationId: convLocalId, content: "again")
         #expect(coordinator.requiresReauth == true, "requiresReauth stays set (no reset)")
+
+        // Exactly one POST per send attempt — no internal retry loop on 401.
+        #expect(callCount.count == 2, "each send makes one POST attempt; 401 must not retry")
     }
 }
 

--- a/HouseCallTests/EncryptionManagerTests.swift
+++ b/HouseCallTests/EncryptionManagerTests.swift
@@ -50,6 +50,25 @@ struct EncryptionManagerTests {
         #expect(decrypted == originalString)
     }
 
+    @Test("clearCachedKeys evicts in-memory keys but preserves at-rest decryptability")
+    func testClearCachedKeysPreservesAtRestData() throws {
+        let manager = makeIsolatedManager()
+        let userId = UUID()
+        let originalString = "Patient Name: John Doe"
+
+        // Encrypt — this derives and caches the user's key.
+        let encrypted = try manager.encryptString(originalString, for: userId)
+
+        // Logout-style cache eviction: drops in-memory master + derived keys but
+        // must NOT delete the Keychain master key.
+        manager.clearCachedKeys()
+
+        // Decryption after eviction must still succeed (master key re-read from
+        // the Keychain, derived key recomputed) — at-rest PHI stays readable.
+        let decrypted = try manager.decryptString(encrypted, for: userId)
+        #expect(decrypted == originalString)
+    }
+
     @Test("Encrypted data is different each time (unique nonce)")
     func testUniqueNoncePerEncryption() throws {
         let manager = makeIsolatedManager()

--- a/openspec/changes/add-patient-cloud-auth/tasks.md
+++ b/openspec/changes/add-patient-cloud-auth/tasks.md
@@ -43,7 +43,7 @@ local credential check so the patient can open their encrypted local record;
 cloud sync stays inactive until a JWT is obtained. Distinguish unreachable vs
 rejected.
 
-### Task 4.2: Logout + 401 handling
+### Task 4.2: Logout + 401 handling  [x]
 Logout clears session, cached derived key, and `coreAPIJWT`. On a `401` from
 `SyncClient`, deactivate cloud sync and require re-login (no retry loop).
 

--- a/openspec/changes/add-patient-cloud-auth/tasks.md
+++ b/openspec/changes/add-patient-cloud-auth/tasks.md
@@ -37,7 +37,7 @@ keys stay device-local and stable. 401 → reject.
 
 ## Phase 4: Offline fallback + session/JWT lifecycle
 
-### Task 4.1: Offline fallback login
+### Task 4.1: Offline fallback login  [x]
 When Core API is unreachable (network/timeout, not 401), fall back to the cached
 local credential check so the patient can open their encrypted local record;
 cloud sync stays inactive until a JWT is obtained. Distinguish unreachable vs


### PR DESCRIPTION
Phase 4 of `add-patient-cloud-auth`: offline fallback + session/token lifecycle.

## Tasks
- [x] 4.1 Offline (unreachable) → local cached-credential fallback (no JWT, cloud inactive); 401 stays fail-closed (separate switch arm + canary test).
- [x] 4.2 logout/timeout clear in-memory key caches (`EncryptionManager.clearCachedKeys()`; Keychain master key preserved → at-rest PHI still decryptable); `CloudSyncCoordinator` deactivates + clears JWT + sets `requiresReauth` on 401, idempotent/no-loop.

## Beads closed
HouseCall-koke (#169), HouseCall-c9wn (#168)

## Security (reviewer-verified)
offline≠unauthorized (no bypass); 401 never falls through to local auth; clearCachedKeys evicts memory only (decrypt-after-clear test); 401 handling loop-free (asserts one POST per send).

## Test
Build + new tests pass in isolation (EncryptionManager + CloudSync 401). Known SyncMock parallel flakes excused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)