### PR TITLE
fix(web): physician login over http localhost (conditional Secure cookie)

### DIFF
--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -38,6 +38,17 @@ var templateFS embed.FS
 
 const sessionCookieName = "hc_session"
 
+// secureCookie reports whether the session cookie should carry the Secure flag.
+// It is true when the request reached us over TLS — either directly
+// (r.TLS != nil) or via a TLS-terminating proxy that set X-Forwarded-Proto.
+// This keeps the cookie Secure in production (served over HTTPS) while allowing
+// the physician web app to work over plain http://localhost during local dev
+// (a Secure cookie is never returned by the browser over HTTP, which otherwise
+// produces an infinite login→queue→login redirect loop).
+func secureCookie(r *http.Request) bool {
+	return r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
+}
+
 // Handler holds the shared dependencies for the physician web app.
 //
 // The storeQ and auditQ fields allow tests (via NewWithQuerier in export_test.go)
@@ -211,7 +222,7 @@ func (h *Handler) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 		Path:     "/web",
 		MaxAge:   int(sessionTTL.Seconds()),
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   secureCookie(r),
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -247,7 +258,7 @@ func (h *Handler) requireWebAuth(next http.Handler) http.Handler {
 				Path:     "/web",
 				MaxAge:   -1,
 				HttpOnly: true,
-				Secure:   true,
+				Secure:   secureCookie(r),
 				SameSite: http.SameSiteLaxMode,
 			})
 			http.Redirect(w, r, "/web/login", http.StatusSeeOther)

--- a/backend/internal/web/web_test.go
+++ b/backend/internal/web/web_test.go
@@ -438,14 +438,52 @@ func TestLoginSubmit_Success(t *testing.T) {
 	if !sessionCookie.HttpOnly {
 		t.Error("session cookie must be HttpOnly")
 	}
-	if !sessionCookie.Secure {
-		t.Error("session cookie must be Secure")
+	// Plain (non-TLS) request → Secure must be OFF so the cookie round-trips
+	// over http://localhost in dev. Production (TLS) is covered separately below.
+	if sessionCookie.Secure {
+		t.Error("session cookie must NOT be Secure for a non-TLS request (breaks http localhost dev)")
 	}
 	if sessionCookie.SameSite != http.SameSiteLaxMode && sessionCookie.SameSite != http.SameSiteStrictMode {
 		t.Errorf("session cookie SameSite must be Lax or Strict, got %v", sessionCookie.SameSite)
 	}
 	if sessionCookie.Value == "" {
 		t.Error("session cookie must carry a token value")
+	}
+}
+
+// TestLoginSubmit_SecureCookieBehindTLS verifies the Secure flag IS set when the
+// request arrives over TLS (production: directly or via a TLS-terminating proxy
+// that sets X-Forwarded-Proto=https), so the dev-friendly relaxation does not
+// weaken production.
+func TestLoginSubmit_SecureCookieBehindTLS(t *testing.T) {
+	const password = "Str0ng!Password#99"
+	h := buildHandler(t, newFakeStoreWithPhysician(t, password))
+	form := url.Values{
+		"tenant_id": {testTenantID.String()},
+		"email":     {"doc@clinic.example"},
+		"password":  {password},
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/web/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Forwarded-Proto", "https") // simulate TLS-terminating proxy
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("want 303, got %d", rec.Code)
+	}
+	var sessionCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hc_session" {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("expected hc_session cookie")
+	}
+	if !sessionCookie.Secure {
+		t.Error("session cookie MUST be Secure when the request is over TLS (X-Forwarded-Proto=https)")
 	}
 }
 


### PR DESCRIPTION
Closes **HouseCall-q72e** — can't log into the physician web portal.

## Cause
`hc_session` cookie was set `Secure: true` unconditionally. Over `http://localhost:8080` the browser never returns a Secure cookie, so login → `/web/queue` → no cookie → bounced to `/web/login` (infinite loop). API auth worked (creds valid); only the web cookie round-trip broke.

## Fix
`secureCookie(r)` sets `Secure` only when the request is over TLS (`r.TLS != nil` or `X-Forwarded-Proto: https`). Production over HTTPS stays Secure; local http dev works. Applied to the session cookie and the clear-cookie path.

## Tests
non-TLS login → cookie NOT Secure; `X-Forwarded-Proto=https` → Secure. Full `make test` green.

Requires a backend rebuild/restart (`make run`) to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)