### PR TITLE
fix(cloud): create server conversation so patient messages POST

### DIFF
--- a/HouseCall/Core/Services/Sync/CloudSyncCoordinator.swift
+++ b/HouseCall/Core/Services/Sync/CloudSyncCoordinator.swift
@@ -515,5 +515,39 @@ final class CloudSyncCoordinator: ObservableObject {
         }
         try? context.save()
     }
+
+    /// Ensures the local conversation has a server-side counterpart so messages
+    /// can be POSTed.  If `serverId` is already set, does nothing.  Otherwise
+    /// creates a conversation on the Core API and persists the returned id as
+    /// the local conversation's `serverId`.
+    ///
+    /// Best-effort: on failure (offline, 401) the conversation simply stays
+    /// local and the next launch retries; no PHI is logged (title is a generic
+    /// non-PHI label).
+    func ensureServerConversation(localConversationId: UUID, title: String) async {
+        let request: NSFetchRequest<Conversation> = Conversation.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", localConversationId as CVarArg)
+        request.fetchLimit = 1
+        guard let conversation = try? context.fetch(request).first else { return }
+        if let existing = conversation.serverId, !existing.isEmpty { return }
+
+        do {
+            let dto = try await syncClient.createConversation(title: title)
+            conversation.serverId = dto.ID
+            try? context.save()
+            try? auditLogger.log(
+                event: .conversationCreated,
+                userId: nil,
+                details: AuditEventDetails(additionalInfo: [
+                    "event": "conversation.created",
+                    "conversationServerId": dto.ID
+                ])
+            )
+        } catch SyncError.unauthorized {
+            handleUnauthorized()
+        } catch {
+            // Offline / transient: leave local; next launch retries. No PHI logged.
+        }
+    }
 }
 

--- a/HouseCall/Core/Services/Sync/SyncClient.swift
+++ b/HouseCall/Core/Services/Sync/SyncClient.swift
@@ -272,6 +272,21 @@ final class SyncClient {
         return try await perform(request)
     }
 
+    /// Create a server-side conversation for the authenticated patient.
+    ///
+    /// Maps to `POST /api/conversations`. The server requires a non-empty title.
+    /// Returns the `ConversationDTO` whose `ID` becomes the local conversation's
+    /// `serverId` (required before any message can be POSTed).
+    func createConversation(title: String) async throws -> ConversationDTO {
+        let payload = try JSONEncoder().encode(["title": title])
+        let request = try authorisedRequest(
+            method: "POST",
+            path: "/api/conversations",
+            body: payload
+        )
+        return try await perform(request)
+    }
+
     /// List messages for a conversation.
     ///
     /// Maps to `GET /api/conversations/{id}/messages`.

--- a/HouseCall/HouseCallApp.swift
+++ b/HouseCall/HouseCallApp.swift
@@ -229,6 +229,16 @@ private struct AutoLaunchChatView: View {
             )
             coordinator?.start()
 
+            // In cloud mode, ensure the conversation exists server-side so the
+            // patient's messages can be POSTed (the send path requires a
+            // serverId). Generic, non-PHI title.
+            if let coordinator {
+                await coordinator.ensureServerConversation(
+                    localConversationId: conversationId,
+                    title: "Consultation"
+                )
+            }
+
             chatViewModel = ConversationViewModel(
                 userId: userId,
                 conversationId: conversationId,

--- a/HouseCallTests/CloudSyncTests.swift
+++ b/HouseCallTests/CloudSyncTests.swift
@@ -1521,6 +1521,76 @@ struct CloudSyncTests {
         // Exactly one POST per send attempt — no internal retry loop on 401.
         #expect(callCount.count == 2, "each send makes one POST attempt; 401 must not retry")
     }
+
+    // MARK: - ensureServerConversation (HouseCall-zkeg)
+
+    @Test("ensureServerConversation creates a server conversation and persists serverId when absent")
+    func testEnsureServerConversationCreatesAndPersists() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let context = makeInMemoryContext()
+        let userId = UUID()
+        // Local conversation with NO serverId — the cloud send path would no-op.
+        let conversation = try seedConversation(in: context, userId: userId, serverId: nil)
+        let convLocalId = conversation.id!
+
+        let newServerId = "srv-conv-\(UUID().uuidString)"
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/conversations") { req in
+            let json = """
+            {"ID":"\(newServerId)","TenantID":"t1","PatientID":"p1","Title":"Consultation","CreatedAt":"2026-06-28T10:00:00Z","UpdatedAt":"2026-06-28T10:00:00Z"}
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let syncClient = try SyncClient(baseURL: URL(string: "http://localhost:8080")!, session: session, keychainManager: kc)
+        let coordinator = CloudSyncCoordinator(
+            syncClient: syncClient,
+            messageRepository: CoreDataMessageRepository(context: context, encryptionManager: EncryptionManager.shared, auditLogger: AuditLogger(context: context)),
+            conversationRepository: CoreDataConversationRepository(context: context, encryptionManager: EncryptionManager.shared, auditLogger: AuditLogger(context: context)),
+            auditLogger: AuditLogger(context: context),
+            context: context
+        )
+
+        await coordinator.ensureServerConversation(localConversationId: convLocalId, title: "Consultation")
+
+        let req: NSFetchRequest<Conversation> = Conversation.fetchRequest()
+        req.predicate = NSPredicate(format: "id == %@", convLocalId as CVarArg)
+        let updated = try context.fetch(req).first
+        #expect(updated?.serverId == newServerId, "serverId must be persisted from the create response")
+    }
+
+    @Test("ensureServerConversation is a no-op when serverId already set")
+    func testEnsureServerConversationSkipsWhenPresent() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let context = makeInMemoryContext()
+        let userId = UUID()
+        let conversation = try seedConversation(in: context, userId: userId, serverId: "already-set")
+        let convLocalId = conversation.id!
+
+        let createCalls = Counter()
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/conversations") { req in
+            createCalls.increment()
+            return ("{}".data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let syncClient = try SyncClient(baseURL: URL(string: "http://localhost:8080")!, session: session, keychainManager: kc)
+        let coordinator = CloudSyncCoordinator(
+            syncClient: syncClient,
+            messageRepository: CoreDataMessageRepository(context: context, encryptionManager: EncryptionManager.shared, auditLogger: AuditLogger(context: context)),
+            conversationRepository: CoreDataConversationRepository(context: context, encryptionManager: EncryptionManager.shared, auditLogger: AuditLogger(context: context)),
+            auditLogger: AuditLogger(context: context),
+            context: context
+        )
+
+        await coordinator.ensureServerConversation(localConversationId: convLocalId, title: "Consultation")
+
+        #expect(createCalls.count == 0, "must not POST when the conversation already has a serverId")
+    }
 }
 
 /// Minimal thread-safe counter for asserting call counts in async stubs.


### PR DESCRIPTION
Closes **HouseCall-zkeg** — "send a message, nothing happens" in cloud mode.

## Root cause
`Conversation.serverId` was never set on iOS — nothing created a server-side conversation. The cloud send path requires it (`if !conversationServerId.isEmpty { POST }; return`), so messages silently never POSTed → no agent interview.

## Fix
- `SyncClient.createConversation(title:)` → `POST /api/conversations`.
- `CloudSyncCoordinator.ensureServerConversation(...)` persists the returned id as the local conversation's `serverId` (idempotent; 401 → deactivate; offline → retry next launch; audit ids-only).
- `AutoLaunchChatView` awaits it when the coordinator is active, before the VM is built (sendMessage re-fetches the conversation, so serverId is seen on first send).

## Verification
Backend loop confirmed via curl on the running stack: login → create conversation → post message → **agent returned an interview question**. New iOS tests: serverId created+persisted; no-op when already set. Build + tests green; local-only mode unaffected (coordinator nil → never called).

🤖 Generated with [Claude Code](https://claude.com/claude-code)