### PR TITLE
fix(agent): make SOAP drafting robust to small-model formatting

### DIFF
--- a/backend/internal/agent/drafter.go
+++ b/backend/internal/agent/drafter.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log"
 	"net"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
@@ -24,6 +25,13 @@ import (
 // wired in Tasks 1.3 and 2.2; this task only defines the constant and the
 // pure helper function.
 const DefaultMaxInterviewTurns = 12
+
+// soapDraftMaxAttempts is how many times draftSOAPNote re-generates the SOAP
+// note when the model returns output that fails section parsing/validation.
+// Small local models format the required headers only intermittently, so a few
+// fresh generations dramatically raise the success rate without masking a true
+// model outage (transport errors are not retried here).
+const soapDraftMaxAttempts = 3
 
 // ModelClient is the narrow interface the Drafter needs from the model. Using
 // an interface rather than *Client directly lets tests inject a stub without
@@ -276,6 +284,11 @@ func draftFailureReason(err error) string {
 	if errors.As(err, &pe) {
 		return "parse_error"
 	}
+	var ve *domain.SOAPValidationError
+	if errors.As(err, &ve) {
+		// SOAP note generated but missing/blank a required section.
+		return "validation_error"
+	}
 	var me *ModelError
 	if errors.As(err, &me) {
 		// Distinguish a transport/connection failure (wrapped inside ModelError
@@ -295,6 +308,22 @@ func draftFailureReason(err error) string {
 		return "model_unavailable"
 	}
 	return "internal_error"
+}
+
+// headerDecorationRE matches leading Markdown/list decoration on a header line:
+// heading hashes, blockquote markers, emphasis (*/_), list bullets (-/+), and an
+// optional ordered-list number ("1." or "1)"). Stripped before label matching.
+var headerDecorationRE = regexp.MustCompile(`^[\s#>*_+\-]*(?:\d+[.)]\s*)?`)
+
+// normalizeHeaderLine reduces a raw line to its bare uppercase header token by
+// stripping surrounding Markdown/list decoration, so headers like
+// "**SUBJECTIVE:**", "### Subjective", "1. SUBJECTIVE", or "- PLAN:" all match
+// the plain labels. Returns the uppercased, trimmed result.
+func normalizeHeaderLine(line string) string {
+	s := strings.TrimSpace(line)
+	s = headerDecorationRE.ReplaceAllString(s, "")
+	s = strings.TrimRight(s, " \t*_#")
+	return strings.ToUpper(strings.TrimSpace(s))
 }
 
 // parseSOAPSections extracts the four required SOAP sections from raw model
@@ -326,7 +355,10 @@ func parseSOAPSections(raw string) (domain.SOAPPayload, error) {
 	var spans []span
 
 	for i, line := range lines {
-		upper := strings.ToUpper(strings.TrimSpace(line))
+		// Strip common Markdown/list decoration the model adds around headers
+		// (e.g. "**SUBJECTIVE:**", "### Subjective", "1. SUBJECTIVE", "- PLAN:")
+		// so the label match is robust to formatting variation from small models.
+		upper := normalizeHeaderLine(line)
 		for _, label := range orderedLabels {
 			if !seen[label] && (upper == label || upper == label+":" || strings.HasPrefix(upper, label+":")) {
 				seen[label] = true
@@ -410,21 +442,34 @@ func (d *Drafter) draftSOAPNote(ctx context.Context, tenantID store.TenantID, co
 		})
 	}
 
-	text, err := d.client.Complete(ctx, modelMsgs)
-	if err != nil {
-		// Non-nil error means no valid model output — do NOT persist.
-		return err
+	// Small models (e.g. medgemma:4b) format the SOAP headers correctly only
+	// intermittently, so a single bad generation must not sink the whole draft.
+	// Retry the generate→parse→validate cycle a few times; only a fresh model
+	// generation can fix a malformed one, so we re-call Complete each attempt.
+	// Transport/model errors are NOT retried here (they surface immediately).
+	var text string
+	var soapPayload domain.SOAPPayload
+	var parseErr error
+	for attempt := 0; attempt < soapDraftMaxAttempts; attempt++ {
+		text, err = d.client.Complete(ctx, modelMsgs)
+		if err != nil {
+			// Non-nil error means no valid model output — do NOT persist.
+			return err
+		}
+		soapPayload, parseErr = parseSOAPSections(text)
+		if parseErr == nil {
+			// Domain validation: all four sections must be non-empty.
+			if vErr := soapPayload.Validate(); vErr != nil {
+				parseErr = vErr
+			}
+		}
+		if parseErr == nil {
+			break
+		}
+		// Malformed output — try a fresh generation (unless this was the last attempt).
 	}
-
-	// Parse the model output into the four SOAP sections.
-	soapPayload, err := parseSOAPSections(text)
-	if err != nil {
-		return err
-	}
-	// Domain validation: all four sections must be non-empty (whitespace-only
-	// content is treated as empty by the validator tightened in task 2.1).
-	if err := soapPayload.Validate(); err != nil {
-		return err
+	if parseErr != nil {
+		return parseErr
 	}
 
 	// Marshal the structured payload for storage.

--- a/backend/internal/agent/soap_robustness_test.go
+++ b/backend/internal/agent/soap_robustness_test.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/markolonius/housecall/backend/internal/domain"
+	"github.com/markolonius/housecall/backend/internal/store"
+)
+
+// --- normalizeHeaderLine / parseSOAPSections: tolerate Markdown-decorated headers ---
+
+func TestNormalizeHeaderLine(t *testing.T) {
+	cases := map[string]string{
+		"SUBJECTIVE:":      "SUBJECTIVE:",
+		"  subjective:  ":  "SUBJECTIVE:",
+		"**SUBJECTIVE:**":  "SUBJECTIVE:",
+		"### Objective":    "OBJECTIVE",
+		"1. ASSESSMENT":    "ASSESSMENT",
+		"2) Plan":          "PLAN",
+		"- PLAN:":          "PLAN:",
+		"__Assessment:__":  "ASSESSMENT:",
+		"> SUBJECTIVE":     "SUBJECTIVE",
+	}
+	for in, want := range cases {
+		if got := normalizeHeaderLine(in); got != want {
+			t.Errorf("normalizeHeaderLine(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseSOAPSections_DecoratedHeaders(t *testing.T) {
+	raw := `Here is the note:
+
+**SUBJECTIVE:**
+34yo male, sore throat and fever x2 days.
+
+### Objective
+None reported
+
+1. ASSESSMENT
+Preliminary assessment: likely viral pharyngitis; requires physician review.
+
+- PLAN:
+Rest, fluids, paracetamol; seek care if worsening.`
+	sp, err := parseSOAPSections(raw)
+	if err != nil {
+		t.Fatalf("parseSOAPSections on decorated headers: %v", err)
+	}
+	if err := sp.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	for name, v := range map[string]string{"subjective": sp.Subjective, "objective": sp.Objective, "assessment": sp.Assessment, "plan": sp.Plan} {
+		if v == "" {
+			t.Errorf("section %q is empty", name)
+		}
+	}
+}
+
+// --- draftSOAPNote retry on parse failure ---
+
+func TestDraftSOAPNote_RetriesOnParseError(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+	f := setupSOAPDrafterFixture(t, s)
+	ctx := context.Background()
+	notifier := &captureNotifier{}
+
+	// First generation is malformed (no headers); second is well-formed.
+	client := &sequentialClient{responses: []struct {
+		text string
+		err  error
+	}{
+		{text: "I'm not sure how to format this note.", err: nil},
+		{text: wellFormedSOAPText, err: nil},
+	}}
+	d := NewDrafter(client, s, notifier, notifier)
+
+	if err := d.draftSOAPNote(ctx, f.TenantID, f.Conv, f.Patient); err != nil {
+		t.Fatalf("draftSOAPNote should succeed on retry, got: %v", err)
+	}
+	// Both responses consumed → it retried after the first parse failure.
+	if client.idx != 2 {
+		t.Errorf("expected 2 model calls (retry), got %d", client.idx)
+	}
+	recs, _ := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
+	n := 0
+	for _, r := range recs {
+		if r.ConversationID == f.Conv.ID && r.PayloadType == domain.PayloadTypeSOAPNote {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected 1 PENDING_REVIEW soap_note after retry, got %d", n)
+	}
+}
+
+func TestDraftSOAPNote_DoesNotRetryOnModelError(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+	f := setupSOAPDrafterFixture(t, s)
+	ctx := context.Background()
+	notifier := &captureNotifier{}
+
+	// A transport/model error must surface immediately — no retry (a model
+	// outage must not be masked by burning all attempts).
+	client := &sequentialClient{responses: []struct {
+		text string
+		err  error
+	}{
+		{text: "", err: &ModelError{StatusCode: 500}},
+		{text: wellFormedSOAPText, err: nil}, // must NOT be reached
+	}}
+	d := NewDrafter(client, s, notifier, notifier)
+
+	if err := d.draftSOAPNote(ctx, f.TenantID, f.Conv, f.Patient); err == nil {
+		t.Fatal("draftSOAPNote should return the model error")
+	}
+	if client.idx != 1 {
+		t.Errorf("model error must not be retried; expected 1 call, got %d", client.idx)
+	}
+}
+
+func TestDraftSOAPNote_FailsAfterMaxAttempts(t *testing.T) {
+	pool := itTestPool(t)
+	s := store.New(pool)
+	f := setupSOAPDrafterFixture(t, s)
+	ctx := context.Background()
+	notifier := &captureNotifier{}
+
+	// Every generation malformed → exhausts soapDraftMaxAttempts, no row persisted.
+	client := &sequentialClient{responses: []struct {
+		text string
+		err  error
+	}{
+		{text: "no headers here", err: nil},
+		{text: "still no headers", err: nil},
+		{text: "nope", err: nil},
+		{text: "extra (should not be reached)", err: nil},
+	}}
+	d := NewDrafter(client, s, notifier, notifier)
+
+	if err := d.draftSOAPNote(ctx, f.TenantID, f.Conv, f.Patient); err == nil {
+		t.Fatal("draftSOAPNote should fail after max attempts on persistently malformed output")
+	}
+	if client.idx != soapDraftMaxAttempts {
+		t.Errorf("expected %d model calls, got %d", soapDraftMaxAttempts, client.idx)
+	}
+	recs, _ := s.ListRecommendationsByState(ctx, f.TenantID, domain.StatePendingReview)
+	for _, r := range recs {
+		if r.ConversationID == f.Conv.ID {
+			t.Fatal("no recommendation must be persisted when all attempts fail")
+		}
+	}
+}


### PR DESCRIPTION
Closes **HouseCall-7pvo** — found during the live backend e2e: `medgemma:4b` formats SOAP headers correctly only ~1/4 of the time, and `draftSOAPNote` didn't retry, so ~75% of forced drafts failed `parse_error` with no recommendation (patient saw nothing).

## Fix
- `normalizeHeaderLine` strips leading Markdown/list decoration (`**SUBJECTIVE:**`, `### Objective`, `1. ASSESSMENT`, `- PLAN:`) before label matching.
- `draftSOAPNote` retries up to `soapDraftMaxAttempts` (3) on parse/validation failure with a fresh generation; **transport/model errors surface immediately (no retry)** so an outage isn't masked. All-or-nothing preserved.
- `draftFailureReason` → `validation_error` for `SOAPValidationError`.

## Tests
normalizeHeaderLine; decorated-header parsing; retry-succeeds-on-2nd; fails-after-max (zero rows); transport-error-no-retry. Full `make test` green.

Note: requires a backend rebuild/restart (`make run`) for the running server to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)