### PR TITLE
add-patient-cloud-auth: Phase 6 — Tests & evaluation

### DIFF
--- a/openspec/changes/add-patient-cloud-auth/tasks.md
+++ b/openspec/changes/add-patient-cloud-auth/tasks.md
@@ -61,12 +61,12 @@ API and agent interview questions arrive over WebSocket (resolves HouseCall-nre3
 
 ## Phase 6: Tests and end-to-end evaluation
 
-### Task 6.1: Backend + iOS auth tests
+### Task 6.1: Backend + iOS auth tests  [x]
 Backend: register endpoint tests (phase 1). iOS: AuthenticationService register/
 login through Core API, offline fallback, logout JWT clearing, encryption-
 identity continuity (same patientId → same derived key).
 
-### Task 6.2: Manual end-to-end evaluation
+### Task 6.2: Manual end-to-end evaluation  [ ] (manual — see HouseCall-vx57; prerequisite HouseCall-u9v0 patient state)
 With Postgres + core-api + agent (Ollama `medgemma:4b`) + physician web app
 running: register a patient in-app, conduct the interview, confirm the SOAP note
 reaches the physician queue, approve it, and confirm the approved plan is


### PR DESCRIPTION
Phase 6 (final) of `add-patient-cloud-auth`.

## Tasks
- [x] 6.1 Final verification: backend `make test` + `go vet` green; iOS `HouseCallTests` green incl. all 6 auth suites (CoreAPIAuthClient, CloudRegistration, CloudLogin, CloudOfflineFallback, CloudActivation, EncryptionManager). Coverage already comprehensive across phases 1–5 — no new code needed.
- [ ] 6.2 Manual e2e — deferred (HouseCall-vx57). Now reachable; **prerequisite HouseCall-u9v0** (patient state for physician licensing).

## Beads closed
HouseCall-kzrc (#165). Deferred: HouseCall-vx57 (#164, manual).

## Resolves
`HouseCall-nre3` — patient↔core-api auth now exists; the iOS cloud path activates after a configured cloud login. This unblocks `add-clinical-soap-review-workflow` task 6.3.

## Remaining before a green manual e2e
- HouseCall-u9v0 (P2): register sets patient `state="--"` → blocks physician state-licensing at SOAP approval. Patient needs a real US state matching the seeded physician.

🤖 Generated with [Claude Code](https://claude.com/claude-code)