### PR TITLE
fix(sync): decode cloud DTOs regardless of server TenantID shape

### DIFF
--- a/HouseCall/Core/Services/Sync/SyncClient.swift
+++ b/HouseCall/Core/Services/Sync/SyncClient.swift
@@ -87,7 +87,6 @@ enum SyncError: LocalizedError, Equatable {
 
 struct ConversationDTO: Codable {
     let ID: String
-    let TenantID: String
     let PatientID: String
     let Title: String
     let CreatedAt: String
@@ -96,7 +95,6 @@ struct ConversationDTO: Codable {
 
 struct MessageDTO: Codable {
     let ID: String
-    let TenantID: String
     let ConversationID: String
     let Role: String
     let Content: String
@@ -105,7 +103,6 @@ struct MessageDTO: Codable {
 
 struct RecommendationDTO: Codable {
     let ID: String
-    let TenantID: String
     let ConversationID: String
     let PatientID: String
     let State: String

--- a/HouseCallTests/SyncClientTests.swift
+++ b/HouseCallTests/SyncClientTests.swift
@@ -781,4 +781,32 @@ struct SyncClientTests {
         #expect(dto.ID == existingServerID,
                 "Dedupe-hit (200) response must return the existing server message ID")
     }
+
+    // MARK: - DTO decoding tolerates the real server shape (HouseCall-zd53)
+
+    // The Go backend marshals store.TenantID (a [16]byte UUID) as a JSON byte
+    // ARRAY, e.g. "TenantID":[0,0,...,1]. The client never uses TenantID (it
+    // comes from the JWT), so the DTOs must decode successfully regardless of
+    // its shape. Before the fix these decodes threw "not in the correct format",
+    // silently breaking conversation create, message sync, and note delivery.
+
+    @Test("ConversationDTO decodes the real server payload (TenantID as byte array)")
+    func testConversationDTODecodesServerShape() throws {
+        let json = """
+        {"ID":"cc50e1b5-bf74-45be-a500-69e881c8f94e","TenantID":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],"PatientID":"00000000-0000-0000-0000-000000000020","Title":"Consultation","CreatedAt":"2026-07-01T10:00:00Z","UpdatedAt":"2026-07-01T10:00:00Z"}
+        """.data(using: .utf8)!
+        let dto = try JSONDecoder().decode(ConversationDTO.self, from: json)
+        #expect(dto.ID == "cc50e1b5-bf74-45be-a500-69e881c8f94e")
+        #expect(dto.Title == "Consultation")
+    }
+
+    @Test("MessageDTO decodes the real server payload (TenantID as byte array)")
+    func testMessageDTODecodesServerShape() throws {
+        let json = """
+        {"ID":"782982f1-0757-413e-9c0e-080452c320d4","TenantID":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],"ConversationID":"cc50e1b5-bf74-45be-a500-69e881c8f94e","Role":"assistant","Content":"What brings you in today?","CreatedAt":"2026-07-01T10:00:01Z"}
+        """.data(using: .utf8)!
+        let dto = try JSONDecoder().decode(MessageDTO.self, from: json)
+        #expect(dto.Role == "assistant")
+        #expect(dto.Content == "What brings you in today?")
+    }
 }


### PR DESCRIPTION
Closes **HouseCall-zd53** — the real root cause of iOS "no responses", found by driving the live simulator + reading the app's os_log.

## Cause
`createConversation` POSTed successfully (201) but `SyncClient` decoding threw *"data isn't in the correct format"*. The Go backend marshals `store.TenantID` (a `[16]byte` UUID) as a JSON **byte array** (`"TenantID":[0,…,1]`), but `ConversationDTO`/`MessageDTO`/`RecommendationDTO` declared `TenantID: String`. Every cloud response failed to decode → `ensureServerConversation`'s catch swallowed it → `serverId` never persisted → every send re-created a server conversation and showed "Unable to reach the server". Same decode failure silently broke message sync and note delivery.

## Fix
Drop the unused `TenantID` field from the three DTOs (client gets tenant from the JWT); `JSONDecoder` then ignores the array key. Unit tests previously passed only because their stubs used a string `TenantID`.

## Verified live on the simulator
After this fix: patient logs in → message **posts** → agent **replies** ("I understand, thank you. Can you describe the sore throat?") — confirmed in the DB across two interview turns. (A separate WebSocket-render defect, HouseCall-<ws>, tracks live reply rendering.)

Tests: `ConversationDTO`/`MessageDTO` decode the exact server payload (TenantID as a byte array).

🤖 Generated with [Claude Code](https://claude.com/claude-code)