### PR TITLE
fix(chat): create server conversation on demand in cloud send path

### DIFF
--- a/HouseCall/Core/Services/AIConversationService.swift
+++ b/HouseCall/Core/Services/AIConversationService.swift
@@ -257,15 +257,32 @@ class AIConversationService: ObservableObject {
 
         // --- Cloud sync path ---
         if let coordinator = syncCoordinator {
-            // serverId for the conversation is required to POST; if absent the
-            // message stays pending and replay will retry when available.
-            let conversationServerId = conversation.serverId ?? ""
+            // A server-side conversation (serverId) is required before any
+            // message can be POSTed. Launch-time ensureServerConversation is
+            // best-effort; if it hasn't run or failed, create it on demand here
+            // so the very first send is never silently dropped.
+            var conversationServerId = conversation.serverId ?? ""
+            if conversationServerId.isEmpty {
+                await coordinator.ensureServerConversation(
+                    localConversationId: conversationId,
+                    title: "Consultation"
+                )
+                // Re-fetch to pick up the serverId ensureServerConversation persisted.
+                if let refreshed = try? conversationRepository.fetchConversation(id: conversationId) {
+                    conversationServerId = refreshed.serverId ?? ""
+                }
+            }
             if !conversationServerId.isEmpty {
                 try await coordinator.postMessage(
                     localMessageId: userMessage.id!,
                     conversationServerId: conversationServerId,
                     conversationLocalId: conversationId
                 )
+            } else {
+                // Could not establish a server conversation (offline / server
+                // unreachable). Surface an error instead of silently dropping —
+                // the message stays pending and replays on reconnect.
+                errorMessage = "Unable to reach the server. Your message will be sent when the connection is restored."
             }
             // AI reply arrives asynchronously via WebSocket; no streaming UI here.
             return

--- a/HouseCallTests/CloudSyncTests.swift
+++ b/HouseCallTests/CloudSyncTests.swift
@@ -1591,6 +1591,57 @@ struct CloudSyncTests {
 
         #expect(createCalls.count == 0, "must not POST when the conversation already has a serverId")
     }
+
+    // MARK: - sendMessage creates the server conversation on demand (HouseCall-y4jt)
+
+    @Test("sendMessage creates the server conversation on demand when serverId is missing, then POSTs")
+    func testSendMessageCreatesServerConversationOnDemand() async throws {
+        let sid = UUID().uuidString
+        let kc = makeKeychain()
+        let session = makeStubSession(sessionID: sid)
+        let context = makeInMemoryContext()
+        let userId = UUID()
+        // Local conversation with NO serverId — the pre-fix send path would drop silently.
+        let conversation = try seedConversation(in: context, userId: userId, serverId: nil)
+        let convLocalId = conversation.id!
+
+        let newServerId = "srv-conv-\(UUID().uuidString)"
+        let serverMsgId = "srv-msg-\(UUID().uuidString)"
+        // Stub 1: POST /api/conversations -> 201 (on-demand create).
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/conversations") { req in
+            let json = """
+            {"ID":"\(newServerId)","TenantID":"t1","PatientID":"p1","Title":"Consultation","CreatedAt":"2026-06-30T10:00:00Z","UpdatedAt":"2026-06-30T10:00:00Z"}
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+        // Stub 2: POST message to the newly-created conversation -> 201.
+        SyncMockURLProtocol.register(sessionID: sid, path: "/api/conversations/\(newServerId)/messages") { req in
+            let json = """
+            {"ID":"\(serverMsgId)","TenantID":"t1","ConversationID":"\(newServerId)","Role":"user","Content":"hi","CreatedAt":"2026-06-30T10:00:01Z"}
+            """
+            return (json.data(using: .utf8)!, makeHTTPResponse(url: req.url!, status: 201))
+        }
+        defer { SyncMockURLProtocol.cleanup(sessionID: sid) }
+
+        let syncClient = try SyncClient(baseURL: URL(string: "http://localhost:8080")!, session: session, keychainManager: kc)
+        let messageRepo = CoreDataMessageRepository(context: context, encryptionManager: EncryptionManager.shared, auditLogger: AuditLogger(context: context))
+        let conversationRepo = CoreDataConversationRepository(context: context, encryptionManager: EncryptionManager.shared, auditLogger: AuditLogger(context: context))
+        let coordinator = CloudSyncCoordinator(syncClient: syncClient, messageRepository: messageRepo, conversationRepository: conversationRepo, auditLogger: AuditLogger(context: context), context: context)
+        let service = AIConversationService(userId: userId, conversationRepository: conversationRepo, messageRepository: messageRepo, auditLogger: AuditLogger(context: context), syncCoordinator: coordinator)
+
+        try await service.loadConversation(convLocalId)
+        try await service.sendMessage(conversationId: convLocalId, content: "hi")
+
+        // Local conversation must now carry the on-demand server id.
+        let conv = try conversationRepo.fetchConversation(id: convLocalId)
+        #expect(conv?.serverId == newServerId, "serverId must be persisted by on-demand create")
+
+        // The user message must have POSTed and synced (not silently dropped).
+        let userMsg = try messageRepo.fetchAllMessages(conversationId: convLocalId).first(where: { $0.role == "user" })
+        #expect(userMsg != nil, "user message persisted")
+        #expect(userMsg?.syncState == "synced", "message must POST after on-demand create, not stay pending")
+        #expect(userMsg?.serverId == serverMsgId, "serverId from POST response")
+    }
 }
 
 /// Minimal thread-safe counter for asserting call counts in async stubs.


### PR DESCRIPTION
Closes **HouseCall-y4jt** — iOS "no responses": the app logged in + created a server conversation, but a typed message never reached the server (0 messages server-side).

## Cause
Cloud send path posted only when `conversation.serverId` was already set and **returned silently** otherwise. `ensureServerConversation` is launch-only/best-effort, so any miss = message persisted-but-pending, no POST, no reply, **no error shown**.

## Fix
`sendMessage` cloud branch: when `serverId` empty → `await ensureServerConversation` on demand → re-fetch → post. If still unreachable → set `errorMessage` (message stays pending for replay) instead of dropping. Idempotent; direct-LLM path untouched.

## Verified
Server + agent proven healthy live (manual POST to the app's own conversation → agent replied). New test: send with `serverId=nil` creates the server conversation and syncs the message. Build + test green.

**Requires an iOS app rebuild** (Xcode → Run) to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)