### PR TITLE
fix(auth): capture patient state at registration for physician licensing

### DIFF
--- a/HouseCall/Config/Base.xcconfig
+++ b/HouseCall/Config/Base.xcconfig
@@ -40,6 +40,12 @@ CORE_API_BASE_URL =
 // Cloud auth is disabled when this is empty.
 CORE_API_TENANT_ID =
 
+// USPS 2-letter state code new patients register under (e.g. CA). Gates which
+// licensed physician may review the patient; must match the seeded physician's
+// licensure (see cmd/seed). Keep EMPTY here; set in Secrets.xcconfig.
+// When empty, registration omits state and the patient is stored as "--".
+CORE_API_PATIENT_STATE =
+
 // Optional include of the gitignored secrets file.
 // Values in Secrets.xcconfig override the defaults above.
 #include? "Secrets.xcconfig"

--- a/HouseCall/Config/Secrets.example.xcconfig
+++ b/HouseCall/Config/Secrets.example.xcconfig
@@ -59,3 +59,9 @@ CORE_API_BASE_URL =
 // and the app falls back to the direct-LLM path with no behaviour change.
 //   Example: CORE_API_TENANT_ID = 00000000-0000-0000-0000-000000000001
 CORE_API_TENANT_ID =
+
+// USPS 2-letter state new patients register under. Must match a state the
+// seeded physician is licensed in (cmd/seed uses CA), or the physician cannot
+// approve the patient's SOAP note. Empty → patient stored as "--".
+//   Example: CORE_API_PATIENT_STATE = CA
+CORE_API_PATIENT_STATE =

--- a/HouseCall/Core/Services/AuthenticationService.swift
+++ b/HouseCall/Core/Services/AuthenticationService.swift
@@ -251,10 +251,13 @@ class AuthenticationService: ObservableObject {
         do {
             // Core API register requires a password credential.
             let pw = password ?? ""
+            // Patient state (USPS code) gates physician state-licensing; supplied
+            // via build config for the MVP, omitted (→ "--") when unconfigured.
             authResult = try await authClient.register(
                 tenantId: tenantId,
                 email: email,
-                password: pw
+                password: pw,
+                state: CoreAPIConfig.patientState()
             )
         } catch let syncErr as SyncError {
             switch syncErr {

--- a/HouseCall/Core/Services/Sync/CoreAPIAuthClient.swift
+++ b/HouseCall/Core/Services/Sync/CoreAPIAuthClient.swift
@@ -63,8 +63,9 @@ protocol CoreAPIAuthClientProtocol {
     /// Authenticate an existing patient account.
     func login(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult
 
-    /// Register a new patient account.
-    func register(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult
+    /// Register a new patient account. `state` is an optional USPS 2-letter code
+    /// determining which licensed physician may review the patient.
+    func register(tenantId: String, email: String, password: String, state: String?) async throws -> CoreAPIAuthResult
 }
 
 // MARK: - CoreAPIAuthClient
@@ -150,9 +151,10 @@ final class CoreAPIAuthClient: CoreAPIAuthClientProtocol {
     func register(
         tenantId: String,
         email: String,
-        password: String
+        password: String,
+        state: String?
     ) async throws -> CoreAPIAuthResult {
-        let body = try encodeBody(tenantId: tenantId, email: email, password: password)
+        let body = try encodeBody(tenantId: tenantId, email: email, password: password, state: state)
         let request = try buildRequest(path: "/api/auth/register", body: body)
         let dto: RegisterResponseDTO = try await perform(request)
         return CoreAPIAuthResult(token: dto.token, patientId: dto.patient_id)
@@ -164,12 +166,15 @@ final class CoreAPIAuthClient: CoreAPIAuthClientProtocol {
     ///
     /// The password value is encoded into the request body.
     /// It must never appear in logs, error strings, or debug output.
-    private func encodeBody(tenantId: String, email: String, password: String) throws -> Data {
-        let dict: [String: String] = [
+    private func encodeBody(tenantId: String, email: String, password: String, state: String? = nil) throws -> Data {
+        var dict: [String: String] = [
             "tenant_id": tenantId,
             "email": email,
             "password": password
         ]
+        if let state, !state.isEmpty {
+            dict["state"] = state
+        }
         return try JSONEncoder().encode(dict)
     }
 

--- a/HouseCall/Core/Services/Sync/CoreAPIConfig.swift
+++ b/HouseCall/Core/Services/Sync/CoreAPIConfig.swift
@@ -54,4 +54,23 @@ enum CoreAPIConfig {
         else { return nil }
         return value
     }
+
+    // MARK: - Patient State
+
+    /// Returns the USPS 2-letter state code to register new patients under, from
+    /// `Info.plist` when substituted by xcconfig at build time.
+    ///
+    /// The patient's state gates which licensed physician may review their
+    /// recommendations, so for the MVP it is supplied via config and must match a
+    /// state the supervising physician is licensed in (see `cmd/seed`).
+    /// Returns `nil` when `CoreAPIPatientState` is absent, empty, or an
+    /// unsubstituted placeholder — registration then omits state (stored "--").
+    static func patientState() -> String? {
+        guard
+            let value = Bundle.main.object(forInfoDictionaryKey: "CoreAPIPatientState") as? String,
+            !value.isEmpty,
+            !value.hasPrefix("$(")
+        else { return nil }
+        return value
+    }
 }

--- a/HouseCall/Info.plist
+++ b/HouseCall/Info.plist
@@ -10,6 +10,10 @@
 	     Empty when CORE_API_TENANT_ID is not set; cloud auth is disabled when absent. -->
 	<key>CoreAPITenantID</key>
 	<string>$(CORE_API_TENANT_ID)</string>
+	<!-- USPS state code new patients register under (substituted from xcconfig).
+	     Empty → registration omits state (stored "--"). -->
+	<key>CoreAPIPatientState</key>
+	<string>$(CORE_API_PATIENT_STATE)</string>
 	<!-- LLM provider defaults — values are substituted at build time from xcconfig. -->
 	<key>LLMDefaultProvider</key>
 	<string>$(LLM_DEFAULT_PROVIDER)</string>

--- a/HouseCallTests/CloudActivationTests.swift
+++ b/HouseCallTests/CloudActivationTests.swift
@@ -45,7 +45,7 @@ private final class StubCoreAPIAuthClientActivation: CoreAPIAuthClientProtocol, 
         try resolve(loginBehaviour)
     }
 
-    func register(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult {
+    func register(tenantId: String, email: String, password: String, state: String?) async throws -> CoreAPIAuthResult {
         try resolve(registerBehaviour)
     }
 

--- a/HouseCallTests/CloudLoginTests.swift
+++ b/HouseCallTests/CloudLoginTests.swift
@@ -47,7 +47,7 @@ private final class StubCoreAPIAuthClient: CoreAPIAuthClientProtocol, @unchecked
         try resolve(loginBehaviour)
     }
 
-    func register(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult {
+    func register(tenantId: String, email: String, password: String, state: String?) async throws -> CoreAPIAuthResult {
         try resolve(registerBehaviour)
     }
 

--- a/HouseCallTests/CloudOfflineFallbackTests.swift
+++ b/HouseCallTests/CloudOfflineFallbackTests.swift
@@ -388,7 +388,7 @@ private final class StubOfflineAuthClient: CoreAPIAuthClientProtocol, @unchecked
         }
     }
 
-    func register(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult {
+    func register(tenantId: String, email: String, password: String, state: String?) async throws -> CoreAPIAuthResult {
         // Registration is not exercised in these tests.
         throw SyncError.offline("not implemented in offline stub")
     }

--- a/HouseCallTests/CloudRegistrationTests.swift
+++ b/HouseCallTests/CloudRegistrationTests.swift
@@ -40,7 +40,7 @@ private final class StubCoreAPIAuthClient: CoreAPIAuthClientProtocol, @unchecked
         self.loginBehaviour = loginBehaviour
     }
 
-    func register(tenantId: String, email: String, password: String) async throws -> CoreAPIAuthResult {
+    func register(tenantId: String, email: String, password: String, state: String?) async throws -> CoreAPIAuthResult {
         try resolve(registerBehaviour)
     }
 

--- a/HouseCallTests/CoreAPIAuthClientTests.swift
+++ b/HouseCallTests/CoreAPIAuthClientTests.swift
@@ -97,7 +97,8 @@ struct CoreAPIAuthClientTests {
         let result = try await client.register(
             tenantId: "tenant-1",
             email: "patient@example.com",
-            password: "TestPassword123!"
+            password: "TestPassword123!",
+            state: "CA"
         )
 
         #expect(result.token == "jwt.register.tok")
@@ -137,7 +138,8 @@ struct CoreAPIAuthClientTests {
         _ = try await client.register(
             tenantId: "t-1",
             email: "a@b.com",
-            password: expectedPassword
+            password: expectedPassword,
+            state: nil
         )
 
         let bodyData = try #require(bodyCapture.data, "Request body was not captured")
@@ -146,6 +148,8 @@ struct CoreAPIAuthClientTests {
         #expect(bodyDict["password"] == expectedPassword)
         #expect(bodyDict["email"] == "a@b.com")
         #expect(bodyDict["tenant_id"] == "t-1")
+        // state was nil → must be omitted from the body entirely.
+        #expect(bodyDict["state"] == nil)
     }
 
     // MARK: - login: success (200)
@@ -231,7 +235,8 @@ struct CoreAPIAuthClientTests {
             _ = try await client.register(
                 tenantId: "t-1",
                 email: "existing@example.com",
-                password: "SomePassword!"
+                password: "SomePassword!",
+                state: nil
             )
             Issue.record("Expected SyncError.conflict but no error was thrown")
         } catch let err as SyncError {

--- a/backend/internal/api/auth.go
+++ b/backend/internal/api/auth.go
@@ -21,6 +21,31 @@ type loginRequest struct {
 	Password string `json:"password"`
 }
 
+// registerRequest extends the login shape with an optional patient state — the
+// USPS 2-letter code that gates which licensed physician may review this
+// patient's recommendations.
+type registerRequest struct {
+	TenantID string `json:"tenant_id"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	State    string `json:"state"`
+}
+
+// isValidUSStateCode reports whether s is exactly two uppercase ASCII letters.
+// Format-only check (does not enforce the 50-state set); the physician
+// state-licensing comparison is the authority on which codes are usable.
+func isValidUSStateCode(s string) bool {
+	if len(s) != 2 {
+		return false
+	}
+	for _, c := range s {
+		if c < 'A' || c > 'Z' {
+			return false
+		}
+	}
+	return true
+}
+
 type loginResponse struct {
 	Token     string `json:"token"`
 	ActorType string `json:"actor_type"`
@@ -100,14 +125,16 @@ func (rt *Router) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 // handleRegister handles POST /api/auth/register.
 //
-// Request body: {"tenant_id": "<uuid>", "email": "<email>", "password": "<plaintext>"}
+// Request body: {"tenant_id", "email", "password", "state"?}. `state` is an
+// optional USPS 2-letter code; it determines which state-licensed physician may
+// review this patient's recommendations, so the patient's clinical state must be
+// captured here. When omitted, the sentinel "--" is stored ("not provided");
+// such a patient cannot pass a physician state-licensing check until updated.
 //
-// The patients table requires full_name and state (both NOT NULL). Those fields
-// are not collected at registration; MVP safe defaults are used:
-//   - full_name: "" (empty — patient may update later)
-//   - state:     "--" (sentinel meaning "not provided"; valid char(2))
+// full_name is NOT NULL in the schema but is not collected at registration; the
+// MVP default "" is used (not PHI; updatable later via a profile endpoint).
 func (rt *Router) handleRegister(w http.ResponseWriter, r *http.Request) {
-	var req loginRequest // same {tenant_id, email, password} shape as login
+	var req registerRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -115,6 +142,16 @@ func (rt *Router) handleRegister(w http.ResponseWriter, r *http.Request) {
 	if req.TenantID == "" || req.Email == "" || req.Password == "" {
 		http.Error(w, "tenant_id, email, and password are required", http.StatusBadRequest)
 		return
+	}
+	// Validate the optional state: when present it must be a 2-letter uppercase
+	// USPS code. Absent → "--" sentinel.
+	patientState := "--"
+	if req.State != "" {
+		if !isValidUSStateCode(req.State) {
+			http.Error(w, "state must be a 2-letter US state code", http.StatusBadRequest)
+			return
+		}
+		patientState = req.State
 	}
 	tid, err := uuid.Parse(req.TenantID)
 	if err != nil {
@@ -142,11 +179,10 @@ func (rt *Router) handleRegister(w http.ResponseWriter, r *http.Request) {
 	patient, err := rt.store.CreatePatient(ctx, tenant, store.Patient{
 		Email:        req.Email,
 		PasswordHash: string(hash),
-		// full_name and state are NOT NULL in the schema but are not collected
-		// at registration (MVP). Safe defaults — neither is PHI and both can
-		// be updated later via a profile endpoint.
+		// full_name is not collected at registration (MVP default ""). State is
+		// the validated USPS code, or "--" when the client did not supply one.
 		FullName: "",
-		State:    "--",
+		State:    patientState,
 	})
 	if err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)

--- a/backend/internal/api/auth_test.go
+++ b/backend/internal/api/auth_test.go
@@ -407,3 +407,75 @@ func TestHandler_Register_PasswordHashStored(t *testing.T) {
 		t.Errorf("bcrypt verification failed: %v (hash=%q)", err, patient.PasswordHash)
 	}
 }
+
+func TestHandler_Register_WithValidState(t *testing.T) {
+	pool := apiTestPool(t)
+	s := store.New(pool)
+	ctx := context.Background()
+
+	tenant, err := s.CreateTenant(ctx, "dtc", "register-state-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	router := api.New(s, apiTestSecret)
+	r := chi.NewRouter()
+	router.Mount(r)
+
+	email := "state@register.test"
+	body, _ := json.Marshal(map[string]string{
+		"tenant_id": tenant.ID.String(),
+		"email":     email,
+		"password":  "hunter2-but-longer",
+		"state":     "CA",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rw := httptest.NewRecorder()
+	r.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rw.Code)
+	}
+
+	patient, err := s.GetPatientByEmail(ctx, store.TenantID(tenant.ID), email)
+	if err != nil {
+		t.Fatalf("get patient: %v", err)
+	}
+	if patient.State != "CA" {
+		t.Errorf("expected stored state CA, got %q", patient.State)
+	}
+}
+
+func TestHandler_Register_InvalidState(t *testing.T) {
+	pool := apiTestPool(t)
+	s := store.New(pool)
+	ctx := context.Background()
+
+	tenant, err := s.CreateTenant(ctx, "dtc", "register-badstate-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	router := api.New(s, apiTestSecret)
+	r := chi.NewRouter()
+	router.Mount(r)
+
+	for _, bad := range []string{"C", "California", "ca", "C1"} {
+		body, _ := json.Marshal(map[string]string{
+			"tenant_id": tenant.ID.String(),
+			"email":     "bad-" + bad + "@register.test",
+			"password":  "hunter2-but-longer",
+			"state":     bad,
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/register", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rw := httptest.NewRecorder()
+		r.ServeHTTP(rw, req)
+
+		if rw.Code != http.StatusBadRequest {
+			t.Errorf("state %q: expected 400, got %d", bad, rw.Code)
+		}
+		if _, err := s.GetPatientByEmail(ctx, store.TenantID(tenant.ID), "bad-"+bad+"@register.test"); err == nil {
+			t.Errorf("state %q: patient should not have been created", bad)
+		}
+	}
+}


### PR DESCRIPTION
Closes **HouseCall-u9v0** — the last code gap before a green end-to-end SOAP run.

Registration hardcoded patient `state="--"`, which no physician can be licensed in, so the SOAP-note approval step always failed `ErrUnlicensedState`. Now:

- **Backend** `POST /api/auth/register` accepts an optional `state` (validated: 2 uppercase letters → 400 on bad input, no row created); absent → `--` (backward compatible — existing tests + login flow unaffected).
- **iOS** `CoreAPIAuthClient.register` + `AuthenticationService` send `state` from a new `CORE_API_PATIENT_STATE` build config (`CoreAPIConfig.patientState()`); omitted from the request when unconfigured so the default build is unchanged.

Set `CORE_API_PATIENT_STATE = CA` (matching `cmd/seed`) in `Secrets.xcconfig` to run the full loop.

## Tests
Backend register state tests (valid stored / invalid→400) + iOS auth suites green; default build unaffected (state omitted when unconfigured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)