### PR TITLE
fix(sync): resolve WS events by server conversation id, not local id

### DIFF
--- a/HouseCall/Core/Services/Sync/CloudSyncCoordinator.swift
+++ b/HouseCall/Core/Services/Sync/CloudSyncCoordinator.swift
@@ -288,7 +288,7 @@ final class CloudSyncCoordinator: ObservableObject {
             // question) on the conversation.  Fetch the full message list and
             // upsert any assistant messages that are not yet present locally.
             guard let cidString = event.data.conversation_id else { return }
-            await handleMessageCreated(conversationIdString: cidString)
+            await handleMessageCreated(conversationServerIdString: cidString)
         default:
             break
         }
@@ -306,13 +306,14 @@ final class CloudSyncCoordinator: ObservableObject {
                   let finalContent = dto.FinalContent,
                   !finalContent.isEmpty else { return }
 
-            // Resolve the local conversation UUID.
-            // conversationId (from the WS event) takes precedence; fall back
-            // to dto.ConversationID (non-optional String from the REST response).
-            let cidString = conversationId ?? dto.ConversationID
-            let localConversationId: UUID? = UUID(uuidString: cidString)
-
-            guard let convLocalId = localConversationId else { return }
+            // Resolve the local conversation via Conversation.serverId.
+            // conversationId (SERVER id from the WS event) takes precedence;
+            // fall back to dto.ConversationID (SERVER id from the REST
+            // response). Both are server-generated ids, independent of the
+            // local Core Data conversation's own id — never parse them
+            // directly as the local UUID.
+            let serverCidString = conversationId ?? dto.ConversationID
+            guard let convLocalId = resolveLocalConversationId(bySeverId: serverCidString) else { return }
 
             // Look up the user ID so we can encrypt the content at rest.
             let userId: UUID
@@ -382,15 +383,12 @@ final class CloudSyncCoordinator: ObservableObject {
     /// so replaying the event on reconnect is safe (no double-inserts).
     ///
     /// Only non-PHI metadata (IDs, syncState, role) is used in audit entries.
-    private func handleMessageCreated(conversationIdString: String) async {
-        guard let convLocalId = UUID(uuidString: conversationIdString) else { return }
-
-        // Resolve the conversation's server ID — required to call listMessages.
-        guard
-            let conversation = try? conversationRepository.fetchConversation(id: convLocalId),
-            let conversationServerId = conversation.serverId,
-            !conversationServerId.isEmpty
-        else { return }
+    private func handleMessageCreated(conversationServerIdString: String) async {
+        // The WS event carries the SERVER conversation id; resolve it to the
+        // local Core Data conversation via Conversation.serverId (the two ids
+        // are independently generated and never equal).
+        guard let convLocalId = resolveLocalConversationId(bySeverId: conversationServerIdString) else { return }
+        let conversationServerId = conversationServerIdString
 
         // Resolve the user ID for content encryption.
         let userId: UUID
@@ -457,7 +455,7 @@ final class CloudSyncCoordinator: ObservableObject {
                 userId: nil,
                 details: AuditEventDetails(
                     errorMessage: "message.created handling failed",
-                    additionalInfo: ["conversationId": conversationIdString]
+                    additionalInfo: ["conversationId": conversationServerIdString]
                 )
             )
         }
@@ -477,6 +475,23 @@ final class CloudSyncCoordinator: ObservableObject {
     }
 
     // MARK: - Core Data helpers
+
+    /// Resolves the LOCAL Core Data conversation id for a given SERVER
+    /// conversation id string (`Conversation.serverId`).
+    ///
+    /// The server and local conversation identifiers are independently
+    /// generated UUIDs — the server never learns the client's local id, and
+    /// the client only learns the server's id via `ensureServerConversation`'s
+    /// response, which is persisted into `Conversation.serverId`. WebSocket
+    /// events (`message.created`, `recommendation.delivered`) always carry the
+    /// SERVER conversation id, so it must be resolved through this mapping
+    /// rather than parsed directly as a local UUID.
+    private func resolveLocalConversationId(bySeverId serverId: String) -> UUID? {
+        let request: NSFetchRequest<Conversation> = Conversation.fetchRequest()
+        request.predicate = NSPredicate(format: "serverId == %@", serverId)
+        request.fetchLimit = 1
+        return (try? context.fetch(request).first)?.id
+    }
 
     /// Returns the set of server message IDs (`serverId`) already stored for
     /// the given conversation.  Used by `handleMessageCreated` to skip messages

--- a/HouseCallTests/CloudSyncTests.swift
+++ b/HouseCallTests/CloudSyncTests.swift
@@ -319,7 +319,11 @@ struct CloudSyncTests {
         let userId = UUID()
         let conversation = try seedConversation(in: context, userId: userId)
         let convLocalId = conversation.id!
-        let convLocalIdString = convLocalId.uuidString
+        // The server never learns the client's local conversation id; WS
+        // events and REST responses always carry the SERVER id
+        // (Conversation.serverId), which the handler resolves back to
+        // convLocalId via a Core Data lookup.
+        let convServerIdString = conversation.serverId!
 
         let recId = "rec-\(UUID().uuidString)"
         let guidanceText = "Stay hydrated and rest. Follow up if symptoms persist."
@@ -333,7 +337,7 @@ struct CloudSyncTests {
             {
               "ID": "\(recId)",
               "TenantID": "t1",
-              "ConversationID": "\(convLocalIdString)",
+              "ConversationID": "\(convServerIdString)",
               "PatientID": "patient-1",
               "State": "DELIVERED",
               "PayloadType": "guidance",
@@ -384,7 +388,7 @@ struct CloudSyncTests {
             type: "recommendation.delivered",
             data: WSEventData(
                 recommendation_id: recId,
-                conversation_id: convLocalIdString
+                conversation_id: convServerIdString
             )
         )
         syncClient.eventPublisher.send(wsEvent)
@@ -992,7 +996,7 @@ struct CloudSyncTests {
             {
               "ID": "\(recId)",
               "TenantID": "t1",
-              "ConversationID": "\(convLocalId.uuidString)",
+              "ConversationID": "\(convServerId)",
               "PatientID": "p1",
               "State": "DELIVERED",
               "PayloadType": "guidance",
@@ -1035,7 +1039,7 @@ struct CloudSyncTests {
             type: "recommendation.delivered",
             data: WSEventData(
                 recommendation_id: recId,
-                conversation_id: convLocalId.uuidString
+                conversation_id: convServerId
             )
         )
         onlineSyncClient.eventPublisher.send(wsEvent)
@@ -1127,11 +1131,13 @@ struct CloudSyncTests {
         coordinator.start()
 
         // Fire a message.created WS event directly into the coordinator.
+        // The WS event carries the SERVER conversation id, exactly as the
+        // real server sends it — the handler resolves it back to convLocalId.
         let wsEvent = WSEvent(
             type: "message.created",
             data: WSEventData(
                 recommendation_id: nil,
-                conversation_id: convLocalId.uuidString,
+                conversation_id: convServerId,
                 message_id: serverMsgId
             )
         )
@@ -1257,7 +1263,7 @@ struct CloudSyncTests {
         let userId = UUID()
         let conversation = try seedConversation(in: context, userId: userId)
         let convLocalId = conversation.id!
-        let convLocalIdString = convLocalId.uuidString
+        let convServerIdString = conversation.serverId!
 
         let recId = "soap-rec-\(UUID().uuidString)"
         // Synthetic SOAP content — not real patient data.
@@ -1273,7 +1279,7 @@ struct CloudSyncTests {
             {
               "ID": "\(recId)",
               "TenantID": "t1",
-              "ConversationID": "\(convLocalIdString)",
+              "ConversationID": "\(convServerIdString)",
               "PatientID": "patient-soap-1",
               "State": "DELIVERED",
               "PayloadType": "soap_note",
@@ -1318,7 +1324,7 @@ struct CloudSyncTests {
             type: "recommendation.delivered",
             data: WSEventData(
                 recommendation_id: recId,
-                conversation_id: convLocalIdString
+                conversation_id: convServerIdString
             )
         )
         syncClient.eventPublisher.send(wsEvent)
@@ -1430,7 +1436,7 @@ struct CloudSyncTests {
             type: "message.created",
             data: WSEventData(
                 recommendation_id: nil,
-                conversation_id: convLocalId.uuidString,
+                conversation_id: convServerId,
                 message_id: serverMsgId
             )
         )


### PR DESCRIPTION
Closes **HouseCall-negq** — the last piece of the iOS "no responses" saga. Verified working end-to-end live on the simulator.

## Root cause
`handleMessageCreated` and `handleRecommendationDelivered` both did `UUID(uuidString: event.data.conversation_id)` and used it directly as the **local** Core Data conversation id. But server and local conversation ids are independently generated UUIDs, linked only via `Conversation.serverId`. Every WS push carries the **server** id, so `fetchConversation(id:)` never matched — both handlers silently no-op'd. Agent interview questions and delivered SOAP notes were persisted server-side but never reached the patient.

Confirmed with a raw Python WebSocket client: the server delivered the frame instantly and correctly. The bug was 100% client-side.

## Fix
Added `resolveLocalConversationId(bySeverId:)` (Core Data lookup on `Conversation.serverId`) and routed both handlers through it. Existing WS tests never caught this because their mock events used the **local** id (a test-double mismatch with real server behavior) — fixed to use the conversation's `serverId`, matching production.

## Live verification
Patient sends a message → the agent's interview question now renders as a chat bubble within seconds via the live WebSocket — no relaunch, no refresh.

## Test
5 previously-passing-for-the-wrong-reason WS tests now correctly exercise the server-id resolution path; all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)